### PR TITLE
feat: three-tab submit page, autocomplete pickers, topbar Submit button

### DIFF
--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -343,15 +343,15 @@ function AnimePane() {
 
           <div className="sub-section"><span className="sub-step">01</span> Titles</div>
           <div className="sub-row">
-            <label>Romaji title <span className="req">*</span></label>
-            <input type="text" value={f.title_romaji} onChange={set("title_romaji")} placeholder="Shingeki no Kyojin" />
-            <span className="hint">The latin-script transliteration. Used as the canonical key.</span>
-            {fieldErrors.title_romaji && <span className="ferr">{fieldErrors.title_romaji}</span>}
+            <label>English title <span className="req">*</span></label>
+            <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />
+            {fieldErrors.title_english && <span className="ferr">{fieldErrors.title_english}</span>}
           </div>
           <div className="sub-grid-2">
             <div className="sub-row">
-              <label>English title <span className="opt">(optional)</span></label>
-              <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />
+              <label>Romaji title <span className="opt">(optional)</span></label>
+              <input type="text" value={f.title_romaji} onChange={set("title_romaji")} placeholder="Shingeki no Kyojin" />
+              <span className="hint">Latin-script transliteration, if different from English.</span>
             </div>
             <div className="sub-row">
               <label>Native (日本語) <span className="opt">(optional)</span></label>


### PR DESCRIPTION
## Summary
- **Submit page rebuilt** to match design spec: full-width layout, large card-style tab choosers (Opening · Anime · Singer) with icons and accent left-border, numbered step sections, form card with header/body/footer
- **Opening tab** — OP/ED/OST type picker with colored tags and radio dots; search-as-you-type autocomplete for anime and singer with keyboard nav, cover thumbnail placeholder, and "Add new…" row that switches tabs
- **Anime tab** — English title required (primary), romaji optional; year, format, episodes, studio, reference URL, notes
- **Singer tab** — name, native name, type select, active since, bio, reference URL, notes
- **Sidebar** — sticky "What happens next" numbered timeline + contextual tips per tab
- **Topbar** — `+ Submit` primary button shown next to profile avatar when logged in
- **SubmitCard** — renamed CTA from "Submit an opening" to "Submit"
- **New API routes** — `/api/anime`, `/api/singers`, `/api/anime/search`, `/api/singers/search`
- **`/api/openings`** — updated to send `anime_id`/`singer_id` directly, returns JSON instead of redirect
- **`lib/types.ts`** — added `AnimeFormat`, `SingerType`, `AnimeAutocompleteItem`, `SingerAutocompleteItem`; updated `Anime`/`Singer` with new fields

## Test plan
- [ ] Log in → topbar shows `+ Submit` button next to avatar
- [ ] Visit `/submit` — three tab cards visible, Opening active
- [ ] Anime tab: fill English title + year + format + reference URL → submit → success message
- [ ] Anime tab: leave English title empty → inline field error shown
- [ ] Singer tab: fill name + type + reference URL → submit → success message
- [ ] After mod approval, Opening tab: type in anime picker → results appear
- [ ] Select anime + singer, fill title + YouTube URL → submit → redirects to catalogue
- [ ] Submit opening without selecting anime → inline error, no network request
- [ ] "Add new anime…" in dropdown → switches to Anime tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)