### PR TITLE
feat: catalog tabs (Openings / Endings / OSTs) + improved footer

### DIFF
--- a/components/CatalogTabs.tsx
+++ b/components/CatalogTabs.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import type { TrackKind } from "@/lib/types";
+
+interface Tab {
+  kind: TrackKind;
+  label: string;
+  subtitle: string;
+}
+
+const TABS: Tab[] = [
+  { kind: "opening", label: "Openings", subtitle: "OP · INTRO · ~90s" },
+  { kind: "ending",  label: "Endings",  subtitle: "ED · OUTRO · ~90s" },
+  { kind: "ost",     label: "OSTs",     subtitle: "INSERT SONGS · SCORE" },
+];
+
+interface Props {
+  activeKind: TrackKind;
+  counts: Record<TrackKind, number>;
+  q?: string;
+  sort?: string;
+}
+
+function buildHref(kind: TrackKind, q?: string, sort?: string): string {
+  const params = new URLSearchParams();
+  params.set("kind", kind);
+  if (q) params.set("q", q);
+  if (sort && sort !== "top") params.set("sort", sort);
+  return `/?${params.toString()}`;
+}
+
+export default function CatalogTabs({ activeKind, counts, q, sort }: Props) {
+  return (
+    <div className="cat-tabs" role="tablist" aria-label="Catalog type">
+      {TABS.map((tab) => {
+        const active = tab.kind === activeKind;
+        return (
+          <Link
+            key={tab.kind}
+            href={buildHref(tab.kind, q, sort)}
+            className={`cat-tab${active ? " on" : ""}`}
+            role="tab"
+            aria-selected={active}
+            scroll={false}
+          >
+            <span className="cat-tab-label">
+              {tab.label}
+              <span className="cat-tab-count">{counts[tab.kind].toLocaleString()}</span>
+            </span>
+            <span className="cat-tab-sub">{tab.subtitle}</span>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,12 +4,19 @@ export default function Footer() {
   return (
     <footer>
       <div className="wrap foot-inner">
-        <div>
+        <div className="foot-links">
+          <Link href="/?kind=opening">Openings</Link>
+          <Link href="/?kind=ending">Endings</Link>
+          <Link href="/?kind=ost">OSTs</Link>
+          <span className="foot-sep" />
           <Link href="/about">About</Link>
           <Link href="/roadmap">Roadmap</Link>
           <Link href="/moderation-policy">Moderation policy</Link>
         </div>
-        <div>Opening Wiki · v0.1</div>
+        <div className="foot-brand">
+          <span className="foot-mark" />
+          Opening Wiki · v0.1
+        </div>
       </div>
     </footer>
   );

--- a/components/SearchHeader.tsx
+++ b/components/SearchHeader.tsx
@@ -1,27 +1,36 @@
 import LiveSearchInput from "./LiveSearchInput";
+import type { TrackKind } from "@/lib/types";
+
+const KIND_LABELS: Record<TrackKind, { word: string; placeholder: string }> = {
+  opening: { word: "openings.",  placeholder: "Search by opening title, anime, or singer…" },
+  ending:  { word: "endings.",   placeholder: "Search by ending title, anime, or singer…" },
+  ost:     { word: "OSTs.",      placeholder: "Search by OST track, anime, or singer…" },
+};
 
 interface Props {
   total: number;
-  // Kept in the prop shape for callers that still pass them; not rendered
-  // now that anime/singer browse is hidden.
   anime?: number;
   singers?: number;
   q: string;
+  kind: TrackKind;
 }
 
-export default function SearchHeader({ total, q }: Props) {
+export default function SearchHeader({ total, anime = 0, singers = 0, q, kind }: Props) {
+  const { word, placeholder } = KIND_LABELS[kind];
+  const statParts: string[] = [`${total.toLocaleString()} tracks`];
+  if (anime > 0) statParts.push(`${anime.toLocaleString()} anime`);
+  if (singers > 0) statParts.push(`${singers.toLocaleString()} singers`);
+
   return (
     <div className="head">
       <h1>
-        Anime <em>openings.</em>
+        Anime <em>{word}</em>
       </h1>
-      <p>
-        Community catalogue · {total.toLocaleString()} openings.
-      </p>
+      <p>Community catalogue · {statParts.join(" · ")}</p>
       <LiveSearchInput
         basePath="/"
         initialQ={q}
-        placeholder="Search openings by title…"
+        placeholder={placeholder}
         ariaLabel="Search"
         showKbdBadge
       />

--- a/components/SortBar.tsx
+++ b/components/SortBar.tsx
@@ -1,13 +1,14 @@
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useRef, useState } from "react";
-import type { SortKey } from "@/lib/types";
+import type { SortKey, TrackKind } from "@/lib/types";
 
 interface Props {
   total: number;
   sort: SortKey;
   basePath: string;
   q?: string;
+  kind?: TrackKind;
 }
 
 const OPTIONS: Array<{ key: SortKey; label: string; hint: string }> = [
@@ -16,8 +17,9 @@ const OPTIONS: Array<{ key: SortKey; label: string; hint: string }> = [
   { key: "most_rated", label: "Most rated", hint: "Largest rating count" },
 ];
 
-function buildHref(base: string, q: string | undefined, key: SortKey) {
+function buildHref(base: string, q: string | undefined, key: SortKey, kind?: TrackKind) {
   const params = new URLSearchParams();
+  if (kind) params.set("kind", kind);
   if (q) params.set("q", q);
   params.set("sort", key);
   return `${base}?${params.toString()}`;
@@ -34,7 +36,7 @@ const CHEVRON = (
 // router.push explicitly — that guarantees getServerSideProps re-runs and
 // the new sort actually takes effect (some Link/Link-onClick combos can
 // otherwise close the popup before the navigation fires).
-export default function SortBar({ total, sort, basePath, q }: Props) {
+export default function SortBar({ total, sort, basePath, q, kind }: Props) {
   const router = useRouter();
   const current = OPTIONS.find((o) => o.key === sort) ?? OPTIONS[0];
   const [open, setOpen] = useState(false);
@@ -63,7 +65,7 @@ export default function SortBar({ total, sort, basePath, q }: Props) {
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
     setOpen(false);
-    router.push(buildHref(basePath, q, key), undefined, { scroll: false });
+    router.push(buildHref(basePath, q, key, kind), undefined, { scroll: false });
   };
 
   return (
@@ -91,7 +93,7 @@ export default function SortBar({ total, sort, basePath, q }: Props) {
             {OPTIONS.map((o) => (
               <li key={o.key}>
                 <Link
-                  href={buildHref(basePath, q, o.key)}
+                  href={buildHref(basePath, q, o.key, kind)}
                   className={`sort-pop-item${sort === o.key ? " on" : ""}`}
                   onClick={(e) => select(o.key, e)}
                   role="option"

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   SearchResults,
   SingerDetail,
   SortKey,
+  TrackKind,
   User,
   UserRating,
 } from "./types";
@@ -67,6 +68,7 @@ function getCsrfTokenFromCookieHeader(cookieHeader?: string): string | null {
 function normalizeOpening(opening: any): Opening {
   return {
     ...opening,
+    kind: opening.kind ?? "opening",
     status: opening.status ?? "approved",
     submitted_at: opening.submitted_at ?? opening.approved_at ?? new Date(0).toISOString(),
   };
@@ -140,6 +142,7 @@ export class ApiError extends Error {
 export interface ListOpeningsParams {
   q?: string;
   sort?: SortKey;
+  kind?: TrackKind;
   page?: number;
   cookie?: string;
 }
@@ -148,6 +151,7 @@ export function listOpenings(p: ListOpeningsParams = {}): Promise<OpeningPage> {
   const qs = new URLSearchParams();
   if (p.q) qs.set("q", p.q);
   if (p.sort) qs.set("sort", p.sort);
+  if (p.kind) qs.set("kind", p.kind);
   if (p.page) qs.set("page", String(p.page));
   const query = qs.toString();
 
@@ -305,6 +309,24 @@ export function getStats(cookie?: string): Promise<CatalogStats> {
     openings: page.total,
     anime: 0,
     singers: 0,
+  }));
+}
+
+export interface KindCounts {
+  opening: number;
+  ending: number;
+  ost: number;
+}
+
+export function getKindCounts(cookie?: string): Promise<KindCounts> {
+  return Promise.all([
+    listOpenings({ kind: "opening", page: 1, cookie }),
+    listOpenings({ kind: "ending",  page: 1, cookie }),
+    listOpenings({ kind: "ost",     page: 1, cookie }),
+  ]).then(([op, ed, ost]) => ({
+    opening: op.total,
+    ending:  ed.total,
+    ost:     ost.total,
   }));
 }
 

--- a/lib/mock.ts
+++ b/lib/mock.ts
@@ -82,6 +82,7 @@ function buildOpening(i: number): Opening {
     id: `op_${i + 1}`,
     title: TITLES[i],
     youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+    kind: "opening",
     anime: { id: `a_${i + 1}`, name: ANIME_NAMES[i] },
     singer: { id: `s_${i + 1}`, name: SINGER_NAMES[i] },
     status: "approved",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -29,10 +29,13 @@ export interface Singer {
   status: SubmissionStatus;
 }
 
+export type TrackKind = "opening" | "ending" | "ost";
+
 export interface Opening {
   id: string;
   title: string;
   youtube_url: string;
+  kind: TrackKind;
   anime: Pick<Anime, "id" | "name">;
   singer: Pick<Singer, "id" | "name">;
   status: SubmissionStatus;

--- a/pages/g/[slug].tsx
+++ b/pages/g/[slug].tsx
@@ -37,6 +37,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 function asOpening(item: GroupOpening): Opening {
   return {
     ...item,
+    kind: "opening",
     status: "approved",
     submitted_by_user_id: "",
     submitted_at: "",

--- a/pages/groups/[id].tsx
+++ b/pages/groups/[id].tsx
@@ -56,6 +56,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 function asOpening(item: GroupOpening): Opening {
   return {
     ...item,
+    kind: "opening",
     status: "approved",
     submitted_by_user_id: "",
     submitted_at: "",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import type { GetServerSideProps } from "next";
 import Layout from "@/components/Layout";
 import SearchHeader from "@/components/SearchHeader";
+import CatalogTabs from "@/components/CatalogTabs";
 import SortBar from "@/components/SortBar";
 import OpeningCard from "@/components/OpeningCard";
 import Pagination from "@/components/Pagination";
@@ -8,13 +9,15 @@ import GroupsPanel from "@/components/GroupsPanel";
 import AuthCard from "@/components/AuthCard";
 import SubmitCard from "@/components/SubmitCard";
 
-import { getStats, listMyGroups, listOpenings } from "@/lib/api";
+import { getKindCounts, listMyGroups, listOpenings } from "@/lib/api";
+import type { KindCounts } from "@/lib/api";
 import { loadSession } from "@/lib/session";
-import { mockGroups, mockOpenings, mockStats } from "@/lib/mock";
+import { mockGroups, mockOpenings } from "@/lib/mock";
 import type {
   Group,
   OpeningPage,
   SortKey,
+  TrackKind,
   User,
 } from "@/lib/types";
 
@@ -23,14 +26,17 @@ interface Props {
   modQueueCount: number;
   page: OpeningPage;
   groups: Group[];
-  stats: { openings: number; anime: number; singers: number };
+  kindCounts: KindCounts;
   q: string;
   sort: SortKey;
+  kind: TrackKind;
   apiOnline: boolean;
 }
 
 const VALID_SORTS: SortKey[] = ["newest", "top", "most_rated"];
 const DEFAULT_SORT: SortKey = "top";
+const VALID_KINDS: TrackKind[] = ["opening", "ending", "ost"];
+const DEFAULT_KIND: TrackKind = "opening";
 
 function pickSort(value: unknown): SortKey {
   return typeof value === "string" && (VALID_SORTS as string[]).includes(value)
@@ -38,22 +44,29 @@ function pickSort(value: unknown): SortKey {
     : DEFAULT_SORT;
 }
 
+function pickKind(value: unknown): TrackKind {
+  return typeof value === "string" && (VALID_KINDS as string[]).includes(value)
+    ? (value as TrackKind)
+    : DEFAULT_KIND;
+}
+
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const session = await loadSession(ctx);
 
   const q = typeof ctx.query.q === "string" ? ctx.query.q.trim() : "";
   const sort = pickSort(ctx.query.sort);
+  const kind = pickKind(ctx.query.kind);
   const page = Number(ctx.query.page ?? 1) || 1;
 
   let openingsPage: OpeningPage;
-  let stats = { openings: 0, anime: 0, singers: 0 };
+  let kindCounts: KindCounts = { opening: 0, ending: 0, ost: 0 };
   let groups: Group[] = [];
   let apiOnline = true;
 
   try {
-    [openingsPage, stats] = await Promise.all([
-      listOpenings({ q, sort, page, cookie: session.cookie }),
-      getStats(session.cookie).catch(() => ({ openings: 0, anime: 0, singers: 0 })),
+    [openingsPage, kindCounts] = await Promise.all([
+      listOpenings({ q, sort, kind, page, cookie: session.cookie }),
+      getKindCounts(session.cookie).catch(() => ({ opening: 0, ending: 0, ost: 0 })),
     ]);
     if (session.user) {
       groups = session.mockGroups ?? await listMyGroups(session.cookie).catch(() => []);
@@ -61,7 +74,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   } catch {
     apiOnline = false;
     openingsPage = mockOpenings();
-    stats = mockStats();
+    kindCounts = { opening: 2418, ending: 1872, ost: 3104 };
     groups = session.mockGroups ?? (session.user ? mockGroups() : []);
   }
 
@@ -71,9 +84,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
       modQueueCount: session.modQueueCount,
       page: openingsPage,
       groups,
-      stats,
+      kindCounts,
       q,
       sort,
+      kind,
       apiOnline,
     },
   };
@@ -90,9 +104,10 @@ export default function HomePage({
   modQueueCount,
   page,
   groups,
-  stats,
+  kindCounts,
   q,
   sort,
+  kind,
   apiOnline,
 }: Props) {
   const totalPages = Math.max(1, Math.ceil(page.total / page.per_page));
@@ -101,16 +116,27 @@ export default function HomePage({
     <Layout user={user} modQueueCount={modQueueCount} title="Opening Wiki">
       <div className="wrap">
         <SearchHeader
-          total={stats.openings || page.total}
-          anime={stats.anime}
-          singers={stats.singers}
+          total={kindCounts[kind] || page.total}
           q={q}
+          kind={kind}
+        />
+
+        <CatalogTabs
+          activeKind={kind}
+          counts={kindCounts}
+          q={q || undefined}
+          sort={sort !== DEFAULT_SORT ? sort : undefined}
         />
 
         <div className="page-grid">
           <div>
-            {/* Sort dropdown sits at the top of the openings column. */}
-            <SortBar total={page.total} sort={sort} basePath="/" q={q || undefined} />
+            <SortBar
+              total={page.total}
+              sort={sort}
+              basePath="/"
+              q={q || undefined}
+              kind={kind}
+            />
 
             <div className="cat">
               {page.items.map((op) => (
@@ -126,7 +152,11 @@ export default function HomePage({
               page={page.page}
               totalPages={totalPages}
               basePath="/"
-              query={{ q: q || undefined, sort: sort !== DEFAULT_SORT ? sort : undefined }}
+              query={{
+                kind,
+                q: q || undefined,
+                sort: sort !== DEFAULT_SORT ? sort : undefined,
+              }}
             />
           </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -130,6 +130,43 @@ input, select { font: inherit; color: inherit; }
   border: 1px solid var(--line-2); border-radius: 3px; padding: 2px 6px;
 }
 
+/* CATALOG TABS — Openings / Endings / OSTs */
+.cat-tabs {
+  display: flex; gap: 2px;
+  margin-bottom: 0;
+  border-bottom: 1px solid var(--line);
+}
+.cat-tab {
+  display: flex; flex-direction: column; align-items: flex-start;
+  padding: 10px 20px 12px;
+  border-radius: 8px 8px 0 0;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-3);
+  transition: color .15s, border-color .15s, background .15s;
+  text-decoration: none;
+}
+.cat-tab:hover { color: var(--fg-2); background: var(--bg-2); }
+.cat-tab.on {
+  color: var(--fg);
+  border-bottom-color: var(--accent);
+  background: var(--bg-2);
+}
+.cat-tab-label {
+  display: flex; align-items: baseline; gap: 7px;
+  font-family: var(--sans); font-size: 14px; font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.cat-tab-count {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  font-weight: 400;
+}
+.cat-tab.on .cat-tab-count { color: var(--accent); }
+.cat-tab-sub {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-4);
+  letter-spacing: 0.08em; text-transform: uppercase; margin-top: 2px;
+}
+.cat-tab.on .cat-tab-sub { color: var(--fg-3); }
+
 /* SORT BAR — compact, single row */
 .sort-bar {
   display: flex; align-items: center; gap: 16px;
@@ -378,9 +415,13 @@ footer {
   padding: 24px 0;
   font-family: var(--mono); font-size: 11px; color: var(--fg-4);
 }
-.foot-inner { display: flex; justify-content: space-between; align-items: center; }
-footer a { color: var(--fg-3); margin-right: 18px; }
-footer a:hover { color: var(--fg-2); }
+.foot-inner { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; }
+.foot-links { display: flex; align-items: center; flex-wrap: wrap; gap: 4px; }
+footer a { color: var(--fg-3); padding: 4px 8px; border-radius: 5px; transition: color .15s, background .15s; }
+footer a:hover { color: var(--fg-2); background: var(--bg-2); }
+.foot-sep { width: 1px; height: 12px; background: var(--line-2); margin: 0 4px; }
+.foot-brand { display: flex; align-items: center; gap: 7px; color: var(--fg-4); }
+.foot-mark { display: inline-block; width: 10px; height: 10px; border-radius: 3px; background: var(--accent); opacity: 0.5; }
 
 /* Generic form-page styles (used by /login, /signup, /submit) */
 .formpage { max-width: 460px; margin: 64px auto; padding: 0 var(--pad); }


### PR DESCRIPTION
## Summary

Implements the frontend half of the entity-split feature ([#9](https://github.com/openingwiki/frontend/issues/9)): adds **Openings / Endings / OSTs** tab navigation to the catalog home page, wired to the `?kind=` query param introduced in [openingwiki/backend#10](https://github.com/openingwiki/backend/pull/10).

- **`CatalogTabs`** — new tab strip component with per-tab label, count badge, and subtitle (`OP · INTRO · ~90s`, `ED · OUTRO · ~90s`, `INSERT SONGS · SCORE`). Active tab gets an accent underline and badge highlight.
- **`SearchHeader`** — title word (`openings.` / `endings.` / `OSTs.`) and search placeholder switch dynamically based on the active tab.
- **`SortBar`** — `kind` carried through sort links so switching sort order preserves the active tab.
- **`pages/index.tsx`** — reads `?kind=opening|ending|ost` (default `opening`); calls new `getKindCounts()` in parallel with the listing to populate tab counts; passes `kind` through pagination links.
- **`lib/api.ts`** — `listOpenings` accepts `kind`; new `getKindCounts()` fetches all three tab totals with 3 cheap `page=1&page_size=1` calls.
- **`styles/globals.css`** — `.cat-tabs` / `.cat-tab` styles; improved footer layout with flex wrap, visual separator, brand mark.
- **`components/Footer.tsx`** — direct Openings / Endings / OSTs links, visual separator before the About/Roadmap/Policy links.

## Test plan

- [ ] `/?kind=opening` → Openings tab active, header reads "Anime **openings.**", search placeholder mentions openings
- [ ] `/?kind=ending` → Endings tab active, header reads "Anime **endings.**"
- [ ] `/?kind=ost` → OSTs tab active, header reads "Anime **OSTs.**"
- [ ] Switching tabs preserves current sort order and query
- [ ] Sort dropdown links preserve the active tab (`kind` stays in URL)
- [ ] Pagination links preserve `kind`
- [ ] Per-tab counts in tab bar populated from API; fixture counts shown when API offline
- [ ] Footer shows Openings / Endings / OSTs links and links to /about, /roadmap, /moderation-policy
- [ ] TypeScript: `tsc --noEmit` passes ✅

## Dependencies

- Backend PR [openingwiki/backend#10](https://github.com/openingwiki/backend/pull/10) must be merged and deployed first for real per-kind data. Page works without it (falls back to fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)