### PR TITLE
feat: opening edit page for admins

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -285,6 +285,24 @@ export function removeOpeningFromGroup(
 
 // Admin-only soft-delete of an opening. Backend expects an admin session
 // (PATCH check inside the handler) and returns 204 No Content.
+export interface AdminUpdateOpeningInput {
+  title: string;
+  youtube_url: string;
+  kind: TrackKind;
+  anime_id: string;
+  singer_id: string;
+  notes_for_moderator?: string | null;
+}
+
+export function adminUpdateOpening(openingId: string, input: AdminUpdateOpeningInput, cookie?: string): Promise<void> {
+  return apiFetchData<void>(`/admin/openings/${encodeURIComponent(openingId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cookie,
+  });
+}
+
 export function adminDeleteOpening(openingId: string, cookie?: string): Promise<void> {
   return apiFetchData<void>(`/admin/openings/${encodeURIComponent(openingId)}`, {
     method: "DELETE",

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -76,6 +76,8 @@ export interface Opening {
   pattern?: 1 | 2 | 3 | 4 | 5 | 6;
   // Optional duration shown over the thumbnail (e.g. "1:30").
   duration?: string;
+  // Admin-only, included when viewer is admin.
+  notes_for_moderator?: string | null;
 }
 
 export interface OpeningPage {

--- a/pages/api/admin/opening-update.ts
+++ b/pages/api/admin/opening-update.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { adminUpdateOpening, ApiError } from "@/lib/api";
+
+// PATCH /api/admin/opening-update  { id, title, youtube_url, kind, anime_id, singer_id, notes_for_moderator? }
+//   → PATCH /api/v1/admin/openings/{id}
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "PATCH");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  const { id, ...input } = req.body ?? {};
+  if (!id || typeof id !== "string") return res.status(400).json({ error: "id is required" });
+
+  try {
+    await adminUpdateOpening(id, input, req.headers.cookie);
+    return res.status(204).end();
+  } catch (err) {
+    if (err instanceof ApiError) {
+      let message = err.message;
+      try {
+        const parsed = JSON.parse(err.body) as { error?: { message?: string; fields?: Record<string, string> } };
+        if (parsed?.error?.message) message = parsed.error.message;
+      } catch {
+        if (err.body) message = err.body;
+      }
+      return res.status(err.status || 502).json({ error: message });
+    }
+    return res.status(502).json({ error: "Backend unreachable" });
+  }
+}

--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -4,7 +4,6 @@ import Layout from "@/components/Layout";
 import RatingPopup from "@/components/RatingPopup";
 import CommentsSection from "@/components/CommentsSection";
 import GroupAddMenu from "@/components/GroupAddMenu";
-import AdminDeleteOpening from "@/components/AdminDeleteOpening";
 import {
   getAdjacentOpenings,
   getMyGroup,
@@ -299,8 +298,16 @@ export default function OpeningDetail({
                 <span className="detail-attr-label">YouTube</span>
                 <span className="detail-attr-val">↗ Watch on YouTube</span>
               </a>
-              {/* Renders nothing for non-admins. */}
-              <AdminDeleteOpening user={user} openingId={op.id} openingTitle={op.title} />
+              {/* Admin-only edit link */}
+              {user?.role === "admin" && (
+                <Link
+                  href={`/openings/${op.id}/edit`}
+                  className="detail-attr detail-attr-link"
+                >
+                  <span className="detail-attr-label">Admin</span>
+                  <span className="detail-attr-val">✎ Edit opening</span>
+                </Link>
+              )}
             </div>
 
             <CommentsSection

--- a/pages/openings/[id]/edit.tsx
+++ b/pages/openings/[id]/edit.tsx
@@ -1,0 +1,568 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState, useCallback, useRef, useEffect } from "react";
+import Layout from "@/components/Layout";
+import { getOpening } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import { pushToast } from "@/lib/toast";
+import { youtubeEmbedURL } from "@/lib/youtube";
+import type { Opening, TrackKind, User } from "@/lib/types";
+
+interface Props {
+  user: User;
+  modQueueCount: number;
+  opening: Opening;
+  embedUrl: string | null;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user || session.user.role !== "admin") {
+    return { notFound: true };
+  }
+  const id = ctx.params?.id as string;
+  try {
+    const opening = await getOpening(id, session.cookie);
+    return {
+      props: {
+        user: session.user,
+        modQueueCount: session.modQueueCount,
+        opening,
+        embedUrl: youtubeEmbedURL(opening.youtube_url),
+      },
+    };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Entity picker (anime / singer search inline dropdown)
+// ---------------------------------------------------------------------------
+
+interface EntityItem { id: string; name: string; sublabel?: string }
+
+interface RelationPickerProps {
+  label: string;
+  kind: "anime" | "singer";
+  value: EntityItem;
+  onChange: (item: EntityItem) => void;
+}
+
+function RelationPicker({ label, kind, value, onChange }: RelationPickerProps) {
+  const [searching, setSearching] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<EntityItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const search = useCallback(async (q: string) => {
+    if (!q.trim()) { setResults([]); return; }
+    setLoading(true);
+    try {
+      const url = kind === "anime"
+        ? `/api/anime/search?q=${encodeURIComponent(q)}`
+        : `/api/singers/search?q=${encodeURIComponent(q)}`;
+      const res = await fetch(url);
+      if (!res.ok) return;
+      const payload = await res.json();
+      const items: any[] = Array.isArray(payload.data) ? payload.data : [];
+      setResults(
+        items.map((x) =>
+          kind === "anime"
+            ? { id: x.id, name: x.name, sublabel: x.year ? `${x.year} · ${(x.format ?? "").toUpperCase().replace("_", " ")}` : undefined }
+            : { id: x.id, name: x.name, sublabel: (x.type ?? "").replace(/_/g, " ") },
+        ),
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [kind]);
+
+  useEffect(() => {
+    const t = setTimeout(() => { if (searching) search(query); }, 250);
+    return () => clearTimeout(t);
+  }, [query, searching, search]);
+
+  // close on outside click
+  useEffect(() => {
+    if (!searching) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setSearching(false);
+        setQuery("");
+        setResults([]);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [searching]);
+
+  const pick = (item: EntityItem) => {
+    onChange(item);
+    setSearching(false);
+    setQuery("");
+    setResults([]);
+  };
+
+  const startSearch = () => {
+    setSearching(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  };
+
+  return (
+    <div className="edit-row">
+      <label className="edit-label">{label} <span className="edit-req">*</span></label>
+      <div ref={containerRef} style={{ position: "relative" }}>
+        {searching ? (
+          <div className="edit-search-wrap">
+            <input
+              ref={inputRef}
+              className="edit-input"
+              placeholder={`Search ${kind === "anime" ? "anime" : "singers"}…`}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => e.key === "Escape" && setSearching(false)}
+            />
+            {(results.length > 0 || loading) && (
+              <div className="edit-dropdown">
+                {loading && <div className="edit-dropdown-hint">Searching…</div>}
+                {results.map((r) => (
+                  <button key={r.id} className="edit-dropdown-item" onClick={() => pick(r)}>
+                    <span className="edit-dropdown-name">{r.name}</span>
+                    {r.sublabel && <span className="edit-dropdown-sub">{r.sublabel}</span>}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className={`edit-relation${kind === "singer" ? " singer" : ""}`}>
+            <div className="edit-relation-ic" />
+            <div>
+              <div className="edit-relation-name">{value.name}</div>
+              {value.sublabel && <div className="edit-relation-sub">{value.sublabel}</div>}
+            </div>
+            <button type="button" className="edit-change-btn" onClick={startSearch}>Change…</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+const KIND_OPTIONS: { value: TrackKind; tag: string; label: string }[] = [
+  { value: "opening", tag: "OP", label: "Opening" },
+  { value: "ending",  tag: "ED", label: "Ending" },
+  { value: "ost",     tag: "OST", label: "OST / insert" },
+];
+
+export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl }: Props) {
+  const router = useRouter();
+
+  const [title, setTitle] = useState(opening.title);
+  const [youtubeUrl, setYoutubeUrl] = useState(opening.youtube_url);
+  const [kind, setKind] = useState<TrackKind>(opening.kind);
+  const [anime, setAnime] = useState<EntityItem>({ id: opening.anime.id, name: opening.anime.name });
+  const [singer, setSinger] = useState<EntityItem>({ id: opening.singer.id, name: opening.singer.name });
+  const [notes, setNotes] = useState(opening.notes_for_moderator ?? "");
+
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const isDirty =
+    title !== opening.title ||
+    youtubeUrl !== opening.youtube_url ||
+    kind !== opening.kind ||
+    anime.id !== opening.anime.id ||
+    singer.id !== opening.singer.id ||
+    notes !== (opening.notes_for_moderator ?? "");
+
+  // Esc closes delete confirm
+  useEffect(() => {
+    if (!confirmDelete) return;
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setConfirmDelete(false); };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [confirmDelete]);
+
+  const save = async () => {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/admin/opening-update", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: opening.id,
+          title: title.trim(),
+          youtube_url: youtubeUrl.trim(),
+          kind,
+          anime_id: anime.id,
+          singer_id: singer.id,
+          notes_for_moderator: notes || null,
+        }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Save failed (${res.status})`);
+      }
+      pushToast({ kind: "success", message: "Opening updated" });
+      router.push(`/openings/${opening.id}`);
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Save failed" });
+      setSaving(false);
+    }
+  };
+
+  const discard = () => {
+    router.push(`/openings/${opening.id}`);
+  };
+
+  const confirmAndDelete = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    try {
+      const res = await fetch("/api/admin/opening-delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: opening.id }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Delete failed (${res.status})`);
+      }
+      pushToast({ kind: "success", message: "Opening deleted" });
+      router.replace("/");
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Delete failed" });
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
+  };
+
+  const displayName = opening.title;
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`Edit · ${displayName} · Opening Wiki`}
+    >
+      <div className="wrap">
+
+        {/* Admin rolebar */}
+        <div className="edit-rolebar">
+          <span style={{ color: "var(--fg-2)" }}>Editing as admin</span>
+          <span style={{ color: "var(--fg-4)" }}>·</span>
+          <Link href="/mod">Moderation queue ({modQueueCount})</Link>
+          <span style={{ marginLeft: "auto" }}>
+            <Link href={`/openings/${opening.id}`}>← View public page</Link>
+          </span>
+        </div>
+
+        {/* Breadcrumb */}
+        <div className="edit-crumb">
+          <Link href="/">Home</Link>
+          <span className="edit-crumb-sep">/</span>
+          <Link href={`/openings/${opening.id}`}>{opening.title}</Link>
+          <span className="edit-crumb-sep">/</span>
+          <span className="edit-crumb-here">Edit</span>
+        </div>
+
+        {/* Heading */}
+        <div className="edit-head">
+          <div>
+            <h1 className="edit-h1">Editing <em>{displayName}</em></h1>
+            <div className="edit-sub">
+              <Link href={`/anime/${opening.anime.id}`}>{opening.anime.name}</Link>
+              {" · "}
+              <Link href={`/singers/${opening.singer.id}`}>{opening.singer.name}</Link>
+              <span style={{ color: "var(--fg-4)" }}> · id: {opening.id}</span>
+            </div>
+          </div>
+          <span style={{ flex: 1 }} />
+          <div className="edit-head-actions">
+            <Link href={`/openings/${opening.id}`} target="_blank" rel="noreferrer" className="btn">
+              ↗ View page
+            </Link>
+          </div>
+        </div>
+
+        <div className="edit-page-grid">
+          <main>
+
+            {/* Preview */}
+            <div className="edit-card">
+              <div className="edit-card-head">
+                <span className="edit-card-step">·</span> Preview
+                <span style={{ flex: 1 }} />
+                <span className="edit-card-meta">Live values</span>
+              </div>
+              <div className="edit-card-body">
+                <div className="edit-preview-strip">
+                  <div className="edit-preview-thumb">
+                    {embedUrl ? (
+                      <iframe
+                        src={embedUrl}
+                        title={opening.title}
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowFullScreen
+                        style={{ width: "100%", height: "100%", border: 0 }}
+                      />
+                    ) : (
+                      <span className="edit-preview-ph">[ youtube ]</span>
+                    )}
+                  </div>
+                  <div className="edit-preview-info">
+                    <div className="edit-pi-row">
+                      <div className="edit-pi-cell">
+                        <span className="edit-pi-lbl">Title</span>
+                        <span className="edit-pi-val">{title || opening.title}</span>
+                      </div>
+                      <div className="edit-pi-cell">
+                        <span className="edit-pi-lbl">Type</span>
+                        <span className="edit-pi-val" style={{ textTransform: "capitalize" }}>
+                          {kind === "ost" ? "OST" : kind}
+                        </span>
+                      </div>
+                    </div>
+                    <div className="edit-pi-row">
+                      <div className="edit-pi-cell">
+                        <span className="edit-pi-lbl">Anime</span>
+                        <span className="edit-pi-val">{anime.name}</span>
+                      </div>
+                      <div className="edit-pi-cell">
+                        <span className="edit-pi-lbl">Singer</span>
+                        <span className="edit-pi-val">{singer.name}</span>
+                      </div>
+                    </div>
+                    <div className="edit-pi-row">
+                      <div className="edit-pi-cell">
+                        <span className="edit-pi-lbl">Score</span>
+                        <span className="edit-pi-val">
+                          {opening.rating_count > 0
+                            ? `${opening.avg_rating.toFixed(1)}/10 · ${opening.rating_count} ratings`
+                            : "No ratings yet"}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 01 Type */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">01</span> Type</div>
+              <div className="edit-card-body">
+                <div className="edit-type-row">
+                  {KIND_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      className={`edit-type-pick${kind === opt.value ? " on" : ""}`}
+                      onClick={() => setKind(opt.value)}
+                    >
+                      <span className="edit-type-tag">{opt.tag}</span>
+                      <span className="edit-type-nm">{opt.label}</span>
+                      <span className="edit-type-radio" />
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </div>
+
+            {/* 02 Source */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">02</span> Source</div>
+              <div className="edit-card-body">
+                <div className={`edit-row${youtubeUrl !== opening.youtube_url ? " dirty" : ""}`}>
+                  <label className="edit-label">
+                    YouTube URL <span className="edit-req">*</span>
+                    {youtubeUrl !== opening.youtube_url && <span className="edit-changed">unsaved</span>}
+                  </label>
+                  <input
+                    type="url"
+                    className="edit-input"
+                    value={youtubeUrl}
+                    onChange={(e) => setYoutubeUrl(e.target.value)}
+                  />
+                  <span className="edit-hint">Official upload preferred.</span>
+                </div>
+                <div className={`edit-row${title !== opening.title ? " dirty" : ""}`}>
+                  <label className="edit-label">
+                    Title <span className="edit-req">*</span>
+                    {title !== opening.title && <span className="edit-changed">unsaved</span>}
+                  </label>
+                  <input
+                    type="text"
+                    className="edit-input"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* 03 Attribution */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">03</span> Attribution</div>
+              <div className="edit-card-body edit-attr-grid">
+                <RelationPicker
+                  label="Anime"
+                  kind="anime"
+                  value={anime}
+                  onChange={setAnime}
+                />
+                <RelationPicker
+                  label="Singer"
+                  kind="singer"
+                  value={singer}
+                  onChange={setSinger}
+                />
+              </div>
+            </div>
+
+            {/* 04 Notes */}
+            <div className="edit-card">
+              <div className="edit-card-head">
+                <span className="edit-card-step">04</span> Notes
+                <span className="edit-card-meta" style={{ marginLeft: 8 }}>internal · not shown publicly</span>
+              </div>
+              <div className="edit-card-body">
+                <textarea
+                  className="edit-textarea"
+                  placeholder="Mod notes about this entry…"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {/* Danger zone — delete only */}
+            <div className="edit-danger-zone">
+              <div className="edit-card-head" style={{ color: "var(--danger)" }}>⚠ Danger zone</div>
+              <div className="edit-dz-row">
+                <div>
+                  <div className="edit-dz-title">Delete opening</div>
+                  <div className="edit-dz-sub">
+                    Removes from all groups, ratings, and comments. Cannot be undone.
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  className="btn danger"
+                  onClick={() => setConfirmDelete(true)}
+                >
+                  Delete opening
+                </button>
+              </div>
+            </div>
+
+          </main>
+
+          {/* Sidebar — Activity only */}
+          <aside className="edit-side">
+            <div className="edit-panel">
+              <div className="edit-panel-head">Activity</div>
+              <div className="edit-panel-body">
+                <div className="edit-activity">
+                  {opening.reviewed_at && (
+                    <div className="edit-act edit">
+                      <div className="edit-act-dot" />
+                      <div>
+                        <div className="edit-act-text">Approved</div>
+                        <div className="edit-act-time">
+                          {new Date(opening.reviewed_at).toLocaleDateString("en-US", {
+                            year: "numeric", month: "short", day: "numeric",
+                          })}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                  <div className="edit-act create">
+                    <div className="edit-act-dot" />
+                    <div>
+                      <div className="edit-act-text">Submitted</div>
+                      <div className="edit-act-time">
+                        {new Date(opening.submitted_at).toLocaleDateString("en-US", {
+                          year: "numeric", month: "short", day: "numeric",
+                        })}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+
+        {/* Sticky save bar */}
+        {isDirty && (
+          <div className="edit-save-bar">
+            <span className="edit-sb-status">
+              <span className="edit-sb-dot" />
+              <span className="edit-sb-lbl">Unsaved changes</span>
+            </span>
+            <span style={{ flex: 1 }} />
+            <div className="edit-sb-actions">
+              <button type="button" className="btn" onClick={discard} disabled={saving}>
+                Discard
+              </button>
+              <button type="button" className="btn primary" onClick={save} disabled={saving}>
+                {saving ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </div>
+        )}
+
+      </div>
+
+      {/* Delete confirm modal */}
+      {confirmDelete && (
+        <div
+          className="admin-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => !deleting && setConfirmDelete(false)}
+        >
+          <div className="admin-modal" onClick={(e) => e.stopPropagation()}>
+            <h2 className="admin-modal-title">Delete this opening?</h2>
+            <p className="admin-modal-body">
+              You&apos;re about to permanently remove <strong>{opening.title}</strong>.
+              All ratings and comments tied to it will remain in the database, but the
+              opening disappears from the catalogue and all groups.
+            </p>
+            <p className="admin-modal-warning">This action cannot be undone.</p>
+            <div className="admin-modal-actions">
+              <button
+                type="button"
+                className="btn ghost sm"
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn admin-modal-confirm"
+                onClick={confirmAndDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting…" : "Yes, delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2127,3 +2127,205 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   .anime-title { font-size: 36px; }
   .anime-stats { grid-template-columns: repeat(2, auto); gap: 16px; }
 }
+
+/* ── Opening Edit page ────────────────────────────────────────────────────── */
+.edit-rolebar {
+  background: var(--bg-2); border-bottom: 1px solid var(--line);
+  margin: 0 calc(-1 * var(--pad)); padding: 0 var(--pad);
+  display: flex; gap: 14px; align-items: center; height: 34px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+}
+.edit-rolebar a { color: var(--fg-2); transition: color .15s; }
+.edit-rolebar a:hover { color: var(--fg); }
+
+.edit-crumb {
+  padding: 22px 0 14px; font-family: var(--mono); font-size: 12px;
+  color: var(--fg-3); display: flex; align-items: center; gap: 8px;
+}
+.edit-crumb a { color: var(--fg-3); transition: color .15s; }
+.edit-crumb a:hover { color: var(--fg); }
+.edit-crumb-sep { color: var(--fg-4); }
+.edit-crumb-here { color: var(--fg); }
+
+.edit-head { padding: 4px 0 24px; display: flex; align-items: flex-end; gap: 24px; }
+.edit-h1 { margin: 0 0 4px; font-weight: 800; font-size: 36px; line-height: 1; letter-spacing: -0.035em; }
+.edit-h1 em { font-style: normal; color: var(--accent); }
+.edit-sub { font-family: var(--mono); font-size: 12px; color: var(--fg-3); }
+.edit-sub a { color: var(--fg-2); border-bottom: 1px dashed var(--line-2); }
+.edit-sub a:hover { color: var(--accent); border-color: var(--accent); }
+.edit-head-actions { display: flex; gap: 8px; }
+
+.edit-page-grid { display: grid; grid-template-columns: 1fr 280px; gap: 36px; padding-bottom: 100px; }
+
+/* Cards */
+.edit-card {
+  border: 1px solid var(--line); border-radius: 10px;
+  background: var(--bg-2); overflow: hidden; margin-bottom: 18px;
+}
+.edit-card-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px; border-bottom: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3);
+}
+.edit-card-step { color: var(--accent); font-weight: 600; }
+.edit-card-meta { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.06em; text-transform: none; margin-left: auto; }
+.edit-card-body { padding: 18px; }
+
+/* Preview strip */
+.edit-preview-strip { display: grid; grid-template-columns: 220px 1fr; gap: 16px; align-items: stretch; }
+.edit-preview-thumb {
+  aspect-ratio: 16/9; border-radius: 6px;
+  border: 1px solid var(--line); overflow: hidden;
+  background: var(--bg-3); display: grid; place-items: center;
+}
+.edit-preview-ph { font-family: var(--mono); font-size: 9px; color: var(--fg-3); letter-spacing: 0.14em; text-transform: uppercase; }
+.edit-preview-info { display: flex; flex-direction: column; justify-content: space-between; gap: 10px; }
+.edit-pi-row { display: flex; gap: 14px; }
+.edit-pi-cell { flex: 1; min-width: 0; }
+.edit-pi-lbl { display: block; font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3); margin-bottom: 4px; }
+.edit-pi-val { font-size: 14px; font-weight: 600; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* Type picker */
+.edit-type-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.edit-type-pick {
+  border: 1px solid var(--line); border-radius: 6px;
+  padding: 10px 12px; background: var(--bg-3); cursor: pointer; text-align: left;
+  display: flex; align-items: center; gap: 10px; transition: border-color .15s;
+}
+.edit-type-pick:hover { border-color: var(--line-2); }
+.edit-type-pick.on { border-color: var(--accent); background: color-mix(in oklab, var(--accent) 10%, var(--bg-3)); }
+.edit-type-tag {
+  font-family: var(--mono); font-size: 10px; font-weight: 700;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 3px;
+  border: 1px solid var(--line-2); color: var(--fg-3);
+}
+.edit-type-pick.on .edit-type-tag { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 60%, transparent); }
+.edit-type-nm { font-size: 13px; font-weight: 500; }
+.edit-type-radio {
+  margin-left: auto; width: 14px; height: 14px; border-radius: 50%;
+  border: 1.5px solid var(--line-2); display: grid; place-items: center;
+}
+.edit-type-pick.on .edit-type-radio { border-color: var(--accent); }
+.edit-type-pick.on .edit-type-radio::after { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
+
+/* Form rows */
+.edit-row { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
+.edit-row:last-child { margin-bottom: 0; }
+.edit-row.dirty .edit-input { border-color: var(--warn); background: color-mix(in oklab, var(--warn) 6%, var(--bg-3)); }
+.edit-label {
+  display: flex; align-items: center; gap: 6px;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.1em; text-transform: uppercase; color: var(--fg-3);
+}
+.edit-req { color: var(--accent); }
+.edit-changed { margin-left: auto; font-family: var(--mono); font-size: 9px; color: var(--warn); letter-spacing: 0.1em; text-transform: uppercase; }
+.edit-hint { font-family: var(--mono); font-size: 10px; color: var(--fg-4); letter-spacing: 0.04em; }
+.edit-input {
+  background: var(--bg-3); border: 1px solid var(--line); border-radius: 6px;
+  padding: 11px 14px; color: var(--fg); font-family: var(--sans); font-size: 14px;
+  outline: none; transition: border-color .15s; width: 100%;
+}
+.edit-input:focus { border-color: var(--accent); }
+.edit-textarea {
+  background: var(--bg-3); border: 1px solid var(--line); border-radius: 6px;
+  padding: 11px 14px; color: var(--fg); font-family: var(--sans); font-size: 14px;
+  outline: none; transition: border-color .15s; width: 100%;
+  min-height: 80px; resize: vertical; line-height: 1.55;
+}
+.edit-textarea:focus { border-color: var(--accent); }
+
+/* Attribution 2-col grid */
+.edit-attr-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+
+/* Relation chip */
+.edit-relation {
+  display: grid; grid-template-columns: 32px 1fr auto; gap: 10px; align-items: center;
+  padding: 10px 14px; border: 1px solid var(--line); border-radius: 6px; background: var(--bg-3);
+}
+.edit-relation.singer .edit-relation-ic { border-radius: 50%; }
+.edit-relation-ic {
+  width: 32px; height: 32px; border-radius: 5px; border: 1px solid var(--line-2);
+  background-image: repeating-linear-gradient(135deg, #1a1628 0 8px, #221c33 8px 9px);
+}
+.edit-relation-name { font-size: 14px; font-weight: 600; }
+.edit-relation-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); margin-top: 2px; }
+.edit-change-btn {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2);
+  padding: 5px 10px; border: 1px solid var(--line-2); border-radius: 4px;
+  cursor: pointer; background: none; transition: color .15s, border-color .15s;
+}
+.edit-change-btn:hover { color: var(--accent); border-color: var(--accent); }
+
+/* Search dropdown */
+.edit-search-wrap { position: relative; }
+.edit-dropdown {
+  position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 20;
+  background: var(--bg-2); border: 1px solid var(--line-2); border-radius: 6px;
+  overflow: hidden; box-shadow: 0 8px 24px rgba(0,0,0,.4);
+  max-height: 260px; overflow-y: auto;
+}
+.edit-dropdown-item {
+  display: flex; flex-direction: column; gap: 2px;
+  padding: 10px 14px; text-align: left; width: 100%;
+  border-bottom: 1px solid var(--line); background: none; cursor: pointer;
+  transition: background .1s;
+}
+.edit-dropdown-item:last-child { border-bottom: 0; }
+.edit-dropdown-item:hover { background: var(--bg-3); }
+.edit-dropdown-name { font-size: 14px; font-weight: 500; color: var(--fg); }
+.edit-dropdown-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.edit-dropdown-hint { padding: 10px 14px; font-family: var(--mono); font-size: 11px; color: var(--fg-4); }
+
+/* Danger zone */
+.edit-danger-zone {
+  border: 1px solid color-mix(in oklab, var(--danger) 25%, var(--line));
+  background: color-mix(in oklab, var(--danger) 4%, var(--bg-2));
+  border-radius: 10px; overflow: hidden; margin-bottom: 18px;
+}
+.edit-danger-zone .edit-card-head { border-bottom: 1px solid color-mix(in oklab, var(--danger) 25%, var(--line)); }
+.edit-dz-row {
+  display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: center;
+  padding: 14px 18px;
+}
+.edit-dz-title { font-weight: 600; font-size: 14px; margin-bottom: 2px; }
+.edit-dz-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+
+/* Sidebar */
+.edit-side { position: sticky; top: 100px; align-self: start; }
+.edit-panel { border: 1px solid var(--line); border-radius: 8px; background: var(--bg-2); overflow: hidden; }
+.edit-panel-head {
+  padding: 12px 14px; border-bottom: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.12em;
+  text-transform: uppercase; color: var(--fg-3);
+}
+.edit-panel-body { padding: 14px; }
+
+/* Activity timeline */
+.edit-activity { display: flex; flex-direction: column; }
+.edit-act {
+  display: grid; grid-template-columns: 20px 1fr; gap: 10px;
+  padding: 10px 0; border-bottom: 1px solid var(--line);
+}
+.edit-act:last-child { border-bottom: 0; }
+.edit-act-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-4); margin: 5px 0 0 6px; }
+.edit-act.create .edit-act-dot { background: var(--ok); }
+.edit-act.edit .edit-act-dot { background: var(--accent); }
+.edit-act-text { font-size: 13px; color: var(--fg-2); }
+.edit-act-time { font-family: var(--mono); font-size: 10px; color: var(--fg-4); margin-top: 2px; }
+
+/* Sticky save bar */
+.edit-save-bar {
+  position: sticky; bottom: 0; z-index: 30;
+  margin: 0 calc(-1 * var(--pad));
+  padding: 14px var(--pad);
+  background: color-mix(in oklab, var(--bg-2) 96%, transparent);
+  backdrop-filter: blur(10px);
+  border-top: 1px solid var(--line-2);
+  display: flex; align-items: center; gap: 14px;
+}
+.edit-sb-status { display: flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 12px; }
+.edit-sb-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--warn); box-shadow: 0 0 0 4px color-mix(in oklab, var(--warn) 18%, transparent); }
+.edit-sb-lbl { color: var(--fg); font-weight: 500; }
+.edit-sb-actions { display: flex; gap: 8px; }


### PR DESCRIPTION
## Summary
- New page `/openings/[id]/edit` (admin-only, 404 for non-admins)
  - **01 Type** — OP/ED/OST picker
  - **02 Source** — YouTube URL + title with "unsaved" dirty indicator
  - **03 Attribution** — inline search dropdowns for anime and singer
  - **04 Notes** — internal moderator notes textarea
  - **Danger zone** — delete only (no reset ratings, no wipe comments per spec)
  - **Sidebar** — activity timeline only (no visibility, no reports panels)
  - **Sticky save bar** — appears when there are unsaved changes
- Opening detail page: admin delete button replaced with "✎ Edit opening" link
- `PATCH /api/admin/opening-update` proxy route
- `notes_for_moderator` added to `Opening` type (backend sends it for admins)

## Test plan
- [ ] Visit `/openings/{id}/edit` as admin → page loads with current values pre-filled
- [ ] Visit same URL as regular user → 404
- [ ] Change type → type picker updates
- [ ] Change anime/singer → search dropdown returns results, selecting updates chip
- [ ] Edit title/URL → "unsaved" badge + save bar appear
- [ ] Save → 204, redirects to opening page with success toast
- [ ] Delete → confirm modal → deletes and redirects home
- [ ] Opening detail page → admin sees "✎ Edit opening" link, non-admin doesn't

🤖 Generated with [Claude Code](https://claude.com/claude-code)