### PR TITLE
feat: three-tab submit page with autocomplete entity pickers

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -11,27 +11,26 @@ interface Props {
   fetchItems: (q: string) => Promise<AutocompleteItem[]>;
   selected: AutocompleteItem | null;
   onSelect: (item: AutocompleteItem | null) => void;
-  inputName?: string;
+  onCreateNew?: () => void;
+  createNewLabel?: string;
 }
 
-export default function Autocomplete({ placeholder, fetchItems, selected, onSelect, inputName }: Props) {
+export default function Autocomplete({ placeholder, fetchItems, selected, onSelect, onCreateNew, createNewLabel }: Props) {
   const [query, setQuery] = useState("");
   const [items, setItems] = useState<AutocompleteItem[]>([]);
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
+  const [activeIdx, setActiveIdx] = useState(-1);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const wrapRef = useRef<HTMLDivElement>(null);
 
   const search = useCallback(async (q: string) => {
-    setLoading(true);
     try {
       const results = await fetchItems(q);
       setItems(results);
       setOpen(true);
+      setActiveIdx(-1);
     } catch {
       setItems([]);
-    } finally {
-      setLoading(false);
     }
   }, [fetchItems]);
 
@@ -42,6 +41,10 @@ export default function Autocomplete({ placeholder, fetchItems, selected, onSele
     timer.current = setTimeout(() => search(q), 250);
   };
 
+  const handleFocus = () => {
+    if (!open) search(query);
+  };
+
   const handleSelect = (item: AutocompleteItem) => {
     onSelect(item);
     setQuery("");
@@ -49,50 +52,80 @@ export default function Autocomplete({ placeholder, fetchItems, selected, onSele
     setOpen(false);
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (!open) return;
+    const total = items.length + (onCreateNew ? 1 : 0);
+    if (e.key === "ArrowDown") { e.preventDefault(); setActiveIdx((i) => Math.min(i + 1, total - 1)); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); setActiveIdx((i) => Math.max(i - 1, -1)); }
+    else if (e.key === "Enter") {
+      e.preventDefault();
+      if (activeIdx >= 0 && activeIdx < items.length) handleSelect(items[activeIdx]);
+      else if (activeIdx === items.length && onCreateNew) onCreateNew();
+    }
+    else if (e.key === "Escape") setOpen(false);
+  };
+
   useEffect(() => {
     const onClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
     };
     document.addEventListener("mousedown", onClick);
     return () => document.removeEventListener("mousedown", onClick);
   }, []);
 
-  if (selected) {
-    return (
-      <div className="ac-chip">
-        {inputName && <input type="hidden" name={inputName} value={selected.id} />}
-        <span className="ac-chip-label">{selected.label}</span>
-        {selected.sublabel && <span className="ac-chip-sub">{selected.sublabel}</span>}
-        <button type="button" className="ac-chip-clear" onClick={() => onSelect(null)} aria-label="Clear">×</button>
-      </div>
-    );
-  }
-
   return (
-    <div className="ac-wrap" ref={containerRef}>
-      {inputName && <input type="hidden" name={inputName} value="" />}
-      <input
-        className="ac-input"
-        value={query}
-        onChange={handleChange}
-        onFocus={() => { if (!open) search(query); }}
-        placeholder={placeholder}
-        autoComplete="off"
-      />
-      {open && items.length > 0 && (
-        <ul className="ac-dropdown">
-          {items.map((item) => (
-            <li key={item.id} className="ac-item" onMouseDown={() => handleSelect(item)}>
-              <span className="ac-item-label">{item.label}</span>
-              {item.sublabel && <span className="ac-item-sub">{item.sublabel}</span>}
-            </li>
-          ))}
-        </ul>
-      )}
-      {open && !loading && items.length === 0 && query.length > 0 && (
-        <div className="ac-empty">No results</div>
+    <div className="auto" ref={wrapRef}>
+      {selected ? (
+        <div className="auto-selected">
+          <span>{selected.label}</span>
+          {selected.sublabel && <span style={{ color: "var(--fg-3)", fontSize: 11, fontFamily: "var(--mono)" }}>{selected.sublabel}</span>}
+          <button type="button" className="x" onClick={() => onSelect(null)} aria-label="Clear">×</button>
+        </div>
+      ) : (
+        <div className={`auto-wrap${open ? " open" : ""}`}>
+          <input
+            value={query}
+            onChange={handleChange}
+            onFocus={handleFocus}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            autoComplete="off"
+          />
+          {open && (items.length > 0 || onCreateNew) && (
+            <div className="auto-results">
+              {items.map((item, i) => (
+                <div
+                  key={item.id}
+                  className={`auto-row${i === activeIdx ? " sel" : ""}`}
+                  onMouseDown={() => handleSelect(item)}
+                  onMouseEnter={() => setActiveIdx(i)}
+                >
+                  <div className="ic" />
+                  <div>
+                    <div className="a-name">{item.label}</div>
+                    {item.sublabel && <div className="a-sub">{item.sublabel}</div>}
+                  </div>
+                  {i === activeIdx && <span className="a-pick">↵ pick</span>}
+                </div>
+              ))}
+              {onCreateNew && (
+                <div
+                  className={`auto-row create${activeIdx === items.length ? " sel" : ""}`}
+                  onMouseDown={onCreateNew}
+                  onMouseEnter={() => setActiveIdx(items.length)}
+                >
+                  <div className="ic">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+                  </div>
+                  <div>
+                    <div className="a-name">{createNewLabel ?? "Add new…"}</div>
+                    <div className="a-sub">opens the form</div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -1,0 +1,99 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+
+export interface AutocompleteItem {
+  id: string;
+  label: string;
+  sublabel?: string;
+}
+
+interface Props {
+  placeholder: string;
+  fetchItems: (q: string) => Promise<AutocompleteItem[]>;
+  selected: AutocompleteItem | null;
+  onSelect: (item: AutocompleteItem | null) => void;
+  inputName?: string;
+}
+
+export default function Autocomplete({ placeholder, fetchItems, selected, onSelect, inputName }: Props) {
+  const [query, setQuery] = useState("");
+  const [items, setItems] = useState<AutocompleteItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const search = useCallback(async (q: string) => {
+    setLoading(true);
+    try {
+      const results = await fetchItems(q);
+      setItems(results);
+      setOpen(true);
+    } catch {
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [fetchItems]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const q = e.target.value;
+    setQuery(q);
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => search(q), 250);
+  };
+
+  const handleSelect = (item: AutocompleteItem) => {
+    onSelect(item);
+    setQuery("");
+    setItems([]);
+    setOpen(false);
+  };
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, []);
+
+  if (selected) {
+    return (
+      <div className="ac-chip">
+        {inputName && <input type="hidden" name={inputName} value={selected.id} />}
+        <span className="ac-chip-label">{selected.label}</span>
+        {selected.sublabel && <span className="ac-chip-sub">{selected.sublabel}</span>}
+        <button type="button" className="ac-chip-clear" onClick={() => onSelect(null)} aria-label="Clear">×</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ac-wrap" ref={containerRef}>
+      {inputName && <input type="hidden" name={inputName} value="" />}
+      <input
+        className="ac-input"
+        value={query}
+        onChange={handleChange}
+        onFocus={() => { if (!open) search(query); }}
+        placeholder={placeholder}
+        autoComplete="off"
+      />
+      {open && items.length > 0 && (
+        <ul className="ac-dropdown">
+          {items.map((item) => (
+            <li key={item.id} className="ac-item" onMouseDown={() => handleSelect(item)}>
+              <span className="ac-item-label">{item.label}</span>
+              {item.sublabel && <span className="ac-item-sub">{item.sublabel}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
+      {open && !loading && items.length === 0 && query.length > 0 && (
+        <div className="ac-empty">No results</div>
+      )}
+    </div>
+  );
+}

--- a/components/SubmitCard.tsx
+++ b/components/SubmitCard.tsx
@@ -15,7 +15,7 @@ export default function SubmitCard({ authed }: Props) {
         anime, and singer.
       </p>
       <Link href={href} className="btn primary">
-        + Submit an opening
+        + Submit
       </Link>
     </div>
   );

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -36,7 +36,9 @@ export default function Topbar({ user }: Props) {
 
         <div className="top-right">
           {user ? (
-            <Link href="/me" className="topbar-me">
+            <>
+              <Link href="/submit" className="btn primary sm">+ Submit</Link>
+              <Link href="/me" className="topbar-me">
               <span className="topbar-avatar" aria-hidden>
                 {user.avatar_url ? (
                   // eslint-disable-next-line @next/next/no-img-element
@@ -47,6 +49,7 @@ export default function Topbar({ user }: Props) {
               </span>
               <span className="topbar-name">{user.display_name}</span>
             </Link>
+            </>
           ) : (
             <>
               <Link href="/login" className="btn ghost">Log in</Link>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,9 @@ export type Role = "user" | "moderator" | "admin";
 
 export type SubmissionStatus = "pending" | "approved" | "rejected";
 
+export type AnimeFormat = "tv" | "film" | "ova_ona" | "special";
+export type SingerType = "solo" | "band" | "idol_group" | "vocaloid_producer" | "composer" | "other";
+
 export interface User {
   id: string;
   email: string;
@@ -17,19 +20,39 @@ export interface User {
 export interface Anime {
   id: string;
   name: string;
-  cover_image_key: string | null;
+  title_romaji: string;
+  title_english: string | null;
+  year: number;
+  format: AnimeFormat;
+  cover_image_url: string | null;
+  is_placeholder: boolean;
   status: SubmissionStatus;
-  created_by_user_id: string;
 }
 
 export interface Singer {
   id: string;
   name: string;
-  cover_image_key: string | null;
+  type: SingerType;
+  cover_image_url: string | null;
+  is_placeholder: boolean;
   status: SubmissionStatus;
 }
 
 export type TrackKind = "opening" | "ending" | "ost";
+
+export interface AnimeAutocompleteItem {
+  id: string;
+  name: string;
+  title_romaji: string;
+  format: AnimeFormat;
+  year: number;
+}
+
+export interface SingerAutocompleteItem {
+  id: string;
+  name: string;
+  type: SingerType;
+}
 
 export interface Opening {
   id: string;
@@ -38,6 +61,8 @@ export interface Opening {
   kind: TrackKind;
   anime: Pick<Anime, "id" | "name">;
   singer: Pick<Singer, "id" | "name">;
+  legacy_anime_name?: string | null;
+  legacy_singer_name?: string | null;
   status: SubmissionStatus;
   submitted_by_user_id: string;
   submitted_at: string;

--- a/pages/api/anime.ts
+++ b/pages/api/anime.ts
@@ -5,19 +5,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const b = req.body ?? {};
-  const rawKind = typeof b.kind === "string" ? b.kind : "opening";
-  const kind = ["opening", "ending", "ost"].includes(rawKind) ? rawKind : "opening";
-
-  const upstream = await fetch(backendUrl("/openings"), {
+  const upstream = await fetch(backendUrl("/anime"), {
     method: "POST",
     headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
     body: JSON.stringify({
-      title: b.title ?? "",
-      youtube_url: b.youtube_url ?? "",
-      kind,
-      anime_id: b.anime_id ?? "",
-      singer_id: b.singer_id ?? "",
-      sequence_number: b.sequence_number ? Number(b.sequence_number) : undefined,
+      name: b.name ?? "",
+      title_romaji: b.title_romaji ?? "",
+      title_english: b.title_english ?? "",
+      title_native: b.title_native ?? "",
+      year: Number(b.year) || 0,
+      format: b.format ?? "",
+      episodes: b.episodes ? Number(b.episodes) : undefined,
+      studio: b.studio ?? "",
+      reference_url: b.reference_url ?? "",
+      cover_image_key: b.cover_image_key ?? "",
       notes_for_moderator: b.notes_for_moderator ?? "",
     }),
   });
@@ -32,5 +33,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const payload = await upstream.json();
-  return res.status(201).json({ ...payload.data, _kind: kind });
+  return res.status(201).json(payload.data);
 }

--- a/pages/api/anime/search.ts
+++ b/pages/api/anime/search.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).end();
+  const q = typeof req.query.q === "string" ? req.query.q : "";
+  const upstream = await fetch(backendUrl(`/anime/search?q=${encodeURIComponent(q)}`), {
+    headers: req.headers.cookie ? { cookie: req.headers.cookie } : undefined,
+  });
+  const data = await upstream.json();
+  return res.status(upstream.status).json(data);
+}

--- a/pages/api/singers.ts
+++ b/pages/api/singers.ts
@@ -5,19 +5,17 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const b = req.body ?? {};
-  const rawKind = typeof b.kind === "string" ? b.kind : "opening";
-  const kind = ["opening", "ending", "ost"].includes(rawKind) ? rawKind : "opening";
-
-  const upstream = await fetch(backendUrl("/openings"), {
+  const upstream = await fetch(backendUrl("/singers"), {
     method: "POST",
     headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
     body: JSON.stringify({
-      title: b.title ?? "",
-      youtube_url: b.youtube_url ?? "",
-      kind,
-      anime_id: b.anime_id ?? "",
-      singer_id: b.singer_id ?? "",
-      sequence_number: b.sequence_number ? Number(b.sequence_number) : undefined,
+      name: b.name ?? "",
+      name_native: b.name_native ?? "",
+      type: b.type ?? "",
+      active_since: b.active_since ? Number(b.active_since) : undefined,
+      bio: b.bio ?? "",
+      reference_url: b.reference_url ?? "",
+      cover_image_key: b.cover_image_key ?? "",
       notes_for_moderator: b.notes_for_moderator ?? "",
     }),
   });
@@ -32,5 +30,5 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const payload = await upstream.json();
-  return res.status(201).json({ ...payload.data, _kind: kind });
+  return res.status(201).json(payload.data);
 }

--- a/pages/api/singers/search.ts
+++ b/pages/api/singers/search.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).end();
+  const q = typeof req.query.q === "string" ? req.query.q : "";
+  const upstream = await fetch(backendUrl(`/singers/search?q=${encodeURIComponent(q)}`), {
+    headers: req.headers.cookie ? { cookie: req.headers.cookie } : undefined,
+  });
+  const data = await upstream.json();
+  return res.status(upstream.status).json(data);
+}

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -1,4 +1,5 @@
 import type { GetServerSideProps } from "next";
+import Link from "next/link";
 import { useState, useCallback } from "react";
 import { useRouter } from "next/router";
 import Layout from "@/components/Layout";
@@ -21,27 +22,9 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 
 type Tab = "opening" | "anime" | "singer";
 
-const KIND_OPTIONS: { value: TrackKind; label: string; sub: string }[] = [
-  { value: "opening", label: "Opening", sub: "OP · INTRO" },
-  { value: "ending",  label: "Ending",  sub: "ED · OUTRO" },
-  { value: "ost",     label: "OST",     sub: "OST · TRACK" },
-];
-
-const ANIME_FORMATS: { value: AnimeFormat; label: string }[] = [
-  { value: "tv",      label: "TV" },
-  { value: "film",    label: "Film" },
-  { value: "ova_ona", label: "OVA / ONA" },
-  { value: "special", label: "Special" },
-];
-
-const SINGER_TYPES: { value: SingerType; label: string }[] = [
-  { value: "solo",              label: "Solo artist" },
-  { value: "band",              label: "Band" },
-  { value: "idol_group",        label: "Idol group" },
-  { value: "vocaloid_producer", label: "Vocaloid / producer" },
-  { value: "composer",          label: "Composer" },
-  { value: "other",             label: "Other" },
-];
+// ---------------------------------------------------------------------------
+// Fetch helpers (called client-side)
+// ---------------------------------------------------------------------------
 
 async function fetchAnimeItems(q: string): Promise<AutocompleteItem[]> {
   const res = await fetch(`/api/anime/search?q=${encodeURIComponent(q)}`);
@@ -51,7 +34,7 @@ async function fetchAnimeItems(q: string): Promise<AutocompleteItem[]> {
   return items.map((a: any) => ({
     id: a.id,
     label: a.name,
-    sublabel: a.year ? `${a.format?.toUpperCase() ?? ""} · ${a.year}` : undefined,
+    sublabel: a.year ? `${a.year} · ${(a.format ?? "").toUpperCase().replace("_", " ")}` : undefined,
   }));
 }
 
@@ -63,21 +46,88 @@ async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
   return items.map((s: any) => ({
     id: s.id,
     label: s.name,
-    sublabel: s.type?.replace(/_/g, " ") ?? undefined,
+    sublabel: (s.type ?? "").replace(/_/g, " "),
   }));
 }
 
 // ---------------------------------------------------------------------------
-// Opening tab
+// Sidebar
 // ---------------------------------------------------------------------------
 
-function OpeningForm() {
+function Sidebar({ tab }: { tab: Tab }) {
+  const tips: Record<Tab, React.ReactNode[]> = {
+    opening: [
+      <><strong>Official upload preferred</strong> — Crunchyroll, the studio, or the artist&apos;s channel.</>,
+      <>Title in romaji or English — no season abbreviations (OP1, OP2 etc.).</>,
+      <>If the anime or singer isn&apos;t in the database yet, submit it first from the other tabs.</>,
+    ],
+    anime: [
+      <>Use the <strong>AniList link</strong> as the reference — it&apos;s the easiest for mods to verify.</>,
+      <>Romaji title is the canonical key — spell it consistently with AniList.</>,
+      <>Sequels and side stories should be separate entries if they have their own OPs.</>,
+    ],
+    singer: [
+      <>Use the canonical name — the one on their official Spotify or Wikipedia page.</>,
+      <>Vocaloid producers and composers count — include them if they made the track.</>,
+      <>One entry per act; solo albums by a band member get their own singer entry.</>,
+    ],
+  };
+
+  return (
+    <aside className="sub-side">
+      <div className="sub-panel">
+        <div className="sub-panel-head">What happens next</div>
+        <div className="sub-panel-body">
+          <div className="sub-timeline">
+            <div className="sub-tl-step now">
+              <div className="sub-tl-dot">1</div>
+              <div className="sub-tl-text">
+                <div className="sub-tl-title">You submit</div>
+                <div className="sub-tl-sub">Lands in the moderation queue. You can edit until a mod picks it up.</div>
+              </div>
+            </div>
+            <div className="sub-tl-step">
+              <div className="sub-tl-dot">2</div>
+              <div className="sub-tl-text">
+                <div className="sub-tl-title">A mod reviews</div>
+                <div className="sub-tl-sub">Checks the source, attribution, and dedup. Usually under 24h.</div>
+              </div>
+            </div>
+            <div className="sub-tl-step">
+              <div className="sub-tl-dot">3</div>
+              <div className="sub-tl-text">
+                <div className="sub-tl-title">It goes live</div>
+                <div className="sub-tl-sub">Shows up as the contributor on the entry.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="sub-panel">
+        <div className="sub-panel-head">Tips</div>
+        <div className="sub-panel-body sub-tips">
+          <ul>
+            {tips[tab].map((tip, i) => <li key={i}>{tip}</li>)}
+          </ul>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Opening form
+// ---------------------------------------------------------------------------
+
+function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
   const router = useRouter();
   const [kind, setKind] = useState<TrackKind>("opening");
   const [title, setTitle] = useState("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [selectedAnime, setSelectedAnime] = useState<AutocompleteItem | null>(null);
   const [selectedSinger, setSelectedSinger] = useState<AutocompleteItem | null>(null);
+  const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -107,6 +157,7 @@ function OpeningForm() {
         kind,
         anime_id: selectedAnime!.id,
         singer_id: selectedSinger!.id,
+        notes_for_moderator: notes.trim(),
       }),
     });
 
@@ -122,102 +173,128 @@ function OpeningForm() {
     router.push(`/?kind=${kind}`);
   };
 
+  const TYPE_OPTIONS = [
+    { value: "opening" as TrackKind, tag: "OP", cls: "op", name: "Opening", desc: "Intro sequence · ~90 sec · plays at the start of every episode" },
+    { value: "ending"  as TrackKind, tag: "ED", cls: "ed", name: "Ending",  desc: "Outro sequence · ~90 sec · plays at the end of every episode" },
+    { value: "ost"     as TrackKind, tag: "OST", cls: "ost", name: "OST / insert", desc: "Score, insert song, or character song · any length" },
+  ];
+
   const titleLabel = kind === "ost" ? "Track title" : kind === "ending" ? "Ending title" : "Opening title";
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
-        <label>Type</label>
-        <div className="kind-picker">
-          {KIND_OPTIONS.map((opt) => (
-            <button
-              key={opt.value}
-              type="button"
-              className={`kind-btn${kind === opt.value ? " on" : ""}`}
-              onClick={() => setKind(opt.value)}
-            >
-              <span className="kind-btn-label">{opt.label}</span>
-              <span className="kind-btn-sub">{opt.sub}</span>
-            </button>
-          ))}
+      <div className="sub-form-card">
+        <div className="sub-form-head">
+          <h2>Submit an <em>{kind === "ost" ? "OST" : kind}</em>.</h2>
+          <p>OP, ED, or OST · We&apos;ll attach it to its anime + singer</p>
         </div>
-      </div>
+        <div className="sub-form-body">
 
-      <div>
-        <label htmlFor="op-title">{titleLabel}</label>
-        <input
-          id="op-title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder={`e.g. Silhouette`}
-        />
-        {fieldErrors.title && <p className="field-error">{fieldErrors.title}</p>}
-      </div>
+          <div className="sub-section"><span className="sub-step">01</span> What kind of track?</div>
+          <div className="sub-type-grid">
+            {TYPE_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={`sub-type-pick ${opt.cls}${kind === opt.value ? " on" : ""}`}
+                onClick={() => setKind(opt.value)}
+              >
+                <div className="tp-row">
+                  <span className="tp-tag">{opt.tag}</span>
+                  <span className="tp-radio" />
+                </div>
+                <div className="tp-name">{opt.name}</div>
+                <div className="tp-desc">{opt.desc}</div>
+              </button>
+            ))}
+          </div>
 
-      <div>
-        <label htmlFor="op-yt">YouTube URL</label>
-        <input
-          id="op-yt"
-          value={youtubeUrl}
-          onChange={(e) => setYoutubeUrl(e.target.value)}
-          placeholder="https://www.youtube.com/watch?v=..."
-        />
-        {fieldErrors.youtube_url && <p className="field-error">{fieldErrors.youtube_url}</p>}
-      </div>
+          <div className="sub-section"><span className="sub-step">02</span> Source video</div>
+          <div className="sub-row">
+            <label>YouTube link <span className="req">*</span></label>
+            <input type="url" value={youtubeUrl} onChange={(e) => setYoutubeUrl(e.target.value)} placeholder="https://youtube.com/watch?v=…" />
+            <span className="hint">Official upload preferred — Crunchyroll, the studio, the artist&apos;s channel.</span>
+            {fieldErrors.youtube_url && <span className="ferr">{fieldErrors.youtube_url}</span>}
+          </div>
+          <div className="sub-row">
+            <label>{titleLabel} <span className="req">*</span></label>
+            <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Song name (romaji or english) — e.g. Mukanjyo" />
+            {fieldErrors.title && <span className="ferr">{fieldErrors.title}</span>}
+          </div>
 
-      <div>
-        <label>Anime</label>
-        <Autocomplete
-          placeholder="Search anime…"
-          fetchItems={fetchAnime}
-          selected={selectedAnime}
-          onSelect={setSelectedAnime}
-        />
-        {fieldErrors.anime_id && <p className="field-error">{fieldErrors.anime_id}</p>}
-        <p className="field-hint">Can&apos;t find it? Submit the anime first from the Anime tab.</p>
-      </div>
+          <div className="sub-section"><span className="sub-step">03</span> Anime &amp; singer</div>
+          <div className="sub-grid-2">
+            <div className="sub-row">
+              <label>Anime <span className="req">*</span></label>
+              <Autocomplete
+                placeholder="Search existing…"
+                fetchItems={fetchAnime}
+                selected={selectedAnime}
+                onSelect={setSelectedAnime}
+                onCreateNew={() => onSwitchTab("anime")}
+                createNewLabel="Add new anime…"
+              />
+              {fieldErrors.anime_id && <span className="ferr">{fieldErrors.anime_id}</span>}
+            </div>
+            <div className="sub-row">
+              <label>Singer <span className="req">*</span></label>
+              <Autocomplete
+                placeholder="Search existing…"
+                fetchItems={fetchSinger}
+                selected={selectedSinger}
+                onSelect={setSelectedSinger}
+                onCreateNew={() => onSwitchTab("singer")}
+                createNewLabel="Add new singer…"
+              />
+              {fieldErrors.singer_id && <span className="ferr">{fieldErrors.singer_id}</span>}
+            </div>
+          </div>
 
-      <div>
-        <label>Singer / Composer</label>
-        <Autocomplete
-          placeholder="Search singer or composer…"
-          fetchItems={fetchSinger}
-          selected={selectedSinger}
-          onSelect={setSelectedSinger}
-        />
-        {fieldErrors.singer_id && <p className="field-error">{fieldErrors.singer_id}</p>}
-        <p className="field-hint">Can&apos;t find them? Submit the singer first from the Singer tab.</p>
-      </div>
+          <div className="sub-section"><span className="sub-step">04</span> Anything else?</div>
+          <div className="sub-row">
+            <label>Notes for moderator <span className="opt">(optional)</span></label>
+            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} placeholder="Sources, alternate titles, why this video over another upload…" />
+          </div>
 
-      {error && <p className="submit-error">{error}</p>}
-
-      <div className="actions">
-        <button type="submit" className="btn primary" disabled={submitting}>
-          {submitting ? "Submitting…" : "Submit for review"}
-        </button>
+        </div>
+        <div className="sub-form-foot">
+          <span className="sub-foot-note">⌘ + Enter to submit</span>
+          <div className="sub-foot-actions">
+            {error && <span className="ferr">{error}</span>}
+            <button type="submit" className="btn primary lg" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit for review →"}
+            </button>
+          </div>
+        </div>
       </div>
     </form>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Anime tab
+// Anime form
 // ---------------------------------------------------------------------------
 
-function AnimeForm() {
-  const router = useRouter();
-  const [fields, setFields] = useState({
+function AnimePane() {
+  const FORMATS: { value: AnimeFormat; label: string }[] = [
+    { value: "tv",      label: "TV series" },
+    { value: "film",    label: "Film" },
+    { value: "ova_ona", label: "OVA / ONA" },
+    { value: "special", label: "Special" },
+  ];
+
+  const [f, setF] = useState({
     title_romaji: "", title_english: "", title_native: "",
-    year: "", format: "tv" as AnimeFormat,
-    episodes: "", studio: "", reference_url: "", notes_for_moderator: "",
+    year: "", format: "tv" as AnimeFormat, episodes: "",
+    studio: "", reference_url: "", notes_for_moderator: "",
   });
+  const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+    setF((prev) => ({ ...prev, [k]: e.target.value }));
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [success, setSuccess] = useState(false);
-
-  const set = (k: keyof typeof fields) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
-    setFields((f) => ({ ...f, [k]: e.target.value }));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -228,112 +305,135 @@ function AnimeForm() {
     const res = await fetch("/api/anime", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        ...fields,
-        year: Number(fields.year) || 0,
-        episodes: fields.episodes ? Number(fields.episodes) : undefined,
-      }),
+      body: JSON.stringify({ ...f, year: Number(f.year) || 0, episodes: f.episodes ? Number(f.episodes) : undefined }),
     });
 
     setSubmitting(false);
-
     if (!res.ok) {
       const payload = await res.json().catch(() => ({}));
       setError(payload.error ?? "Submission failed");
       if (payload.fields) setFieldErrors(payload.fields);
       return;
     }
-
     setSuccess(true);
   };
 
   if (success) {
     return (
-      <div className="submit-success">
-        <p>Anime submitted for review. Once approved it will appear in the anime picker.</p>
-        <button type="button" className="btn" onClick={() => { setSuccess(false); setFields({ title_romaji: "", title_english: "", title_native: "", year: "", format: "tv", episodes: "", studio: "", reference_url: "", notes_for_moderator: "" }); }}>
-          Submit another
-        </button>
+      <div className="sub-form-card">
+        <div className="sub-form-body" style={{ textAlign: "center", padding: "48px 26px" }}>
+          <p style={{ fontSize: 16, marginBottom: 20 }}>Anime submitted for review ✓</p>
+          <p className="hint" style={{ marginBottom: 24 }}>Once a mod approves it, it will appear in the anime picker on the Opening tab.</p>
+          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ title_romaji: "", title_english: "", title_native: "", year: "", format: "tv", episodes: "", studio: "", reference_url: "", notes_for_moderator: "" }); }}>
+            Submit another
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="a-romaji">Romaji title <span className="req">*</span></label>
-        <input id="a-romaji" value={fields.title_romaji} onChange={set("title_romaji")} placeholder="e.g. Naruto Shippuden" />
-        {fieldErrors.title_romaji && <p className="field-error">{fieldErrors.title_romaji}</p>}
-      </div>
-      <div>
-        <label htmlFor="a-english">English title</label>
-        <input id="a-english" value={fields.title_english} onChange={set("title_english")} placeholder="e.g. Naruto: Shippuden" />
-      </div>
-      <div>
-        <label htmlFor="a-native">Native title</label>
-        <input id="a-native" value={fields.title_native} onChange={set("title_native")} placeholder="e.g. ナルト 疾風伝" />
-      </div>
-      <div className="form-row">
-        <div>
-          <label htmlFor="a-year">Year <span className="req">*</span></label>
-          <input id="a-year" type="number" value={fields.year} onChange={set("year")} placeholder="e.g. 2007" min={1900} max={2030} />
-          {fieldErrors.year && <p className="field-error">{fieldErrors.year}</p>}
+      <div className="sub-form-card">
+        <div className="sub-form-head">
+          <h2>Submit an <em>anime</em>.</h2>
+          <p>So OPs, EDs, and OSTs can be attached to a real series</p>
         </div>
-        <div>
-          <label htmlFor="a-episodes">Episodes</label>
-          <input id="a-episodes" type="number" value={fields.episodes} onChange={set("episodes")} placeholder="e.g. 500" min={1} />
+        <div className="sub-form-body">
+
+          <div className="sub-section"><span className="sub-step">01</span> Titles</div>
+          <div className="sub-row">
+            <label>Romaji title <span className="req">*</span></label>
+            <input type="text" value={f.title_romaji} onChange={set("title_romaji")} placeholder="Shingeki no Kyojin" />
+            <span className="hint">The latin-script transliteration. Used as the canonical key.</span>
+            {fieldErrors.title_romaji && <span className="ferr">{fieldErrors.title_romaji}</span>}
+          </div>
+          <div className="sub-grid-2">
+            <div className="sub-row">
+              <label>English title <span className="opt">(optional)</span></label>
+              <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />
+            </div>
+            <div className="sub-row">
+              <label>Native (日本語) <span className="opt">(optional)</span></label>
+              <input type="text" value={f.title_native} onChange={set("title_native")} placeholder="進撃の巨人" />
+            </div>
+          </div>
+
+          <div className="sub-section"><span className="sub-step">02</span> Production</div>
+          <div className="sub-grid-3">
+            <div className="sub-row">
+              <label>Year <span className="req">*</span></label>
+              <input type="text" inputMode="numeric" value={f.year} onChange={set("year")} placeholder="2013" />
+              {fieldErrors.year && <span className="ferr">{fieldErrors.year}</span>}
+            </div>
+            <div className="sub-row">
+              <label>Format</label>
+              <select value={f.format} onChange={set("format")}>
+                {FORMATS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+              </select>
+            </div>
+            <div className="sub-row">
+              <label>Episodes <span className="opt">(optional)</span></label>
+              <input type="text" inputMode="numeric" value={f.episodes} onChange={set("episodes")} placeholder="25" />
+            </div>
+          </div>
+          <div className="sub-row">
+            <label>Studio <span className="opt">(optional)</span></label>
+            <input type="text" value={f.studio} onChange={set("studio")} placeholder="Wit Studio · MAPPA" />
+          </div>
+
+          <div className="sub-section"><span className="sub-step">03</span> Verification</div>
+          <div className="sub-row">
+            <label>Reference link <span className="req">*</span></label>
+            <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="https://anilist.co/anime/… or MyAnimeList / official site" />
+            <span className="hint">Helps the moderator verify the entry. AniList preferred.</span>
+            {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
+          </div>
+          <div className="sub-row">
+            <label>Notes for moderator <span className="opt">(optional)</span></label>
+            <textarea value={f.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Sequel/prequel relationships, alternate titles…" />
+          </div>
+
         </div>
-      </div>
-      <div>
-        <label>Format <span className="req">*</span></label>
-        <div className="kind-picker">
-          {ANIME_FORMATS.map((opt) => (
-            <button key={opt.value} type="button" className={`kind-btn${fields.format === opt.value ? " on" : ""}`} onClick={() => setFields((f) => ({ ...f, format: opt.value }))}>
-              <span className="kind-btn-label">{opt.label}</span>
+        <div className="sub-form-foot">
+          <span className="sub-foot-note">⌘ + Enter to submit</span>
+          <div className="sub-foot-actions">
+            {error && <span className="ferr">{error}</span>}
+            <button type="submit" className="btn primary lg" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit for review →"}
             </button>
-          ))}
+          </div>
         </div>
-        {fieldErrors.format && <p className="field-error">{fieldErrors.format}</p>}
-      </div>
-      <div>
-        <label htmlFor="a-studio">Studio</label>
-        <input id="a-studio" value={fields.studio} onChange={set("studio")} placeholder="e.g. Studio Pierrot" />
-      </div>
-      <div>
-        <label htmlFor="a-ref">Reference URL <span className="req">*</span></label>
-        <input id="a-ref" value={fields.reference_url} onChange={set("reference_url")} placeholder="https://anilist.co/anime/..." />
-        {fieldErrors.reference_url && <p className="field-error">{fieldErrors.reference_url}</p>}
-      </div>
-      <div>
-        <label htmlFor="a-notes">Notes for moderator</label>
-        <textarea id="a-notes" value={fields.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
-      </div>
-      {error && <p className="submit-error">{error}</p>}
-      <div className="actions">
-        <button type="submit" className="btn primary" disabled={submitting}>
-          {submitting ? "Submitting…" : "Submit for review"}
-        </button>
       </div>
     </form>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Singer tab
+// Singer form
 // ---------------------------------------------------------------------------
 
-function SingerForm() {
-  const [fields, setFields] = useState({
+function SingerPane() {
+  const TYPES: { value: SingerType; label: string }[] = [
+    { value: "solo",              label: "Solo artist" },
+    { value: "band",              label: "Band" },
+    { value: "idol_group",        label: "Idol group" },
+    { value: "vocaloid_producer", label: "Vocaloid producer" },
+    { value: "composer",          label: "Composer" },
+    { value: "other",             label: "Other" },
+  ];
+
+  const [f, setF] = useState({
     name: "", name_native: "", type: "solo" as SingerType,
     active_since: "", bio: "", reference_url: "", notes_for_moderator: "",
   });
+  const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+    setF((prev) => ({ ...prev, [k]: e.target.value }));
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const [success, setSuccess] = useState(false);
-
-  const set = (k: keyof typeof fields) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-    setFields((f) => ({ ...f, [k]: e.target.value }));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -344,79 +444,94 @@ function SingerForm() {
     const res = await fetch("/api/singers", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        ...fields,
-        active_since: fields.active_since ? Number(fields.active_since) : undefined,
-      }),
+      body: JSON.stringify({ ...f, active_since: f.active_since ? Number(f.active_since) : undefined }),
     });
 
     setSubmitting(false);
-
     if (!res.ok) {
       const payload = await res.json().catch(() => ({}));
       setError(payload.error ?? "Submission failed");
       if (payload.fields) setFieldErrors(payload.fields);
       return;
     }
-
     setSuccess(true);
   };
 
   if (success) {
     return (
-      <div className="submit-success">
-        <p>Singer submitted for review. Once approved they will appear in the singer picker.</p>
-        <button type="button" className="btn" onClick={() => { setSuccess(false); setFields({ name: "", name_native: "", type: "solo", active_since: "", bio: "", reference_url: "", notes_for_moderator: "" }); }}>
-          Submit another
-        </button>
+      <div className="sub-form-card">
+        <div className="sub-form-body" style={{ textAlign: "center", padding: "48px 26px" }}>
+          <p style={{ fontSize: 16, marginBottom: 20 }}>Singer submitted for review ✓</p>
+          <p className="hint" style={{ marginBottom: 24 }}>Once approved, they will appear in the singer picker on the Opening tab.</p>
+          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ name: "", name_native: "", type: "solo", active_since: "", bio: "", reference_url: "", notes_for_moderator: "" }); }}>
+            Submit another
+          </button>
+        </div>
       </div>
     );
   }
 
   return (
     <form onSubmit={handleSubmit}>
-      <div>
-        <label htmlFor="s-name">Name <span className="req">*</span></label>
-        <input id="s-name" value={fields.name} onChange={set("name")} placeholder="e.g. FLOW" />
-        {fieldErrors.name && <p className="field-error">{fieldErrors.name}</p>}
-      </div>
-      <div>
-        <label htmlFor="s-native">Native name</label>
-        <input id="s-native" value={fields.name_native} onChange={set("name_native")} placeholder="e.g. フロウ" />
-      </div>
-      <div>
-        <label>Type <span className="req">*</span></label>
-        <div className="kind-picker" style={{ flexWrap: "wrap" }}>
-          {SINGER_TYPES.map((opt) => (
-            <button key={opt.value} type="button" className={`kind-btn${fields.type === opt.value ? " on" : ""}`} onClick={() => setFields((f) => ({ ...f, type: opt.value }))}>
-              <span className="kind-btn-label">{opt.label}</span>
-            </button>
-          ))}
+      <div className="sub-form-card">
+        <div className="sub-form-head">
+          <h2>Submit a <em>singer</em>.</h2>
+          <p>Solo artist, band, group, or producer whose work appears in anime</p>
         </div>
-        {fieldErrors.type && <p className="field-error">{fieldErrors.type}</p>}
-      </div>
-      <div>
-        <label htmlFor="s-since">Active since (year)</label>
-        <input id="s-since" type="number" value={fields.active_since} onChange={set("active_since")} placeholder="e.g. 2003" min={1900} max={2030} />
-      </div>
-      <div>
-        <label htmlFor="s-bio">Bio</label>
-        <textarea id="s-bio" value={fields.bio} onChange={set("bio")} rows={3} placeholder="Short description" />
-      </div>
-      <div>
-        <label htmlFor="s-ref">Reference URL <span className="req">*</span></label>
-        <input id="s-ref" value={fields.reference_url} onChange={set("reference_url")} placeholder="https://www.last.fm/music/..." />
-        {fieldErrors.reference_url && <p className="field-error">{fieldErrors.reference_url}</p>}
-      </div>
-      <div>
-        <label htmlFor="s-notes">Notes for moderator</label>
-        <textarea id="s-notes" value={fields.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
-      </div>
-      {error && <p className="submit-error">{error}</p>}
-      <div className="actions">
-        <button type="submit" className="btn primary" disabled={submitting}>
-          {submitting ? "Submitting…" : "Submit for review"}
-        </button>
+        <div className="sub-form-body">
+
+          <div className="sub-section"><span className="sub-step">01</span> Identity</div>
+          <div className="sub-row">
+            <label>Name <span className="req">*</span></label>
+            <input type="text" value={f.name} onChange={set("name")} placeholder="YOASOBI" />
+            <span className="hint">Romaji or English — whichever is the canonical form.</span>
+            {fieldErrors.name && <span className="ferr">{fieldErrors.name}</span>}
+          </div>
+          <div className="sub-row">
+            <label>Native (日本語) <span className="opt">(optional)</span></label>
+            <input type="text" value={f.name_native} onChange={set("name_native")} placeholder="ヨアソビ" />
+          </div>
+
+          <div className="sub-section"><span className="sub-step">02</span> About</div>
+          <div className="sub-grid-2">
+            <div className="sub-row">
+              <label>Type <span className="req">*</span></label>
+              <select value={f.type} onChange={set("type")}>
+                {TYPES.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+              </select>
+              {fieldErrors.type && <span className="ferr">{fieldErrors.type}</span>}
+            </div>
+            <div className="sub-row">
+              <label>Active since <span className="opt">(optional)</span></label>
+              <input type="text" inputMode="numeric" value={f.active_since} onChange={set("active_since")} placeholder="2019" />
+            </div>
+          </div>
+          <div className="sub-row">
+            <label>Short bio <span className="opt">(optional)</span></label>
+            <textarea value={f.bio} onChange={set("bio")} rows={3} placeholder="One or two sentences. Genres, notable works, anything that helps recognize them." />
+          </div>
+
+          <div className="sub-section"><span className="sub-step">03</span> Verification</div>
+          <div className="sub-row">
+            <label>Reference link <span className="req">*</span></label>
+            <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="Official site, Spotify, Wikipedia…" />
+            {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
+          </div>
+          <div className="sub-row">
+            <label>Notes for moderator <span className="opt">(optional)</span></label>
+            <textarea value={f.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
+          </div>
+
+        </div>
+        <div className="sub-form-foot">
+          <span className="sub-foot-note">⌘ + Enter to submit</span>
+          <div className="sub-foot-actions">
+            {error && <span className="ferr">{error}</span>}
+            <button type="submit" className="btn primary lg" disabled={submitting}>
+              {submitting ? "Submitting…" : "Submit for review →"}
+            </button>
+          </div>
+        </div>
       </div>
     </form>
   );
@@ -426,43 +541,67 @@ function SingerForm() {
 // Page
 // ---------------------------------------------------------------------------
 
-const TAB_LABELS: Record<Tab, string> = {
-  opening: "Opening / Ending / OST",
-  anime: "Anime",
-  singer: "Singer",
-};
-
-const TAB_TITLES: Record<Tab, string> = {
-  opening: "Submit a track",
-  anime: "Submit an anime",
-  singer: "Submit a singer",
-};
+const TABS: { id: Tab; icon: React.ReactNode; label: string; sub: string }[] = [
+  {
+    id: "opening",
+    icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m22 8-6 4 6 4V8Z"/><rect x="2" y="6" width="14" height="12" rx="2"/></svg>,
+    label: "An opening",
+    sub: "OP, ED, or OST · 30 sec",
+  },
+  {
+    id: "anime",
+    icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>,
+    label: "An anime",
+    sub: "New series · for OPs to attach to",
+  },
+  {
+    id: "singer",
+    icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>,
+    label: "A singer",
+    sub: "Solo, band, or group · vocaloid",
+  },
+];
 
 export default function SubmitPage({ user, modQueueCount }: Props) {
   const [tab, setTab] = useState<Tab>("opening");
 
   return (
-    <Layout user={user} modQueueCount={modQueueCount} title={TAB_TITLES[tab]}>
-      <div className="formpage">
-        <h1>{TAB_TITLES[tab]}</h1>
-        <p>Goes to the moderation queue. Mods/admins are auto-approved.</p>
+    <Layout user={user} modQueueCount={modQueueCount} title="Submit · Opening Wiki">
+      <div className="wrap">
+        <div className="sub-crumb">
+          <Link href="/">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
+            Back to catalogue
+          </Link>
+        </div>
 
-        <div className="submit-tabs">
-          {(["opening", "anime", "singer"] as Tab[]).map((t) => (
+        <div className="sub-head">
+          <h1>Submit something <em>new</em>.</h1>
+          <p>Anyone can propose entries · Mods review within 24h · You&apos;ll get a notification when it&apos;s live</p>
+        </div>
+
+        <div className="sub-tabs">
+          {TABS.map((t) => (
             <button
-              key={t}
+              key={t.id}
               type="button"
-              className={`submit-tab${tab === t ? " on" : ""}`}
-              onClick={() => setTab(t)}
+              className={`sub-tab${tab === t.id ? " on" : ""}`}
+              onClick={() => setTab(t.id)}
             >
-              {TAB_LABELS[t]}
+              <span className="st-label">{t.icon}{t.label}</span>
+              <span className="st-sub">{t.sub}</span>
             </button>
           ))}
         </div>
 
-        {tab === "opening" && <OpeningForm />}
-        {tab === "anime" && <AnimeForm />}
-        {tab === "singer" && <SingerForm />}
+        <div className="sub-page-grid">
+          <div>
+            {tab === "opening" && <OpeningPane onSwitchTab={setTab} />}
+            {tab === "anime"   && <AnimePane />}
+            {tab === "singer"  && <SingerPane />}
+          </div>
+          <Sidebar tab={tab} />
+        </div>
       </div>
     </Layout>
   );

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -1,9 +1,10 @@
 import type { GetServerSideProps } from "next";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/router";
 import Layout from "@/components/Layout";
+import Autocomplete, { type AutocompleteItem } from "@/components/Autocomplete";
 import { loadSession } from "@/lib/session";
-import type { TrackKind, User } from "@/lib/types";
+import type { TrackKind, AnimeFormat, SingerType, User } from "@/lib/types";
 
 interface Props {
   user: User | null;
@@ -15,10 +16,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   if (!session.user) {
     return { redirect: { destination: "/login?next=/submit", permanent: false } };
   }
-  return {
-    props: { user: session.user, modQueueCount: session.modQueueCount },
-  };
+  return { props: { user: session.user, modQueueCount: session.modQueueCount } };
 };
+
+type Tab = "opening" | "anime" | "singer";
 
 const KIND_OPTIONS: { value: TrackKind; label: string; sub: string }[] = [
   { value: "opening", label: "Opening", sub: "OP · INTRO" },
@@ -26,73 +27,442 @@ const KIND_OPTIONS: { value: TrackKind; label: string; sub: string }[] = [
   { value: "ost",     label: "OST",     sub: "OST · TRACK" },
 ];
 
-const KIND_TITLES: Record<TrackKind, string> = {
-  opening: "Submit an opening",
-  ending:  "Submit an ending",
-  ost:     "Submit an OST",
+const ANIME_FORMATS: { value: AnimeFormat; label: string }[] = [
+  { value: "tv",      label: "TV" },
+  { value: "film",    label: "Film" },
+  { value: "ova_ona", label: "OVA / ONA" },
+  { value: "special", label: "Special" },
+];
+
+const SINGER_TYPES: { value: SingerType; label: string }[] = [
+  { value: "solo",              label: "Solo artist" },
+  { value: "band",              label: "Band" },
+  { value: "idol_group",        label: "Idol group" },
+  { value: "vocaloid_producer", label: "Vocaloid / producer" },
+  { value: "composer",          label: "Composer" },
+  { value: "other",             label: "Other" },
+];
+
+async function fetchAnimeItems(q: string): Promise<AutocompleteItem[]> {
+  const res = await fetch(`/api/anime/search?q=${encodeURIComponent(q)}`);
+  if (!res.ok) return [];
+  const payload = await res.json();
+  const items = Array.isArray(payload.data) ? payload.data : [];
+  return items.map((a: any) => ({
+    id: a.id,
+    label: a.name,
+    sublabel: a.year ? `${a.format?.toUpperCase() ?? ""} · ${a.year}` : undefined,
+  }));
+}
+
+async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
+  const res = await fetch(`/api/singers/search?q=${encodeURIComponent(q)}`);
+  if (!res.ok) return [];
+  const payload = await res.json();
+  const items = Array.isArray(payload.data) ? payload.data : [];
+  return items.map((s: any) => ({
+    id: s.id,
+    label: s.name,
+    sublabel: s.type?.replace(/_/g, " ") ?? undefined,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Opening tab
+// ---------------------------------------------------------------------------
+
+function OpeningForm() {
+  const router = useRouter();
+  const [kind, setKind] = useState<TrackKind>("opening");
+  const [title, setTitle] = useState("");
+  const [youtubeUrl, setYoutubeUrl] = useState("");
+  const [selectedAnime, setSelectedAnime] = useState<AutocompleteItem | null>(null);
+  const [selectedSinger, setSelectedSinger] = useState<AutocompleteItem | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const fetchAnime = useCallback(fetchAnimeItems, []);
+  const fetchSinger = useCallback(fetchSingerItems, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const errs: Record<string, string> = {};
+    if (!title.trim()) errs.title = "Title is required";
+    if (!youtubeUrl.trim()) errs.youtube_url = "YouTube URL is required";
+    if (!selectedAnime) errs.anime_id = "Select an anime";
+    if (!selectedSinger) errs.singer_id = "Select a singer";
+    if (Object.keys(errs).length > 0) { setFieldErrors(errs); return; }
+
+    setSubmitting(true);
+    setError(null);
+    setFieldErrors({});
+
+    const res = await fetch("/api/openings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: title.trim(),
+        youtube_url: youtubeUrl.trim(),
+        kind,
+        anime_id: selectedAnime!.id,
+        singer_id: selectedSinger!.id,
+      }),
+    });
+
+    setSubmitting(false);
+
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      setError(payload.error ?? "Submission failed");
+      if (payload.fields) setFieldErrors(payload.fields);
+      return;
+    }
+
+    router.push(`/?kind=${kind}`);
+  };
+
+  const titleLabel = kind === "ost" ? "Track title" : kind === "ending" ? "Ending title" : "Opening title";
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>Type</label>
+        <div className="kind-picker">
+          {KIND_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={`kind-btn${kind === opt.value ? " on" : ""}`}
+              onClick={() => setKind(opt.value)}
+            >
+              <span className="kind-btn-label">{opt.label}</span>
+              <span className="kind-btn-sub">{opt.sub}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="op-title">{titleLabel}</label>
+        <input
+          id="op-title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={`e.g. Silhouette`}
+        />
+        {fieldErrors.title && <p className="field-error">{fieldErrors.title}</p>}
+      </div>
+
+      <div>
+        <label htmlFor="op-yt">YouTube URL</label>
+        <input
+          id="op-yt"
+          value={youtubeUrl}
+          onChange={(e) => setYoutubeUrl(e.target.value)}
+          placeholder="https://www.youtube.com/watch?v=..."
+        />
+        {fieldErrors.youtube_url && <p className="field-error">{fieldErrors.youtube_url}</p>}
+      </div>
+
+      <div>
+        <label>Anime</label>
+        <Autocomplete
+          placeholder="Search anime…"
+          fetchItems={fetchAnime}
+          selected={selectedAnime}
+          onSelect={setSelectedAnime}
+        />
+        {fieldErrors.anime_id && <p className="field-error">{fieldErrors.anime_id}</p>}
+        <p className="field-hint">Can&apos;t find it? Submit the anime first from the Anime tab.</p>
+      </div>
+
+      <div>
+        <label>Singer / Composer</label>
+        <Autocomplete
+          placeholder="Search singer or composer…"
+          fetchItems={fetchSinger}
+          selected={selectedSinger}
+          onSelect={setSelectedSinger}
+        />
+        {fieldErrors.singer_id && <p className="field-error">{fieldErrors.singer_id}</p>}
+        <p className="field-hint">Can&apos;t find them? Submit the singer first from the Singer tab.</p>
+      </div>
+
+      {error && <p className="submit-error">{error}</p>}
+
+      <div className="actions">
+        <button type="submit" className="btn primary" disabled={submitting}>
+          {submitting ? "Submitting…" : "Submit for review"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Anime tab
+// ---------------------------------------------------------------------------
+
+function AnimeForm() {
+  const router = useRouter();
+  const [fields, setFields] = useState({
+    title_romaji: "", title_english: "", title_native: "",
+    year: "", format: "tv" as AnimeFormat,
+    episodes: "", studio: "", reference_url: "", notes_for_moderator: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [success, setSuccess] = useState(false);
+
+  const set = (k: keyof typeof fields) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
+    setFields((f) => ({ ...f, [k]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setFieldErrors({});
+
+    const res = await fetch("/api/anime", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...fields,
+        year: Number(fields.year) || 0,
+        episodes: fields.episodes ? Number(fields.episodes) : undefined,
+      }),
+    });
+
+    setSubmitting(false);
+
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      setError(payload.error ?? "Submission failed");
+      if (payload.fields) setFieldErrors(payload.fields);
+      return;
+    }
+
+    setSuccess(true);
+  };
+
+  if (success) {
+    return (
+      <div className="submit-success">
+        <p>Anime submitted for review. Once approved it will appear in the anime picker.</p>
+        <button type="button" className="btn" onClick={() => { setSuccess(false); setFields({ title_romaji: "", title_english: "", title_native: "", year: "", format: "tv", episodes: "", studio: "", reference_url: "", notes_for_moderator: "" }); }}>
+          Submit another
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="a-romaji">Romaji title <span className="req">*</span></label>
+        <input id="a-romaji" value={fields.title_romaji} onChange={set("title_romaji")} placeholder="e.g. Naruto Shippuden" />
+        {fieldErrors.title_romaji && <p className="field-error">{fieldErrors.title_romaji}</p>}
+      </div>
+      <div>
+        <label htmlFor="a-english">English title</label>
+        <input id="a-english" value={fields.title_english} onChange={set("title_english")} placeholder="e.g. Naruto: Shippuden" />
+      </div>
+      <div>
+        <label htmlFor="a-native">Native title</label>
+        <input id="a-native" value={fields.title_native} onChange={set("title_native")} placeholder="e.g. ナルト 疾風伝" />
+      </div>
+      <div className="form-row">
+        <div>
+          <label htmlFor="a-year">Year <span className="req">*</span></label>
+          <input id="a-year" type="number" value={fields.year} onChange={set("year")} placeholder="e.g. 2007" min={1900} max={2030} />
+          {fieldErrors.year && <p className="field-error">{fieldErrors.year}</p>}
+        </div>
+        <div>
+          <label htmlFor="a-episodes">Episodes</label>
+          <input id="a-episodes" type="number" value={fields.episodes} onChange={set("episodes")} placeholder="e.g. 500" min={1} />
+        </div>
+      </div>
+      <div>
+        <label>Format <span className="req">*</span></label>
+        <div className="kind-picker">
+          {ANIME_FORMATS.map((opt) => (
+            <button key={opt.value} type="button" className={`kind-btn${fields.format === opt.value ? " on" : ""}`} onClick={() => setFields((f) => ({ ...f, format: opt.value }))}>
+              <span className="kind-btn-label">{opt.label}</span>
+            </button>
+          ))}
+        </div>
+        {fieldErrors.format && <p className="field-error">{fieldErrors.format}</p>}
+      </div>
+      <div>
+        <label htmlFor="a-studio">Studio</label>
+        <input id="a-studio" value={fields.studio} onChange={set("studio")} placeholder="e.g. Studio Pierrot" />
+      </div>
+      <div>
+        <label htmlFor="a-ref">Reference URL <span className="req">*</span></label>
+        <input id="a-ref" value={fields.reference_url} onChange={set("reference_url")} placeholder="https://anilist.co/anime/..." />
+        {fieldErrors.reference_url && <p className="field-error">{fieldErrors.reference_url}</p>}
+      </div>
+      <div>
+        <label htmlFor="a-notes">Notes for moderator</label>
+        <textarea id="a-notes" value={fields.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
+      </div>
+      {error && <p className="submit-error">{error}</p>}
+      <div className="actions">
+        <button type="submit" className="btn primary" disabled={submitting}>
+          {submitting ? "Submitting…" : "Submit for review"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Singer tab
+// ---------------------------------------------------------------------------
+
+function SingerForm() {
+  const [fields, setFields] = useState({
+    name: "", name_native: "", type: "solo" as SingerType,
+    active_since: "", bio: "", reference_url: "", notes_for_moderator: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [success, setSuccess] = useState(false);
+
+  const set = (k: keyof typeof fields) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+    setFields((f) => ({ ...f, [k]: e.target.value }));
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setFieldErrors({});
+
+    const res = await fetch("/api/singers", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...fields,
+        active_since: fields.active_since ? Number(fields.active_since) : undefined,
+      }),
+    });
+
+    setSubmitting(false);
+
+    if (!res.ok) {
+      const payload = await res.json().catch(() => ({}));
+      setError(payload.error ?? "Submission failed");
+      if (payload.fields) setFieldErrors(payload.fields);
+      return;
+    }
+
+    setSuccess(true);
+  };
+
+  if (success) {
+    return (
+      <div className="submit-success">
+        <p>Singer submitted for review. Once approved they will appear in the singer picker.</p>
+        <button type="button" className="btn" onClick={() => { setSuccess(false); setFields({ name: "", name_native: "", type: "solo", active_since: "", bio: "", reference_url: "", notes_for_moderator: "" }); }}>
+          Submit another
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="s-name">Name <span className="req">*</span></label>
+        <input id="s-name" value={fields.name} onChange={set("name")} placeholder="e.g. FLOW" />
+        {fieldErrors.name && <p className="field-error">{fieldErrors.name}</p>}
+      </div>
+      <div>
+        <label htmlFor="s-native">Native name</label>
+        <input id="s-native" value={fields.name_native} onChange={set("name_native")} placeholder="e.g. フロウ" />
+      </div>
+      <div>
+        <label>Type <span className="req">*</span></label>
+        <div className="kind-picker" style={{ flexWrap: "wrap" }}>
+          {SINGER_TYPES.map((opt) => (
+            <button key={opt.value} type="button" className={`kind-btn${fields.type === opt.value ? " on" : ""}`} onClick={() => setFields((f) => ({ ...f, type: opt.value }))}>
+              <span className="kind-btn-label">{opt.label}</span>
+            </button>
+          ))}
+        </div>
+        {fieldErrors.type && <p className="field-error">{fieldErrors.type}</p>}
+      </div>
+      <div>
+        <label htmlFor="s-since">Active since (year)</label>
+        <input id="s-since" type="number" value={fields.active_since} onChange={set("active_since")} placeholder="e.g. 2003" min={1900} max={2030} />
+      </div>
+      <div>
+        <label htmlFor="s-bio">Bio</label>
+        <textarea id="s-bio" value={fields.bio} onChange={set("bio")} rows={3} placeholder="Short description" />
+      </div>
+      <div>
+        <label htmlFor="s-ref">Reference URL <span className="req">*</span></label>
+        <input id="s-ref" value={fields.reference_url} onChange={set("reference_url")} placeholder="https://www.last.fm/music/..." />
+        {fieldErrors.reference_url && <p className="field-error">{fieldErrors.reference_url}</p>}
+      </div>
+      <div>
+        <label htmlFor="s-notes">Notes for moderator</label>
+        <textarea id="s-notes" value={fields.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
+      </div>
+      {error && <p className="submit-error">{error}</p>}
+      <div className="actions">
+        <button type="submit" className="btn primary" disabled={submitting}>
+          {submitting ? "Submitting…" : "Submit for review"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const TAB_LABELS: Record<Tab, string> = {
+  opening: "Opening / Ending / OST",
+  anime: "Anime",
+  singer: "Singer",
 };
 
-const TITLE_LABELS: Record<TrackKind, string> = {
-  opening: "Opening title",
-  ending:  "Ending title",
-  ost:     "Track title",
+const TAB_TITLES: Record<Tab, string> = {
+  opening: "Submit a track",
+  anime: "Submit an anime",
+  singer: "Submit a singer",
 };
 
 export default function SubmitPage({ user, modQueueCount }: Props) {
-  const router = useRouter();
-  const error = typeof router.query.error === "string" ? router.query.error : null;
-  const [kind, setKind] = useState<TrackKind>("opening");
+  const [tab, setTab] = useState<Tab>("opening");
 
   return (
-    <Layout user={user} modQueueCount={modQueueCount} title={KIND_TITLES[kind]}>
+    <Layout user={user} modQueueCount={modQueueCount} title={TAB_TITLES[tab]}>
       <div className="formpage">
-        <h1>{KIND_TITLES[kind]}</h1>
+        <h1>{TAB_TITLES[tab]}</h1>
         <p>Goes to the moderation queue. Mods/admins are auto-approved.</p>
-        {error && <p className="mock-notice">{error}</p>}
-        <form action="/api/openings" method="post">
-          <div>
-            <label>Type</label>
-            <div className="kind-picker">
-              {KIND_OPTIONS.map((opt) => (
-                <button
-                  key={opt.value}
-                  type="button"
-                  className={`kind-btn${kind === opt.value ? " on" : ""}`}
-                  onClick={() => setKind(opt.value)}
-                >
-                  <span className="kind-btn-label">{opt.label}</span>
-                  <span className="kind-btn-sub">{opt.sub}</span>
-                </button>
-              ))}
-            </div>
-            <input type="hidden" name="kind" value={kind} />
-          </div>
-          <div>
-            <label htmlFor="title">{TITLE_LABELS[kind]}</label>
-            <input id="title" name="title" required />
-          </div>
-          <div>
-            <label htmlFor="youtube_url">YouTube URL</label>
-            <input
-              id="youtube_url"
-              name="youtube_url"
-              type="url"
-              required
-              placeholder="https://www.youtube.com/watch?v=..."
-            />
-          </div>
-          <div>
-            <label htmlFor="anime">Anime</label>
-            <input id="anime" name="anime" required placeholder="Existing or new anime name" />
-          </div>
-          <div>
-            <label htmlFor="singer">Singer / Composer</label>
-            <input id="singer" name="singer" required placeholder="Existing or new artist name" />
-          </div>
-          <div className="actions">
-            <button type="submit" className="btn primary">Submit for review</button>
-          </div>
-        </form>
+
+        <div className="submit-tabs">
+          {(["opening", "anime", "singer"] as Tab[]).map((t) => (
+            <button
+              key={t}
+              type="button"
+              className={`submit-tab${tab === t ? " on" : ""}`}
+              onClick={() => setTab(t)}
+            >
+              {TAB_LABELS[t]}
+            </button>
+          ))}
+        </div>
+
+        {tab === "opening" && <OpeningForm />}
+        {tab === "anime" && <AnimeForm />}
+        {tab === "singer" && <SingerForm />}
       </div>
     </Layout>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -455,6 +455,66 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .kind-btn-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.06em; }
 .kind-btn.on .kind-btn-sub { color: var(--accent); opacity: 0.7; }
 
+/* Submit page tabs */
+.submit-tabs { display: flex; gap: 4px; margin-bottom: 24px; border-bottom: 1px solid var(--line); padding-bottom: 0; }
+.submit-tab {
+  padding: 8px 14px; font-family: var(--mono); font-size: 11px; text-transform: uppercase;
+  letter-spacing: 0.08em; color: var(--fg-3); background: none; border: none;
+  border-bottom: 2px solid transparent; cursor: pointer; transition: color .15s;
+  margin-bottom: -1px;
+}
+.submit-tab:hover { color: var(--fg-2); }
+.submit-tab.on { color: var(--fg); border-bottom-color: var(--accent); }
+
+/* Two-column form row */
+.formpage .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+/* Required field marker */
+.formpage .req { color: var(--accent); }
+
+/* Inline field error */
+.formpage .field-error { font-family: var(--mono); font-size: 11px; color: #f87171; margin: 4px 0 0; }
+.formpage .field-hint  { font-family: var(--mono); font-size: 11px; color: var(--fg-4); margin: 4px 0 0; }
+.formpage .submit-error { font-size: 13px; color: #f87171; padding: 10px 14px; border-radius: 8px; background: rgba(248,113,113,0.08); border: 1px solid rgba(248,113,113,0.2); }
+
+/* Success message */
+.formpage .submit-success { text-align: center; padding: 32px 0; }
+.formpage .submit-success p { color: var(--fg-2); margin-bottom: 20px; font-size: 14px; }
+
+/* Autocomplete */
+.ac-wrap { position: relative; }
+.ac-input {
+  width: 100%; background: var(--bg-2); border: 1px solid var(--line);
+  border-radius: 8px; padding: 12px 14px; color: var(--fg); font-size: 14px;
+}
+.ac-input:focus { outline: none; border-color: var(--accent); }
+.ac-dropdown {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 100;
+  background: var(--bg-2); border: 1px solid var(--line-2);
+  border-radius: 8px; list-style: none; max-height: 220px; overflow-y: auto;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+}
+.ac-item {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 10px 14px; cursor: pointer; transition: background .1s;
+}
+.ac-item:hover { background: var(--bg-3, #1e1b2e); }
+.ac-item-label { font-size: 14px; color: var(--fg); }
+.ac-item-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
+.ac-empty { padding: 12px 14px; font-family: var(--mono); font-size: 12px; color: var(--fg-4); }
+.ac-chip {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px; background: var(--bg-2); border: 1px solid var(--accent);
+  border-radius: 8px;
+}
+.ac-chip-label { font-size: 14px; color: var(--fg); flex: 1; }
+.ac-chip-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
+.ac-chip-clear {
+  background: none; border: none; color: var(--fg-3); font-size: 18px; line-height: 1;
+  cursor: pointer; padding: 0 2px; transition: color .15s;
+}
+.ac-chip-clear:hover { color: var(--fg); }
+
 /* ── Detail page ──────────────────────────────────────────────────────────── */
 
 /* Breadcrumb bar */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -455,65 +455,226 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .kind-btn-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.06em; }
 .kind-btn.on .kind-btn-sub { color: var(--accent); opacity: 0.7; }
 
-/* Submit page tabs */
-.submit-tabs { display: flex; gap: 4px; margin-bottom: 24px; border-bottom: 1px solid var(--line); padding-bottom: 0; }
-.submit-tab {
-  padding: 8px 14px; font-family: var(--mono); font-size: 11px; text-transform: uppercase;
-  letter-spacing: 0.08em; color: var(--fg-3); background: none; border: none;
-  border-bottom: 2px solid transparent; cursor: pointer; transition: color .15s;
-  margin-bottom: -1px;
+/* ── Submit page ─────────────────────────────────────────────────────────── */
+.sub-crumb {
+  padding: 28px 0 14px; font-family: var(--mono); font-size: 12px; color: var(--fg-3);
 }
-.submit-tab:hover { color: var(--fg-2); }
-.submit-tab.on { color: var(--fg); border-bottom-color: var(--accent); }
+.sub-crumb a {
+  display: inline-flex; align-items: center; gap: 6px; color: var(--fg-3); transition: color .15s;
+}
+.sub-crumb a:hover { color: var(--fg); }
+.sub-crumb svg { width: 12px; height: 12px; }
 
-/* Two-column form row */
-.formpage .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.sub-head { padding: 4px 0 28px; }
+.sub-head h1 {
+  font-weight: 800; font-size: 44px; line-height: 1; letter-spacing: -0.035em; margin: 0 0 10px;
+}
+.sub-head h1 em { font-style: normal; color: var(--accent); }
+.sub-head p { color: var(--fg-3); font-family: var(--mono); font-size: 12px; margin: 0; letter-spacing: 0.04em; }
 
-/* Required field marker */
-.formpage .req { color: var(--accent); }
+/* Tab chooser — 3 card-style buttons */
+.sub-tabs {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 36px;
+}
+.sub-tab {
+  display: flex; flex-direction: column; gap: 8px; padding: 18px 20px;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--bg-2);
+  text-align: left; cursor: pointer; transition: border-color .15s, background .15s;
+  position: relative;
+}
+.sub-tab:hover { border-color: var(--line-2); background: var(--bg-3); }
+.sub-tab.on {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 8%, var(--bg-2));
+}
+.sub-tab.on::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0;
+  width: 3px; background: var(--accent); border-radius: 8px 0 0 8px;
+}
+.sub-tab .st-label {
+  display: flex; align-items: center; gap: 10px;
+  font-weight: 700; font-size: 16px; letter-spacing: -0.015em; color: var(--fg-2);
+}
+.sub-tab .st-label svg { color: var(--fg-3); flex-shrink: 0; transition: color .15s; }
+.sub-tab.on .st-label { color: var(--fg); }
+.sub-tab.on .st-label svg { color: var(--accent); }
+.sub-tab .st-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); letter-spacing: 0.02em; }
 
-/* Inline field error */
-.formpage .field-error { font-family: var(--mono); font-size: 11px; color: #f87171; margin: 4px 0 0; }
-.formpage .field-hint  { font-family: var(--mono); font-size: 11px; color: var(--fg-4); margin: 4px 0 0; }
-.formpage .submit-error { font-size: 13px; color: #f87171; padding: 10px 14px; border-radius: 8px; background: rgba(248,113,113,0.08); border: 1px solid rgba(248,113,113,0.2); }
+/* Two-column page grid: form + sidebar */
+.sub-page-grid {
+  display: grid; grid-template-columns: 1fr 320px; gap: 40px; padding-bottom: 80px; align-items: start;
+}
 
-/* Success message */
-.formpage .submit-success { text-align: center; padding: 32px 0; }
-.formpage .submit-success p { color: var(--fg-2); margin-bottom: 20px; font-size: 14px; }
+/* Form card */
+.sub-form-card {
+  border: 1px solid var(--line); border-radius: 10px; background: var(--bg-2); overflow: hidden;
+}
+.sub-form-head {
+  padding: 22px 26px 18px; border-bottom: 1px solid var(--line);
+}
+.sub-form-head h2 {
+  margin: 0 0 4px; font-weight: 800; font-size: 22px; letter-spacing: -0.025em;
+}
+.sub-form-head h2 em { font-style: normal; color: var(--accent); }
+.sub-form-head p { margin: 0; color: var(--fg-3); font-family: var(--mono); font-size: 11px; letter-spacing: 0.04em; }
+.sub-form-body { padding: 24px 26px; }
+.sub-form-foot {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 26px; border-top: 1px solid var(--line); background: var(--bg);
+}
+.sub-foot-note { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.06em; }
+.sub-foot-actions { display: flex; align-items: center; gap: 12px; }
 
-/* Autocomplete */
-.ac-wrap { position: relative; }
-.ac-input {
-  width: 100%; background: var(--bg-2); border: 1px solid var(--line);
-  border-radius: 8px; padding: 12px 14px; color: var(--fg); font-size: 14px;
+/* Numbered section header */
+.sub-section {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase;
+  color: var(--fg-3); border-top: 1px solid var(--line);
+  padding-top: 22px; margin-top: 22px; margin-bottom: 16px;
 }
-.ac-input:focus { outline: none; border-color: var(--accent); }
-.ac-dropdown {
-  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 100;
-  background: var(--bg-2); border: 1px solid var(--line-2);
-  border-radius: 8px; list-style: none; max-height: 220px; overflow-y: auto;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+.sub-section:first-child { border-top: 0; padding-top: 0; margin-top: 0; }
+.sub-step { color: var(--accent); margin-right: 8px; font-weight: 600; }
+
+/* Type picker (OP / ED / OST) */
+.sub-type-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-bottom: 0; }
+.sub-type-pick {
+  border: 1px solid var(--line); border-radius: 8px; padding: 16px 16px 14px;
+  background: var(--bg-3); cursor: pointer; text-align: left;
+  transition: border-color .15s, background .15s;
+  display: flex; flex-direction: column; gap: 6px;
 }
-.ac-item {
-  display: flex; flex-direction: column; gap: 2px;
-  padding: 10px 14px; cursor: pointer; transition: background .1s;
+.sub-type-pick:hover { border-color: var(--line-2); }
+.sub-type-pick.on {
+  border-color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 12%, var(--bg-3));
 }
-.ac-item:hover { background: var(--bg-3, #1e1b2e); }
-.ac-item-label { font-size: 14px; color: var(--fg); }
-.ac-item-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
-.ac-empty { padding: 12px 14px; font-family: var(--mono); font-size: 12px; color: var(--fg-4); }
-.ac-chip {
-  display: flex; align-items: center; gap: 8px;
-  padding: 10px 14px; background: var(--bg-2); border: 1px solid var(--accent);
-  border-radius: 8px;
+.sub-type-pick.ed.on { border-color: var(--ok); background: color-mix(in oklab, var(--ok) 10%, var(--bg-3)); }
+.sub-type-pick.ost.on { border-color: var(--warn); background: color-mix(in oklab, var(--warn) 10%, var(--bg-3)); }
+.tp-row { display: flex; align-items: center; gap: 8px; }
+.tp-tag {
+  font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 0.14em;
+  text-transform: uppercase; padding: 3px 7px; border-radius: 3px;
+  border: 1px solid var(--line-2); color: var(--fg-3);
 }
-.ac-chip-label { font-size: 14px; color: var(--fg); flex: 1; }
-.ac-chip-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.06em; }
-.ac-chip-clear {
-  background: none; border: none; color: var(--fg-3); font-size: 18px; line-height: 1;
-  cursor: pointer; padding: 0 2px; transition: color .15s;
+.sub-type-pick.on .tp-tag { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 60%, transparent); background: color-mix(in oklab, var(--accent) 10%, transparent); }
+.sub-type-pick.ed.on .tp-tag { color: var(--ok); border-color: color-mix(in oklab, var(--ok) 60%, transparent); background: color-mix(in oklab, var(--ok) 10%, transparent); }
+.sub-type-pick.ost.on .tp-tag { color: var(--warn); border-color: color-mix(in oklab, var(--warn) 60%, transparent); background: color-mix(in oklab, var(--warn) 10%, transparent); }
+.tp-name { font-weight: 600; font-size: 15px; letter-spacing: -0.015em; }
+.tp-desc { font-family: var(--mono); font-size: 11px; color: var(--fg-3); line-height: 1.4; }
+.tp-radio {
+  width: 16px; height: 16px; border-radius: 50%; border: 1.5px solid var(--line-2);
+  margin-left: auto; display: grid; place-items: center; flex-shrink: 0;
 }
-.ac-chip-clear:hover { color: var(--fg); }
+.sub-type-pick.on .tp-radio { border-color: var(--accent); }
+.sub-type-pick.on .tp-radio::after { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--accent); }
+.sub-type-pick.ed.on .tp-radio { border-color: var(--ok); }
+.sub-type-pick.ed.on .tp-radio::after { background: var(--ok); }
+.sub-type-pick.ost.on .tp-radio { border-color: var(--warn); }
+.sub-type-pick.ost.on .tp-radio::after { background: var(--warn); }
+
+/* Form fields */
+.sub-row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+.sub-row:last-child { margin-bottom: 0; }
+.sub-row label {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+  color: var(--fg-3); display: flex; align-items: center; gap: 6px;
+}
+.sub-row label .req { color: var(--accent); }
+.sub-row label .opt { color: var(--fg-4); font-size: 9px; letter-spacing: 0.08em; }
+.sub-row input, .sub-row select, .sub-row textarea {
+  background: var(--bg-3); border: 1px solid var(--line); border-radius: 6px;
+  padding: 11px 14px; color: var(--fg); font-family: var(--sans); font-size: 14px;
+  outline: none; transition: border-color .15s; width: 100%;
+}
+.sub-row textarea { min-height: 80px; resize: vertical; line-height: 1.55; }
+.sub-row input:focus, .sub-row select:focus, .sub-row textarea:focus { border-color: var(--accent); }
+.sub-row .hint { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.04em; line-height: 1.5; }
+.ferr { font-family: var(--mono); font-size: 10px; color: var(--danger); letter-spacing: 0.04em; }
+.sub-grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+.sub-grid-3 { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 14px; }
+
+/* Autocomplete — matches design's .auto pattern */
+.auto { position: relative; }
+.auto-wrap {
+  background: var(--bg-3); border: 1px solid var(--line); border-radius: 6px;
+  transition: border-color .15s;
+}
+.auto-wrap.open, .auto-wrap:focus-within { border-color: var(--accent); }
+.auto-wrap input {
+  background: transparent; border: 0; padding: 11px 14px; width: 100%;
+  color: var(--fg); font-size: 14px; outline: none; font-family: var(--sans);
+}
+.auto-results {
+  border-top: 1px solid var(--line); max-height: 200px; overflow: auto;
+}
+.auto-row {
+  display: grid; grid-template-columns: 28px 1fr auto; gap: 10px; align-items: center;
+  padding: 8px 14px; cursor: pointer; border-bottom: 1px solid var(--line);
+  transition: background .1s;
+}
+.auto-row:last-child { border-bottom: 0; }
+.auto-row:hover, .auto-row.sel { background: color-mix(in oklab, var(--accent) 10%, transparent); }
+.auto-row .ic {
+  width: 28px; height: 28px; border-radius: 4px;
+  background-image: repeating-linear-gradient(45deg, #1a1628 0 6px, #241e36 6px 7px);
+  border: 1px solid var(--line-2);
+}
+.a-name { font-size: 13px; line-height: 1.2; }
+.a-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px; }
+.a-pick { font-family: var(--mono); font-size: 10px; color: var(--accent); }
+.auto-row.create { color: var(--accent); background: color-mix(in oklab, var(--accent) 6%, var(--bg-3)); }
+.auto-row.create .ic {
+  background: transparent; border-style: dashed; display: grid; place-items: center; color: var(--accent);
+}
+.auto-row.create .a-name { color: var(--accent); font-weight: 500; }
+.auto-selected {
+  display: inline-flex; align-items: center; gap: 8px; padding: 8px 12px;
+  background: color-mix(in oklab, var(--accent) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+  border-radius: 6px; font-size: 13px; width: 100%;
+}
+.auto-selected .x {
+  color: var(--fg-3); cursor: pointer; padding: 0 2px; background: none; border: none;
+  font-size: 16px; line-height: 1; margin-left: auto; transition: color .15s;
+}
+.auto-selected .x:hover { color: var(--fg); }
+
+/* Sidebar */
+.sub-side { display: flex; flex-direction: column; gap: 18px; position: sticky; top: 80px; align-self: start; }
+.sub-panel { border: 1px solid var(--line); border-radius: 8px; background: var(--bg-2); overflow: hidden; }
+.sub-panel-head {
+  padding: 12px 14px; border-bottom: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-3);
+}
+.sub-panel-body { padding: 14px; }
+.sub-timeline { display: flex; flex-direction: column; }
+.sub-tl-step { display: grid; grid-template-columns: 22px 1fr; gap: 12px; position: relative; padding: 12px 0; }
+.sub-tl-step:not(:last-child)::after {
+  content: ""; position: absolute; left: 10px; top: 32px; bottom: -4px;
+  width: 1px; background: var(--line-2);
+}
+.sub-tl-dot {
+  width: 22px; height: 22px; border-radius: 50%; border: 1px solid var(--line-2);
+  background: var(--bg-3); display: grid; place-items: center;
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3); font-weight: 600;
+}
+.sub-tl-step.now .sub-tl-dot { background: var(--accent); border-color: var(--accent); color: var(--accent-ink); }
+.sub-tl-text { padding-top: 1px; }
+.sub-tl-title { font-size: 13px; font-weight: 600; line-height: 1.3; }
+.sub-tl-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px; line-height: 1.5; }
+.sub-tips { font-size: 13px; color: var(--fg-2); line-height: 1.6; }
+.sub-tips ul { margin: 0; padding-left: 18px; }
+.sub-tips li { margin-bottom: 8px; }
+.sub-tips li:last-child { margin-bottom: 0; }
+.sub-tips strong { color: var(--fg); font-weight: 600; }
+
+@media (max-width: 900px) {
+  .sub-page-grid { grid-template-columns: 1fr; }
+  .sub-side { display: none; }
+  .sub-tabs { grid-template-columns: 1fr; }
+  .sub-head h1 { font-size: 28px; }
+  .sub-grid-2, .sub-grid-3 { grid-template-columns: 1fr; }
+  .sub-type-grid { grid-template-columns: 1fr; }
+}
 
 /* ── Detail page ──────────────────────────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Submit page split into three tabs: **Opening / Ending / OST**, **Anime**, **Singer**
- Opening tab uses search-as-you-type autocomplete pickers for anime and singer (backed by new proxy routes `/api/anime/search` and `/api/singers/search`)
- Anime tab collects full metadata required by the backend: romaji/english/native titles, year, format picker, episodes, studio, reference URL, notes
- Singer tab collects: name, native name, type picker, active since, bio, reference URL, notes
- All forms submit via JSON `fetch` and show inline field validation errors from the backend
- New `Autocomplete` component: debounced 250ms search, dropdown with sublabel, chip display on selection with clear button
- New API proxy routes: `/api/anime`, `/api/singers`, `/api/anime/search`, `/api/singers/search`
- `/api/openings` updated to send `anime_id`/`singer_id` directly — no more inline entity creation
- `lib/types.ts` updated with `AnimeFormat`, `SingerType`, `AnimeAutocompleteItem`, `SingerAutocompleteItem`; `Anime`/`Singer` interfaces now include new backend fields

## Test plan
- [ ] Visit `/submit` — three tabs visible, Opening tab active
- [ ] Click Anime tab, fill in title_romaji + reference_url + year + format → Submit → success message
- [ ] Click Singer tab, fill in name + type + reference_url → Submit → success message
- [ ] After approving anime/singer via mod queue, go to Opening tab — type in anime picker and see results
- [ ] Select anime and singer, fill in title + YouTube URL → Submit → redirects to catalog
- [ ] Submit with missing anime/singer selection → inline error shown, no network request

🤖 Generated with [Claude Code](https://claude.com/claude-code)