### PR TITLE
feat: anime detail page, opening→anime links, S3 cover upload

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -155,6 +155,8 @@ export interface AnimeOpening {
   id: string;
   title: string;
   youtube_url: string;
+  kind: TrackKind;
+  sequence_number: number | null;
   avg_rating: number;
   rating_count: number;
   approved_at: string | null;
@@ -174,6 +176,14 @@ export interface SingerOpening {
 export interface AnimeDetail {
   id: string;
   name: string;
+  title_romaji: string;
+  title_english: string | null;
+  title_native: string | null;
+  year: number;
+  format: AnimeFormat;
+  episodes: number | null;
+  studio: string | null;
+  reference_url: string;
   cover_image_url: string | null;
   openings: AnimeOpening[];
 }

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -1,0 +1,247 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import { getAnime } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import type { AnimeDetail, AnimeOpening, TrackKind, User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+  anime: AnimeDetail;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  const id = ctx.params?.id as string;
+
+  try {
+    const anime = await getAnime(id, session.cookie);
+    return { props: { user: session.user, modQueueCount: session.modQueueCount, anime } };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const FORMAT_LABEL: Record<string, string> = {
+  tv: "TV series",
+  film: "Film",
+  ova_ona: "OVA / ONA",
+  special: "Special",
+};
+
+function kindLabel(op: AnimeOpening): string {
+  const tag = op.kind === "opening" ? "OP" : op.kind === "ending" ? "ED" : "OST";
+  return op.sequence_number != null ? `${tag} ${op.sequence_number}` : tag;
+}
+
+function kindClass(kind: TrackKind): string {
+  if (kind === "opening") return "op";
+  if (kind === "ending") return "ed";
+  return "ost";
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+type FilterTab = "all" | TrackKind;
+
+export default function AnimePage({ user, modQueueCount, anime }: Props) {
+  const [filter, setFilter] = useState<FilterTab>("all");
+  const [sort, setSort] = useState<"sequence" | "top" | "newest">("sequence");
+
+  const ops    = anime.openings.filter((o) => o.kind === "opening");
+  const eds    = anime.openings.filter((o) => o.kind === "ending");
+  const osts   = anime.openings.filter((o) => o.kind === "ost");
+  const avgScore = anime.openings.length > 0
+    ? (anime.openings.reduce((s, o) => s + o.avg_rating, 0) / anime.openings.length).toFixed(1)
+    : "—";
+
+  const visible = anime.openings.filter(
+    (o) => filter === "all" || o.kind === filter,
+  ).slice().sort((a, b) => {
+    if (sort === "top") return b.avg_rating - a.avg_rating;
+    if (sort === "newest") return (b.approved_at ?? "").localeCompare(a.approved_at ?? "");
+    // sequence: OPs first, then EDs, then OSTs, then by sequence_number
+    const kindOrder = { opening: 0, ending: 1, ost: 2 };
+    const ko = kindOrder[a.kind] - kindOrder[b.kind];
+    if (ko !== 0) return ko;
+    return (a.sequence_number ?? 99) - (b.sequence_number ?? 99);
+  });
+
+  const displayName = anime.title_english ?? anime.title_romaji ?? anime.name;
+  const nativeTitle = anime.title_native;
+  const romajiTitle = anime.title_romaji !== displayName ? anime.title_romaji : null;
+
+  const leadParts: string[] = [];
+  if (anime.year) leadParts.push(String(anime.year));
+  if (anime.format) leadParts.push(FORMAT_LABEL[anime.format] ?? anime.format);
+  if (anime.episodes) leadParts.push(`${anime.episodes} episodes`);
+  if (anime.studio) leadParts.push(anime.studio);
+
+  const TABS: { key: FilterTab; label: string; count: number }[] = [
+    { key: "all",     label: "All",      count: anime.openings.length },
+    { key: "opening", label: "Openings", count: ops.length },
+    { key: "ending",  label: "Endings",  count: eds.length },
+    { key: "ost",     label: "OSTs",     count: osts.length },
+  ];
+
+  const SORT_OPTIONS: { key: typeof sort; label: string }[] = [
+    { key: "sequence", label: "Sequence" },
+    { key: "top",      label: "Top rated" },
+    { key: "newest",   label: "Newest" },
+  ];
+
+  const filterLabel: Record<FilterTab, string> = {
+    all: "entries", opening: "openings", ending: "endings", ost: "OSTs",
+  };
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`${displayName} · Opening Wiki`}
+      description={`All openings, endings, and OSTs from ${displayName}`}
+    >
+      <div className="wrap">
+        {/* Breadcrumb */}
+        <div className="crumb">
+          <Link href="/" className="crumb-link">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="12" height="12">
+              <path d="M19 12H5"/><path d="m12 19-7-7 7-7"/>
+            </svg>
+            All anime
+          </Link>
+        </div>
+
+        {/* Hero */}
+        <section className="anime-hero">
+          <div className="anime-cover">
+            {anime.cover_image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={anime.cover_image_url} alt={displayName} />
+            ) : (
+              <div className="anime-cover-ph">
+                <strong>cover art</strong>
+                2:3 poster
+              </div>
+            )}
+          </div>
+          <div className="anime-hero-meta">
+            <div className="anime-eyebrow">Anime</div>
+            <h1 className="anime-title">{displayName}</h1>
+            {nativeTitle && <div className="anime-native">{nativeTitle}</div>}
+            {romajiTitle && <div className="anime-romaji">{romajiTitle}</div>}
+            {leadParts.length > 0 && (
+              <div className="anime-lead">
+                {leadParts.map((p, i) => (
+                  <span key={i}>
+                    {i > 0 && <span className="anime-sep"> · </span>}
+                    {p}
+                  </span>
+                ))}
+              </div>
+            )}
+            <div className="anime-stats">
+              <div className="anime-stat"><span className="ast-lbl">Openings</span><span className="ast-val">{ops.length}</span></div>
+              <div className="anime-stat"><span className="ast-lbl">Endings</span><span className="ast-val">{eds.length}</span></div>
+              <div className="anime-stat"><span className="ast-lbl">OSTs</span><span className="ast-val">{osts.length}</span></div>
+              <div className="anime-stat"><span className="ast-lbl">Avg score</span><span className="ast-val">{avgScore}{anime.openings.length > 0 && <em>/10</em>}</span></div>
+            </div>
+            <div className="anime-actions">
+              <Link href={`/submit?tab=opening&anime_id=${anime.id}`} className="btn primary">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M12 5v14"/><path d="M5 12h14"/>
+                </svg>
+                Submit an opening
+              </Link>
+              {anime.reference_url && anime.reference_url !== "about:blank" && (
+                <a href={anime.reference_url} target="_blank" rel="noopener noreferrer" className="btn">
+                  ↗ Reference
+                </a>
+              )}
+            </div>
+          </div>
+        </section>
+
+        {/* Type tabs */}
+        <div className="type-tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              className={`type-tab${filter === tab.key ? " on" : ""}`}
+              onClick={() => setFilter(tab.key)}
+            >
+              <span className="tt-label">
+                {tab.label} <span className="tt-count">{tab.count}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Sort bar */}
+        <div className="sort-bar">
+          <span>
+            <span className="sort-count">{visible.length}</span>{" "}
+            <span>{filterLabel[filter]}</span>
+          </span>
+          <span style={{ flex: 1 }} />
+          <span className="sort-label">Sort</span>
+          {SORT_OPTIONS.map((o) => (
+            <button
+              key={o.key}
+              className={`sort-btn${sort === o.key ? " on" : ""}`}
+              onClick={() => setSort(o.key)}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+
+        {/* Grid */}
+        {visible.length === 0 ? (
+          <div className="empty-state">No entries yet.</div>
+        ) : (
+          <div className="cat">
+            {visible.map((op, i) => (
+              <article key={op.id} className="op-card">
+                <Link href={`/openings/${op.id}`} className={`op-thumb p-${(i % 6) + 1}`}>
+                  <span className={`op-seq ${kindClass(op.kind)}`}>{kindLabel(op)}</span>
+                  <span className="op-play">
+                    <div>
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M8 5v14l11-7z"/>
+                      </svg>
+                    </div>
+                  </span>
+                </Link>
+                <div className="op-info">
+                  <div className="op-main">
+                    <h3 className="op-title">
+                      <Link href={`/openings/${op.id}`}>{op.title}</Link>
+                    </h3>
+                    <div className="op-meta">
+                      <Link href={`/singers/${op.singer.id}`} className="op-meta-link">{op.singer.name}</Link>
+                    </div>
+                  </div>
+                  {op.rating_count > 0 && (
+                    <div className="op-score">
+                      <div className="n">{op.avg_rating.toFixed(1)}<em>/10</em></div>
+                      <div className="ct">{op.rating_count}</div>
+                    </div>
+                  )}
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/pages/api/uploads/cover.ts
+++ b/pages/api/uploads/cover.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+  const b = req.body ?? {};
+  const upstream = await fetch(backendUrl("/uploads/cover"), {
+    method: "POST",
+    headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      filename: b.filename ?? "",
+      content_type: b.content_type ?? "",
+      entity_type: b.entity_type ?? "",
+    }),
+  });
+
+  copyBackendCookies(res, upstream);
+
+  if (!upstream.ok) {
+    const payload = await upstream.json().catch(() => ({}));
+    return res.status(upstream.status).json({ error: payload?.error?.message ?? "Upload init failed" });
+  }
+
+  const payload = await upstream.json();
+  return res.status(200).json(payload.data);
+}

--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -251,9 +251,9 @@ export default function OpeningDetail({
               <div style={{ minWidth: 0, flex: 1 }}>
                 <h1 className="detail-title">{op.title}</h1>
                 <div className="detail-sub">
-                  <span className="detail-link">{op.anime.name}</span>
+                  <Link href={`/anime/${op.anime.id}`} className="detail-link">{op.anime.name}</Link>
                   <span className="detail-sep"> · </span>
-                  <span className="detail-link">{op.singer.name}</span>
+                  <Link href={`/singers/${op.singer.id}`} className="detail-link">{op.singer.name}</Link>
                 </div>
               </div>
               {/* Rating popup is anchored here — its trigger lives where the

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -1,6 +1,6 @@
 import type { GetServerSideProps } from "next";
 import Link from "next/link";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import Layout from "@/components/Layout";
 import Autocomplete, { type AutocompleteItem } from "@/components/Autocomplete";
@@ -48,6 +48,113 @@ async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
     label: s.name,
     sublabel: (s.type ?? "").replace(/_/g, " "),
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Cover upload
+// ---------------------------------------------------------------------------
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+interface CoverUploadProps {
+  entityType: "anime" | "singer";
+  aspect?: "poster" | "square"; // poster = 2:3, square = 1:1
+  onUploaded: (objectKey: string, previewUrl: string) => void;
+}
+
+function CoverUpload({ entityType, aspect = "poster", onUploaded }: CoverUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadErr, setUploadErr] = useState<string | null>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setUploadErr("JPEG, PNG, or WebP only");
+      return;
+    }
+    setUploading(true);
+    setUploadErr(null);
+    const localUrl = URL.createObjectURL(file);
+    setPreview(localUrl);
+    try {
+      // 1. Get presigned URL
+      const initRes = await fetch("/api/uploads/cover", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ filename: file.name, content_type: file.type, entity_type: entityType }),
+      });
+      if (!initRes.ok) throw new Error("Failed to get upload URL");
+      const { object_key, upload_url, headers: extraHeaders } = await initRes.json();
+
+      // 2. PUT directly to S3
+      const putRes = await fetch(upload_url, {
+        method: "PUT",
+        headers: { "Content-Type": file.type, ...extraHeaders },
+        body: file,
+      });
+      if (!putRes.ok) throw new Error(`S3 upload failed (${putRes.status})`);
+
+      onUploaded(object_key, localUrl);
+    } catch (err) {
+      setUploadErr(err instanceof Error ? err.message : "Upload failed");
+      setPreview(null);
+      URL.revokeObjectURL(localUrl);
+    } finally {
+      setUploading(false);
+    }
+  }, [entityType, onUploaded]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  return (
+    <div className={`cover-upload ${aspect}`}>
+      <div
+        className={`cover-zone${preview ? " has-preview" : ""}`}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === "Enter" && inputRef.current?.click()}
+      >
+        {preview ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={preview} alt="Cover preview" className="cover-preview-img" />
+        ) : (
+          <div className="cover-ph">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
+              <path d="m21 15-5-5L5 21"/>
+            </svg>
+            <span>{uploading ? "Uploading…" : "Click or drop image"}</span>
+            <span className="cover-ph-sub">JPEG · PNG · WebP</span>
+          </div>
+        )}
+      </div>
+      {!preview && (
+        <button type="button" className="btn sm" onClick={() => inputRef.current?.click()} disabled={uploading}>
+          {uploading ? "Uploading…" : "Choose file"}
+        </button>
+      )}
+      {preview && (
+        <button type="button" className="btn sm ghost" onClick={() => { setPreview(null); onUploaded("", ""); }}>
+          Remove
+        </button>
+      )}
+      {uploadErr && <span className="ferr">{uploadErr}</span>}
+      <input ref={inputRef} type="file" accept="image/jpeg,image/png,image/webp" style={{ display: "none" }} onChange={handleChange} />
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -291,6 +398,7 @@ function AnimePane() {
   const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
     setF((prev) => ({ ...prev, [k]: e.target.value }));
 
+  const [coverKey, setCoverKey] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -305,7 +413,7 @@ function AnimePane() {
     const res = await fetch("/api/anime", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...f, year: Number(f.year) || 0, episodes: f.episodes ? Number(f.episodes) : undefined }),
+      body: JSON.stringify({ ...f, year: Number(f.year) || 0, episodes: f.episodes ? Number(f.episodes) : undefined, cover_image_key: coverKey }),
     });
 
     setSubmitting(false);
@@ -341,7 +449,14 @@ function AnimePane() {
         </div>
         <div className="sub-form-body">
 
-          <div className="sub-section"><span className="sub-step">01</span> Titles</div>
+          <div className="sub-section"><span className="sub-step">01</span> Cover image <span className="opt">(optional)</span></div>
+          <CoverUpload
+            entityType="anime"
+            aspect="poster"
+            onUploaded={(key) => setCoverKey(key)}
+          />
+
+          <div className="sub-section"><span className="sub-step">02</span> Titles</div>
           <div className="sub-row">
             <label>English title <span className="req">*</span></label>
             <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />
@@ -359,7 +474,7 @@ function AnimePane() {
             </div>
           </div>
 
-          <div className="sub-section"><span className="sub-step">02</span> Production</div>
+          <div className="sub-section"><span className="sub-step">03</span> Production</div>
           <div className="sub-grid-3">
             <div className="sub-row">
               <label>Year <span className="req">*</span></label>
@@ -382,7 +497,7 @@ function AnimePane() {
             <input type="text" value={f.studio} onChange={set("studio")} placeholder="Wit Studio · MAPPA" />
           </div>
 
-          <div className="sub-section"><span className="sub-step">03</span> Verification</div>
+          <div className="sub-section"><span className="sub-step">04</span> Verification</div>
           <div className="sub-row">
             <label>Reference link <span className="req">*</span></label>
             <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="https://anilist.co/anime/… or MyAnimeList / official site" />
@@ -430,6 +545,7 @@ function SingerPane() {
   const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
     setF((prev) => ({ ...prev, [k]: e.target.value }));
 
+  const [coverKey, setCoverKey] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -444,7 +560,7 @@ function SingerPane() {
     const res = await fetch("/api/singers", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...f, active_since: f.active_since ? Number(f.active_since) : undefined }),
+      body: JSON.stringify({ ...f, active_since: f.active_since ? Number(f.active_since) : undefined, cover_image_key: coverKey }),
     });
 
     setSubmitting(false);
@@ -480,7 +596,14 @@ function SingerPane() {
         </div>
         <div className="sub-form-body">
 
-          <div className="sub-section"><span className="sub-step">01</span> Identity</div>
+          <div className="sub-section"><span className="sub-step">01</span> Photo <span className="opt">(optional)</span></div>
+          <CoverUpload
+            entityType="singer"
+            aspect="square"
+            onUploaded={(key) => setCoverKey(key)}
+          />
+
+          <div className="sub-section"><span className="sub-step">02</span> Identity</div>
           <div className="sub-row">
             <label>Name <span className="req">*</span></label>
             <input type="text" value={f.name} onChange={set("name")} placeholder="YOASOBI" />
@@ -492,7 +615,7 @@ function SingerPane() {
             <input type="text" value={f.name_native} onChange={set("name_native")} placeholder="ヨアソビ" />
           </div>
 
-          <div className="sub-section"><span className="sub-step">02</span> About</div>
+          <div className="sub-section"><span className="sub-step">03</span> About</div>
           <div className="sub-grid-2">
             <div className="sub-row">
               <label>Type <span className="req">*</span></label>
@@ -511,7 +634,7 @@ function SingerPane() {
             <textarea value={f.bio} onChange={set("bio")} rows={3} placeholder="One or two sentences. Genres, notable works, anything that helps recognize them." />
           </div>
 
-          <div className="sub-section"><span className="sub-step">03</span> Verification</div>
+          <div className="sub-section"><span className="sub-step">04</span> Verification</div>
           <div className="sub-row">
             <label>Reference link <span className="req">*</span></label>
             <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="Official site, Spotify, Wikipedia…" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2006,3 +2006,124 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
     grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
+
+/* ── Anime detail page ────────────────────────────────────────────────────── */
+.crumb {
+  padding: 28px 0 14px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-3);
+}
+.crumb-link {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--fg-3); transition: color .15s;
+}
+.crumb-link:hover { color: var(--fg); }
+
+.anime-hero {
+  display: grid; grid-template-columns: 220px 1fr; gap: 36px;
+  padding: 8px 0 36px; border-bottom: 1px solid var(--line);
+}
+.anime-cover {
+  aspect-ratio: 2/3; border-radius: 8px; border: 1px solid var(--line-2);
+  background: var(--bg-2);
+  background-image: repeating-linear-gradient(135deg, #1a1628 0 14px, #221c33 14px 15px);
+  overflow: hidden; display: grid; place-items: center;
+}
+.anime-cover img { width: 100%; height: 100%; object-fit: cover; border-radius: 7px; }
+.anime-cover-ph {
+  color: var(--fg-3); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; text-align: center; padding: 0 14px;
+}
+.anime-cover-ph strong { display: block; color: var(--fg-2); font-weight: 600; margin-bottom: 4px; font-size: 11px; }
+.anime-hero-meta { padding-top: 6px; }
+.anime-eyebrow {
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--accent); margin-bottom: 12px;
+}
+.anime-title {
+  margin: 0 0 4px; font-weight: 800; font-size: 56px;
+  line-height: 0.98; letter-spacing: -0.04em;
+}
+.anime-native { font-size: 18px; color: var(--fg-3); letter-spacing: 0.04em; margin-bottom: 4px; }
+.anime-romaji { font-family: var(--mono); font-size: 13px; color: var(--fg-4); margin-bottom: 18px; }
+.anime-lead {
+  font-family: var(--mono); font-size: 12px; color: var(--fg-3);
+  letter-spacing: 0.04em; margin-bottom: 22px; display: flex; gap: 0; flex-wrap: wrap;
+}
+.anime-sep { color: var(--fg-4); margin: 0 8px; }
+.anime-stats {
+  display: grid; grid-template-columns: repeat(4, auto); gap: 24px; justify-content: start;
+  border-top: 1px solid var(--line); padding-top: 18px; margin-bottom: 24px;
+}
+.anime-stat { display: flex; flex-direction: column; gap: 4px; }
+.ast-lbl { font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3); }
+.ast-val { font-weight: 700; font-size: 22px; letter-spacing: -0.02em; line-height: 1; }
+.ast-val em { font-style: normal; font-family: var(--mono); font-weight: 400; font-size: 12px; color: var(--fg-3); }
+.anime-actions { display: flex; gap: 10px; }
+.anime-actions .btn svg { width: 12px; height: 12px; }
+
+/* Type tabs (shared by home + anime page) */
+.type-tabs {
+  display: flex; align-items: stretch;
+  border-bottom: 1px solid var(--line); margin: 36px 0 0; gap: 0;
+}
+.type-tab {
+  flex: 0 0 auto; padding: 14px 22px 14px 0; margin-right: 26px;
+  color: var(--fg-3); border-bottom: 2px solid transparent; margin-bottom: -1px;
+  cursor: pointer; transition: color .15s, border-color .15s; text-align: left;
+}
+.type-tab:hover { color: var(--fg-2); }
+.type-tab.on { color: var(--fg); border-bottom-color: var(--accent); }
+.tt-label { display: inline-flex; align-items: baseline; gap: 8px; font-weight: 600; font-size: 15px; letter-spacing: -0.01em; }
+.tt-count { font-family: var(--mono); font-size: 11px; color: var(--fg-4); letter-spacing: 0.04em; }
+.type-tab.on .tt-count { color: var(--accent); }
+
+/* Sort bar extras for anime page */
+.sort-count { color: var(--fg); }
+.sort-label { font-family: var(--mono); font-size: 12px; color: var(--fg-3); }
+
+/* OP/ED/OST sequence badge */
+.op-seq {
+  position: absolute; top: 10px; left: 10px;
+  font-family: var(--mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  background: rgba(12,10,20,.85); color: var(--fg);
+  padding: 4px 8px; border-radius: 3px; border: 1px solid var(--line-2);
+}
+.op-seq.op  { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 50%, transparent); }
+.op-seq.ed  { color: var(--ok);     border-color: color-mix(in oklab, var(--ok) 50%, transparent); }
+.op-seq.ost { color: var(--warn);   border-color: color-mix(in oklab, var(--warn) 50%, transparent); }
+
+/* op-meta link variant */
+.op-meta-link { color: var(--fg-2); transition: color .15s; }
+.op-meta-link:hover { color: var(--accent); }
+
+/* Empty state */
+.empty-state {
+  padding: 48px 0; text-align: center;
+  font-family: var(--mono); font-size: 13px; color: var(--fg-4);
+}
+
+/* ── Cover upload (submit page) ───────────────────────────────────────────── */
+.cover-upload { display: flex; flex-direction: column; gap: 10px; width: fit-content; margin-bottom: 4px; }
+.cover-upload.poster .cover-zone { width: 160px; aspect-ratio: 2/3; }
+.cover-upload.square .cover-zone { width: 120px; aspect-ratio: 1/1; border-radius: 50%; }
+.cover-zone {
+  border: 2px dashed var(--line-2); border-radius: 8px;
+  background: var(--bg-2); cursor: pointer;
+  display: grid; place-items: center; overflow: hidden;
+  transition: border-color .15s, background .15s;
+}
+.cover-zone:hover { border-color: var(--accent); background: color-mix(in oklab, var(--bg-2) 90%, var(--accent)); }
+.cover-zone.has-preview { border-style: solid; border-color: var(--line-2); }
+.cover-ph { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 16px; text-align: center; color: var(--fg-3); }
+.cover-ph svg { opacity: .5; }
+.cover-ph span { font-family: var(--mono); font-size: 11px; }
+.cover-ph-sub { font-size: 10px; color: var(--fg-4); }
+.cover-preview-img { width: 100%; height: 100%; object-fit: cover; }
+.cover-upload.square .cover-preview-img { border-radius: 50%; }
+
+@media (max-width: 900px) {
+  .anime-hero { grid-template-columns: 140px 1fr; gap: 20px; }
+  .anime-title { font-size: 36px; }
+  .anime-stats { grid-template-columns: repeat(2, auto); gap: 16px; }
+}


### PR DESCRIPTION
## Summary
- **Anime page** (`/anime/:id`) — matches `Anime.html` design: 2:3 cover image, title/native/romaji headline, year/format/episodes/studio lead, stats bar (OPs / EDs / OSTs / avg score), type-filter tabs, sortable opening grid with OP/ED/OST badges, each singer name links to their singer page
- **Opening page** — anime name and singer name are now clickable links (`/anime/:id` and `/singers/:id`)
- **Submit page** — S3 cover upload added as step 01 for both anime (2:3 poster dropzone) and singer (1:1 square dropzone); `CoverUpload` component handles presigned PUT via `/api/uploads/cover`; `cover_image_key` sent with form body
- **`/api/uploads/cover`** — new Next.js proxy that forwards presign requests to `POST /api/v1/uploads/cover`
- **Types** — `AnimeOpening` gains `kind` + `sequence_number`; `AnimeDetail` gains all new metadata fields

## Test plan
- [ ] Navigate to `/anime/:id` for a known anime — hero shows correct metadata, tabs filter correctly
- [ ] On opening page, click anime name → goes to anime page; click singer name → goes to singer page
- [ ] On submit → anime tab, attach an image → uploads to S3, preview appears, cover_image_key sent on submit
- [ ] On submit → singer tab, same upload flow works for 1:1 square

🤖 Generated with [Claude Code](https://claude.com/claude-code)