### PR TITLE
feat: singer page + sort dropdown on anime/singer pages

### DIFF
--- a/components/LocalSortDropdown.tsx
+++ b/components/LocalSortDropdown.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+
+export interface SortOption<K extends string = string> {
+  key: K;
+  label: string;
+  hint?: string;
+}
+
+interface Props<K extends string> {
+  options: SortOption<K>[];
+  value: K;
+  onChange: (key: K) => void;
+}
+
+const CHEVRON = (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+    <path d="M6 9l6 6 6-6" />
+  </svg>
+);
+
+export default function LocalSortDropdown<K extends string>({ options, value, onChange }: Props<K>) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const current = options.find((o) => o.key === value) ?? options[0];
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div className={`sort-menu${open ? " open" : ""}`} ref={wrapRef}>
+      <button
+        type="button"
+        className="sort-trigger"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="sort-trigger-l">Sort</span>
+        <span className="sort-trigger-v">{current.label}</span>
+        <span className={`sort-trigger-c${open ? " up" : ""}`}>{CHEVRON}</span>
+      </button>
+
+      {open && (
+        <ul className="sort-pop" role="listbox">
+          {options.map((o) => (
+            <li key={o.key}>
+              <button
+                type="button"
+                className={`sort-pop-item${value === o.key ? " on" : ""}`}
+                role="option"
+                aria-selected={value === o.key}
+                onClick={() => { onChange(o.key); setOpen(false); }}
+              >
+                <span className="sort-pop-l">{o.label}</span>
+                {o.hint && <span className="sort-pop-h">{o.hint}</span>}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -169,6 +169,8 @@ export interface SingerOpening {
   id: string;
   title: string;
   youtube_url: string;
+  kind: TrackKind;
+  sequence_number: number | null;
   avg_rating: number;
   rating_count: number;
   approved_at: string | null;
@@ -193,6 +195,8 @@ export interface AnimeDetail {
 export interface SingerDetail {
   id: string;
   name: string;
+  name_native: string | null;
+  type: SingerType;
   cover_image_url: string | null;
   openings: SingerOpening[];
 }

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -2,6 +2,7 @@ import type { GetServerSideProps } from "next";
 import Link from "next/link";
 import { useState } from "react";
 import Layout from "@/components/Layout";
+import LocalSortDropdown from "@/components/LocalSortDropdown";
 import { getAnime } from "@/lib/api";
 import { loadSession } from "@/lib/session";
 import type { AnimeDetail, AnimeOpening, TrackKind, User } from "@/lib/types";
@@ -92,10 +93,10 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
     { key: "ost",     label: "OSTs",     count: osts.length },
   ];
 
-  const SORT_OPTIONS: { key: typeof sort; label: string }[] = [
-    { key: "sequence", label: "Sequence" },
-    { key: "top",      label: "Top rated" },
-    { key: "newest",   label: "Newest" },
+  const SORT_OPTIONS: { key: typeof sort; label: string; hint: string }[] = [
+    { key: "sequence", label: "Sequence",  hint: "OPs → EDs → OSTs by number" },
+    { key: "top",      label: "Top rated", hint: "Highest average score" },
+    { key: "newest",   label: "Newest",    hint: "Recently approved first" },
   ];
 
   const filterLabel: Record<FilterTab, string> = {
@@ -191,17 +192,12 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
             <span className="sort-count">{visible.length}</span>{" "}
             <span>{filterLabel[filter]}</span>
           </span>
-          <span style={{ flex: 1 }} />
-          <span className="sort-label">Sort</span>
-          {SORT_OPTIONS.map((o) => (
-            <button
-              key={o.key}
-              className={`sort-btn${sort === o.key ? " on" : ""}`}
-              onClick={() => setSort(o.key)}
-            >
-              {o.label}
-            </button>
-          ))}
+          <span className="spacer" />
+          <LocalSortDropdown
+            options={SORT_OPTIONS}
+            value={sort}
+            onChange={setSort}
+          />
         </div>
 
         {/* Grid */}

--- a/pages/singers/[id].tsx
+++ b/pages/singers/[id].tsx
@@ -1,0 +1,244 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import LocalSortDropdown from "@/components/LocalSortDropdown";
+import { getSinger } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import type { SingerDetail, SingerOpening, TrackKind, User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+  singer: SingerDetail;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  const id = ctx.params?.id as string;
+  try {
+    const singer = await getSinger(id, session.cookie);
+    return { props: { user: session.user, modQueueCount: session.modQueueCount, singer } };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function kindLabel(op: SingerOpening): string {
+  const tag = op.kind === "opening" ? "OP" : op.kind === "ending" ? "ED" : "OST";
+  return op.sequence_number != null ? `${tag} ${op.sequence_number}` : tag;
+}
+
+function kindClass(kind: TrackKind): string {
+  if (kind === "opening") return "op";
+  if (kind === "ending") return "ed";
+  return "ost";
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  solo: "Solo artist",
+  band: "Band",
+  idol_group: "Idol group",
+  vocaloid_producer: "Vocaloid / Producer",
+  composer: "Composer",
+  other: "Artist",
+};
+
+type SortKey = "sequence" | "top" | "newest";
+type FilterTab = "all" | TrackKind;
+
+const SORT_OPTIONS: Array<{ key: SortKey; label: string; hint: string }> = [
+  { key: "sequence", label: "Sequence",   hint: "OPs → EDs → OSTs by number" },
+  { key: "top",      label: "Top rated",  hint: "Highest average score" },
+  { key: "newest",   label: "Newest",     hint: "Recently approved first" },
+];
+
+const KIND_ORDER: Record<TrackKind, number> = { opening: 0, ending: 1, ost: 2 };
+
+function sortOpenings(items: SingerOpening[], sort: SortKey): SingerOpening[] {
+  return items.slice().sort((a, b) => {
+    if (sort === "top") return b.avg_rating - a.avg_rating;
+    if (sort === "newest") return (b.approved_at ?? "").localeCompare(a.approved_at ?? "");
+    const ko = KIND_ORDER[a.kind] - KIND_ORDER[b.kind];
+    if (ko !== 0) return ko;
+    return (a.sequence_number ?? 99) - (b.sequence_number ?? 99);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export default function SingerPage({ user, modQueueCount, singer }: Props) {
+  const [filter, setFilter] = useState<FilterTab>("all");
+  const [sort, setSort] = useState<SortKey>("sequence");
+
+  const ops  = singer.openings.filter((o) => o.kind === "opening");
+  const eds  = singer.openings.filter((o) => o.kind === "ending");
+  const osts = singer.openings.filter((o) => o.kind === "ost");
+
+  const avgScore = singer.openings.length > 0
+    ? (singer.openings.reduce((s, o) => s + o.avg_rating, 0) / singer.openings.length).toFixed(1)
+    : null;
+
+  const filtered = singer.openings.filter((o) => filter === "all" || o.kind === filter);
+  const visible = sortOpenings(filtered, sort);
+
+  const TABS: { key: FilterTab; label: string; count: number }[] = [
+    { key: "all",     label: "All",      count: singer.openings.length },
+    { key: "opening", label: "Openings", count: ops.length },
+    { key: "ending",  label: "Endings",  count: eds.length },
+    { key: "ost",     label: "OSTs",     count: osts.length },
+  ];
+
+  const typeLabel = TYPE_LABEL[singer.type] ?? "Artist";
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`${singer.name} · Opening Wiki`}
+      description={`All openings, endings, and OSTs by ${singer.name}`}
+    >
+      <div className="wrap">
+
+        {/* Breadcrumb */}
+        <div className="crumb">
+          <Link href="/?kind=opening" className="crumb-link">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" width="12" height="12">
+              <path d="M19 12H5"/><path d="m12 19-7-7 7-7"/>
+            </svg>
+            All singers
+          </Link>
+        </div>
+
+        {/* Hero */}
+        <section className="singer-hero">
+          <div className="singer-portrait">
+            {singer.cover_image_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={singer.cover_image_url} alt={singer.name} />
+            ) : (
+              <div className="singer-portrait-ph">
+                <strong>portrait</strong>
+                1:1 photo
+              </div>
+            )}
+          </div>
+          <div className="singer-hero-meta">
+            <div className="singer-eyebrow">
+              Singer
+              <span className="singer-type-pill">{typeLabel}</span>
+            </div>
+            <h1 className="singer-title">{singer.name}</h1>
+            {singer.name_native && (
+              <div className="singer-native">{singer.name_native}</div>
+            )}
+            <div className="singer-stats">
+              <div className="singer-stat">
+                <span className="sst-lbl">Tracks</span>
+                <span className="sst-val">{singer.openings.length}</span>
+              </div>
+              <div className="singer-stat">
+                <span className="sst-lbl">Openings</span>
+                <span className="sst-val">{ops.length}</span>
+              </div>
+              <div className="singer-stat">
+                <span className="sst-lbl">Endings</span>
+                <span className="sst-val">{eds.length}</span>
+              </div>
+              {avgScore && (
+                <div className="singer-stat">
+                  <span className="sst-lbl">Avg score</span>
+                  <span className="sst-val">{avgScore}<em>/10</em></span>
+                </div>
+              )}
+            </div>
+            <div className="singer-actions">
+              <Link href={`/submit?tab=opening`} className="btn primary">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                  <path d="M12 5v14"/><path d="M5 12h14"/>
+                </svg>
+                Submit a track
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Type tabs */}
+        <div className="type-tabs">
+          {TABS.map((tab) => (
+            <button
+              key={tab.key}
+              className={`type-tab${filter === tab.key ? " on" : ""}`}
+              onClick={() => setFilter(tab.key)}
+            >
+              <span className="tt-label">
+                {tab.label} <span className="tt-count">{tab.count}</span>
+              </span>
+            </button>
+          ))}
+        </div>
+
+        {/* Sort bar */}
+        <div className="sort-bar">
+          <span>
+            <span className="sort-count">{visible.length}</span>{" "}
+            <span>tracks</span>
+          </span>
+          <span className="spacer" />
+          <LocalSortDropdown
+            options={SORT_OPTIONS}
+            value={sort}
+            onChange={setSort}
+          />
+        </div>
+
+        {/* Track list */}
+        {visible.length === 0 ? (
+          <div className="empty-state">No entries yet.</div>
+        ) : (
+          <div className="singer-entries">
+            {visible.map((op, i) => (
+              <Link key={op.id} href={`/openings/${op.id}`} className="singer-entry">
+                <div className={`singer-e-thumb p-${(i % 6) + 1}`}>
+                  <div className="singer-e-play">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M8 5v14l11-7z"/>
+                    </svg>
+                  </div>
+                </div>
+                <div className="singer-e-meta">
+                  <div className="singer-e-row">
+                    <span className={`e-tag ${kindClass(op.kind)}`}>{kindLabel(op)}</span>
+                    <span className="singer-e-title">{op.title}</span>
+                  </div>
+                  <div className="singer-e-sub">
+                    <Link
+                      href={`/anime/${op.anime.id}`}
+                      className="singer-e-anime"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {op.anime.name}
+                    </Link>
+                  </div>
+                </div>
+                {op.rating_count > 0 && (
+                  <div className="singer-e-score">
+                    <div className="n">{op.avg_rating.toFixed(1)}<em>/10</em></div>
+                    <div className="ct">{op.rating_count}</div>
+                  </div>
+                )}
+              </Link>
+            ))}
+          </div>
+        )}
+
+      </div>
+    </Layout>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2128,6 +2128,106 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   .anime-stats { grid-template-columns: repeat(2, auto); gap: 16px; }
 }
 
+/* ── Singer page ──────────────────────────────────────────────────────────── */
+.singer-hero {
+  display: grid; grid-template-columns: 180px 1fr; gap: 36px;
+  align-items: start; padding: 8px 0 36px;
+  border-bottom: 1px solid var(--line);
+}
+.singer-portrait {
+  width: 180px; height: 180px; border-radius: 50%;
+  border: 1px solid var(--line-2); background: var(--bg-2);
+  background-image: repeating-linear-gradient(60deg, #1a1628 0 12px, #2a2240 12px 13px);
+  overflow: hidden; display: grid; place-items: center;
+}
+.singer-portrait img { width: 100%; height: 100%; object-fit: cover; }
+.singer-portrait-ph {
+  color: var(--fg-3); font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; text-align: center; padding: 0 14px;
+}
+.singer-portrait-ph strong { display: block; color: var(--fg-2); font-weight: 600; margin-bottom: 4px; font-size: 11px; }
+.singer-hero-meta { padding-top: 6px; }
+.singer-eyebrow {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase;
+  color: var(--accent); margin-bottom: 12px;
+}
+.singer-type-pill {
+  color: var(--fg-3); border: 1px solid var(--line-2);
+  padding: 2px 8px; border-radius: 3px; letter-spacing: 0.1em;
+}
+.singer-title {
+  margin: 0 0 4px; font-weight: 800;
+  font-size: 52px; line-height: 0.98; letter-spacing: -0.04em;
+}
+.singer-native { font-size: 18px; color: var(--fg-3); letter-spacing: 0.04em; margin-bottom: 22px; }
+.singer-stats {
+  display: grid; grid-template-columns: repeat(4, auto); gap: 24px; justify-content: start;
+  border-top: 1px solid var(--line); padding-top: 18px; margin-bottom: 24px;
+}
+.singer-stat { display: flex; flex-direction: column; gap: 4px; }
+.sst-lbl { font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3); }
+.sst-val { font-weight: 700; font-size: 22px; letter-spacing: -0.02em; line-height: 1; }
+.sst-val em { font-style: normal; font-family: var(--mono); font-weight: 400; font-size: 12px; color: var(--fg-3); }
+.singer-actions { display: flex; gap: 10px; }
+
+/* Singer track list */
+.singer-entries {
+  display: flex; flex-direction: column;
+  border: 1px solid var(--line); border-radius: 10px;
+  background: var(--bg-2); overflow: hidden; margin-bottom: 60px;
+}
+.singer-entry {
+  display: grid; grid-template-columns: 72px 1fr auto; gap: 16px;
+  align-items: center; padding: 12px 18px;
+  border-bottom: 1px solid var(--line); transition: background .1s;
+}
+.singer-entry:last-child { border-bottom: 0; }
+.singer-entry:hover { background: var(--bg-3); }
+.singer-e-thumb {
+  width: 72px; aspect-ratio: 16/9; border-radius: 4px;
+  border: 1px solid var(--line-2); position: relative; overflow: hidden;
+}
+.singer-e-thumb.p-1 { background-image: repeating-linear-gradient(45deg, #1a1628 0 8px, #221c33 8px 9px); }
+.singer-e-thumb.p-2 { background-image: repeating-linear-gradient(90deg, #1a1628 0 8px, #241e36 8px 9px); }
+.singer-e-thumb.p-3 { background-image: repeating-linear-gradient(-45deg, #1a1628 0 8px, #1f1a30 8px 9px); }
+.singer-e-thumb.p-4 { background-image: repeating-linear-gradient(135deg, #1a1628 0 8px, #1f1a30 8px 9px); }
+.singer-e-thumb.p-5 { background-image: repeating-linear-gradient(0deg, #1a1628 0 8px, #231d34 8px 9px); }
+.singer-e-thumb.p-6 { background-image: repeating-linear-gradient(60deg, #1a1628 0 8px, #241e36 8px 9px); }
+.singer-e-play {
+  position: absolute; inset: 0; display: grid; place-items: center;
+  opacity: 0; transition: opacity .15s; background: rgba(0,0,0,.4); color: #fff;
+}
+.singer-entry:hover .singer-e-play { opacity: 1; }
+.singer-e-meta { min-width: 0; }
+.singer-e-row { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
+.singer-e-title { font-weight: 600; font-size: 15px; letter-spacing: -0.015em; color: var(--fg); }
+.singer-e-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.singer-e-anime { color: var(--fg-3); transition: color .15s; }
+.singer-e-anime:hover { color: var(--accent); }
+.singer-e-score { text-align: right; white-space: nowrap; }
+.singer-e-score .n { font-weight: 700; font-size: 16px; letter-spacing: -0.02em; }
+.singer-e-score .n em { color: var(--fg-4); font-style: normal; font-size: 11px; font-family: var(--mono); font-weight: 400; }
+.singer-e-score .ct { font-family: var(--mono); font-size: 10px; color: var(--fg-4); }
+
+/* e-tag reused from design (OP/ED/OST badges) */
+.e-tag {
+  font-family: var(--mono); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 2px 6px; border-radius: 3px;
+  border: 1px solid var(--line-2); color: var(--fg-3);
+  flex-shrink: 0; white-space: nowrap;
+}
+.e-tag.op  { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 50%, transparent); }
+.e-tag.ed  { color: var(--ok);     border-color: color-mix(in oklab, var(--ok) 50%, transparent); }
+.e-tag.ost { color: var(--warn);   border-color: color-mix(in oklab, var(--warn) 50%, transparent); }
+
+@media (max-width: 768px) {
+  .singer-hero { grid-template-columns: 120px 1fr; gap: 20px; }
+  .singer-title { font-size: 36px; }
+  .singer-stats { grid-template-columns: repeat(2, auto); gap: 16px; }
+}
+
 /* ── Opening Edit page ────────────────────────────────────────────────────── */
 .edit-rolebar {
   background: var(--bg-2); border-bottom: 1px solid var(--line);


### PR DESCRIPTION
## Summary
- **New `/singers/[id]` page**: circle portrait, name + native subtitle, type pill (Solo/Band/etc), stats bar (Tracks/Openings/Endings/Avg score), type-filter tabs (All/Openings/Endings/OSTs), flat track list with OP/ED/OST badges and clickable anime link
- **New `LocalSortDropdown` component**: same dropdown UI as home page SortBar but client-side (no URL navigation) — reused on both singer and anime pages
- **Anime page**: sort buttons replaced with `LocalSortDropdown` (Sequence / Top rated / Newest)
- **Types**: `SingerOpening` gains `kind` + `sequence_number`; `SingerDetail` gains `name_native` + `type`

## Backend dependency
Requires backend PR #16 to be merged first (adds `kind`, `sequence_number`, `type`, `name_native` to singer detail response).

## Test plan
- [ ] `/singers/{id}` loads, portrait/stats display correctly
- [ ] Type tabs filter the list
- [ ] Sort dropdown changes order (Sequence / Top rated / Newest)
- [ ] Clicking a track goes to `/openings/{id}`
- [ ] Clicking anime name goes to `/anime/{id}` (not the opening)
- [ ] Anime page sort dropdown works, replaces old buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)