### PR TITLE
feat: singer page, sort dropdown, opening detail rails

### DIFF
--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -6,9 +6,11 @@ import CommentsSection from "@/components/CommentsSection";
 import GroupAddMenu from "@/components/GroupAddMenu";
 import {
   getAdjacentOpenings,
+  getAnime,
   getMyGroup,
   getMyRating,
   getOpening,
+  getSinger,
   listMyGroups,
   listOpeningComments,
 } from "@/lib/api";
@@ -20,14 +22,16 @@ import {
 } from "@/lib/mock";
 import type {
   AdjacentOpenings,
+  AnimeOpening,
   Group,
   Opening,
   OpeningComment,
+  SingerOpening,
   SortKey,
+  TrackKind,
   User,
   UserRating,
 } from "@/lib/types";
-import { youtubeEmbedURL } from "@/lib/youtube";
 
 interface Props {
   user: User | null;
@@ -37,12 +41,17 @@ interface Props {
   // server-side by fetching each /me/groups/{id} in parallel.
   initialMemberships: string[];
   opening: Opening | null;
-  embedUrl: string | null;
   adjacent: AdjacentOpenings;
   userRating: UserRating | null;
   initialComments: OpeningComment[];
   commentsAvailable: boolean;
   apiOnline: boolean;
+  animeOpenings: AnimeOpening[];
+  animeName: string;
+  animeId: string;
+  singerOpenings: SingerOpening[];
+  singerName: string;
+  singerId: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -65,6 +74,13 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   let commentsAvailable = true;
   let apiOnline = true;
 
+  let animeOpenings: AnimeOpening[] = [];
+  let animeName = "";
+  let animeId = "";
+  let singerOpenings: SingerOpening[] = [];
+  let singerName = "";
+  let singerId = "";
+
   try {
     [opening, adjacent] = await Promise.all([
       getOpening(id, session.cookie),
@@ -72,6 +88,23 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
         (): AdjacentOpenings => ({ prev: null, next: null }),
       ),
     ]);
+
+    if (opening) {
+      const [animeDetail, singerDetail] = await Promise.all([
+        getAnime(opening.anime.id, session.cookie).catch(() => null),
+        getSinger(opening.singer.id, session.cookie).catch(() => null),
+      ]);
+      if (animeDetail) {
+        animeOpenings = animeDetail.openings;
+        animeName = animeDetail.title_english ?? animeDetail.title_romaji ?? animeDetail.name;
+        animeId = animeDetail.id;
+      }
+      if (singerDetail) {
+        singerOpenings = singerDetail.openings;
+        singerName = singerDetail.name;
+        singerId = singerDetail.id;
+      }
+    }
 
     if (session.user && opening) {
       // Fetch the user's actual groups so the "Save to groups" menu in the
@@ -130,12 +163,17 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
       groups,
       initialMemberships,
       opening,
-      embedUrl: youtubeEmbedURL(opening.youtube_url),
       adjacent,
       userRating,
       initialComments,
       commentsAvailable,
       apiOnline,
+      animeOpenings,
+      animeName,
+      animeId,
+      singerOpenings,
+      singerName,
+      singerId,
     },
   };
 };
@@ -188,6 +226,97 @@ function OpeningNav({ adjacent }: { adjacent: AdjacentOpenings }) {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function kindLabel(kind: TrackKind, seq: number | null): string {
+  const tag = kind === "opening" ? "OP" : kind === "ending" ? "ED" : "OST";
+  return seq != null ? `${tag} ${seq}` : tag;
+}
+
+function kindClass(kind: TrackKind): string {
+  if (kind === "opening") return "op";
+  if (kind === "ending") return "ed";
+  return "ost";
+}
+
+// ---------------------------------------------------------------------------
+// Rail widget
+// ---------------------------------------------------------------------------
+
+interface RailItem {
+  id: string;
+  title: string;
+  kind: TrackKind;
+  sequence_number: number | null;
+  avg_rating: number;
+  rating_count: number;
+  subtitle: string;
+}
+
+function Rail({
+  heading,
+  pageHref,
+  pageLinkLabel,
+  items,
+  currentId,
+}: {
+  heading: React.ReactNode;
+  pageHref: string;
+  pageLinkLabel: string;
+  items: RailItem[];
+  currentId: string;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <section className="rail-section">
+      <div className="sec-head">
+        <h2 className="sec-h2">{heading}</h2>
+        <span className="sec-count">{items.length}</span>
+        <span className="spacer" />
+        <Link href={pageHref} className="all-link">{pageLinkLabel} →</Link>
+      </div>
+      <div className="rail">
+        {items.map((item, i) => {
+          const isCurrent = item.id === currentId;
+          return (
+            <Link
+              key={item.id}
+              href={`/openings/${item.id}`}
+              className={`rail-card${isCurrent ? " current-card" : ""}`}
+            >
+              <div className={`rail-thumb p-${(i % 6) + 1}${isCurrent ? " current" : ""}`}>
+                <span className={`rail-seq ${kindClass(item.kind)}${isCurrent ? " current" : ""}`}>
+                  {kindLabel(item.kind, item.sequence_number)}
+                </span>
+                {isCurrent && <span className="rail-now">now playing</span>}
+                {!isCurrent && (
+                  <span className="rail-play">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M8 5v14l11-7z"/>
+                    </svg>
+                  </span>
+                )}
+              </div>
+              <div className="rail-meta">
+                <div className="rail-title">{item.title}</div>
+                <div className="rail-sub">{item.subtitle}</div>
+                {item.rating_count > 0 && (
+                  <div className="rail-rating">
+                    {item.avg_rating.toFixed(1)}<em>/10</em>
+                    <span className="rail-ct">{item.rating_count}</span>
+                  </div>
+                )}
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -197,14 +326,39 @@ export default function OpeningDetail({
   groups,
   initialMemberships,
   opening,
-  embedUrl,
   adjacent,
   userRating,
   initialComments,
   commentsAvailable,
   apiOnline,
+  animeOpenings,
+  animeName,
+  animeId,
+  singerOpenings,
+  singerName,
+  singerId,
 }: Props) {
   const op = opening!;
+
+  const animeRailItems = animeOpenings.map((ao) => ({
+    id: ao.id,
+    title: ao.title,
+    kind: ao.kind,
+    sequence_number: ao.sequence_number,
+    avg_rating: ao.avg_rating,
+    rating_count: ao.rating_count,
+    subtitle: ao.singer.name,
+  }));
+
+  const singerRailItems = singerOpenings.map((so) => ({
+    id: so.id,
+    title: so.title,
+    kind: so.kind,
+    sequence_number: so.sequence_number,
+    avg_rating: so.avg_rating,
+    rating_count: so.rating_count,
+    subtitle: so.anime.name,
+  }));
 
   return (
     <Layout
@@ -234,16 +388,19 @@ export default function OpeningDetail({
         <div className="detail-grid">
           <div>
             <div className="detail-video">
-              {embedUrl ? (
-                <iframe
-                  src={embedUrl}
-                  title={op.title}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                />
-              ) : (
-                <div className="detail-no-video">Video unavailable</div>
-              )}
+              <a
+                href={op.youtube_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`detail-thumb p-${((op.pattern ?? 1) - 1) % 6 + 1}`}
+              >
+                <span className="detail-thumb-play">
+                  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+                    <path d="M8 5v14l11-7z"/>
+                  </svg>
+                </span>
+                <span className="detail-thumb-label">Watch on YouTube</span>
+              </a>
             </div>
 
             <div className="detail-meta-row">
@@ -315,6 +472,22 @@ export default function OpeningDetail({
               user={user}
               initialComments={initialComments}
               available={commentsAvailable}
+            />
+
+            <Rail
+              heading={<>More from <em>{animeName}</em></>}
+              pageHref={`/anime/${animeId}`}
+              pageLinkLabel="Anime page"
+              items={animeRailItems}
+              currentId={op.id}
+            />
+
+            <Rail
+              heading={<>More from <em>{singerName}</em></>}
+              pageHref={`/singers/${singerId}`}
+              pageLinkLabel="Singer page"
+              items={singerRailItems}
+              currentId={op.id}
             />
           </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -711,6 +711,27 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   width: 100%; height: 100%; display: grid; place-items: center;
   color: var(--fg-4); font-family: var(--mono); font-size: 12px;
 }
+.detail-thumb {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  width: 100%; height: 100%; gap: 10px; text-decoration: none;
+  transition: opacity .15s;
+}
+.detail-thumb:hover { opacity: 0.85; }
+.detail-thumb.p-1 { background-image: repeating-linear-gradient(45deg, #1a1628 0 12px, #221c33 12px 13px); }
+.detail-thumb.p-2 { background-image: repeating-linear-gradient(90deg, #1a1628 0 12px, #241e36 12px 13px); }
+.detail-thumb.p-3 { background-image: repeating-linear-gradient(-45deg, #1a1628 0 12px, #1f1a30 12px 13px); }
+.detail-thumb.p-4 { background-image: repeating-linear-gradient(0deg,  #1a1628 0 12px, #231d34 12px 13px); }
+.detail-thumb.p-5 { background-image: repeating-linear-gradient(135deg, #1a1628 0 12px, #1f1a30 12px 13px); }
+.detail-thumb.p-6 { background-image: repeating-linear-gradient(60deg, #1a1628 0 12px, #241e36 12px 13px); }
+.detail-thumb-play {
+  width: 56px; height: 56px; border-radius: 50%;
+  background: color-mix(in oklab, var(--accent) 15%, transparent);
+  border: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+  display: flex; align-items: center; justify-content: center; color: var(--accent);
+}
+.detail-thumb-label {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3); letter-spacing: 0.08em;
+}
 
 /* Title row */
 .detail-meta-row {
@@ -2429,3 +2450,93 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .edit-sb-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--warn); box-shadow: 0 0 0 4px color-mix(in oklab, var(--warn) 18%, transparent); }
 .edit-sb-lbl { color: var(--fg); font-weight: 500; }
 .edit-sb-actions { display: flex; gap: 8px; }
+
+/* ---------------------------------------------------------------------------
+   Opening detail — "More from" rails
+   --------------------------------------------------------------------------- */
+.rail-section { margin-top: 48px; }
+.sec-head {
+  display: flex; align-items: baseline; gap: 10px; margin-bottom: 16px;
+}
+.sec-h2 {
+  font-size: 18px; font-weight: 700; letter-spacing: -0.02em; margin: 0;
+}
+.sec-h2 em { font-style: normal; color: var(--accent); }
+.sec-count {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-4);
+}
+.all-link {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  transition: color .15s;
+}
+.all-link:hover { color: var(--accent); }
+
+.rail {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 200px;
+  gap: 14px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  padding-bottom: 8px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-2) transparent;
+}
+.rail-card {
+  display: flex; flex-direction: column; gap: 10px;
+  scroll-snap-align: start; text-decoration: none;
+  transition: transform .15s;
+}
+.rail-card:hover { transform: translateY(-2px); }
+
+.rail-thumb {
+  aspect-ratio: 16 / 9; border-radius: 8px; overflow: hidden;
+  border: 1px solid var(--line); position: relative;
+  transition: border-color .15s;
+}
+.rail-card:hover .rail-thumb { border-color: var(--line-2); }
+.rail-thumb.current { outline: 2px solid var(--accent); outline-offset: -2px; }
+.rail-thumb.p-1 { background-image: repeating-linear-gradient(45deg, #1a1628 0 10px, #221c33 10px 11px); }
+.rail-thumb.p-2 { background-image: repeating-linear-gradient(90deg, #1a1628 0 10px, #241e36 10px 11px); }
+.rail-thumb.p-3 { background-image: repeating-linear-gradient(-45deg, #1a1628 0 10px, #1f1a30 10px 11px); }
+.rail-thumb.p-4 { background-image: repeating-linear-gradient(0deg,  #1a1628 0 10px, #231d34 10px 11px); }
+.rail-thumb.p-5 { background-image: repeating-linear-gradient(135deg, #1a1628 0 10px, #1f1a30 10px 11px); }
+.rail-thumb.p-6 { background-image: repeating-linear-gradient(60deg, #1a1628 0 10px, #241e36 10px 11px); }
+
+.rail-seq {
+  position: absolute; top: 6px; left: 6px;
+  font-family: var(--mono); font-size: 9px; font-weight: 600; letter-spacing: 0.08em;
+  padding: 2px 6px; border-radius: 4px; border: 1px solid;
+  text-transform: uppercase;
+}
+.rail-seq.op  { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 50%, transparent); }
+.rail-seq.ed  { color: var(--ok);     border-color: color-mix(in oklab, var(--ok) 50%, transparent); }
+.rail-seq.ost { color: var(--warn);   border-color: color-mix(in oklab, var(--warn) 50%, transparent); }
+.rail-seq.current { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); }
+
+.rail-now {
+  position: absolute; bottom: 6px; right: 6px;
+  font-family: var(--mono); font-size: 9px; color: var(--accent); letter-spacing: 0.06em;
+}
+.rail-play {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  color: var(--fg-3); opacity: 0; transition: opacity .15s;
+}
+.rail-card:hover .rail-play { opacity: 1; }
+
+.rail-meta { display: flex; flex-direction: column; gap: 3px; }
+.rail-title {
+  font-size: 13px; font-weight: 600; color: var(--fg);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.current-card .rail-title { color: var(--accent); }
+.rail-sub {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.rail-rating {
+  font-family: var(--mono); font-size: 12px; color: var(--fg-2); font-weight: 600;
+  display: flex; align-items: baseline; gap: 6px; margin-top: 2px;
+}
+.rail-rating em { font-style: normal; font-size: 10px; color: var(--fg-4); }
+.rail-ct { font-size: 10px; color: var(--fg-4); }


### PR DESCRIPTION
## Summary
- Singer page (/singers/:id): portrait hero, type pill, flat track list with OP/ED/OST tags, type-filter tabs, sort dropdown
- LocalSortDropdown component: client-side sort (Sequence / Top rated / Newest), reuses existing sort CSS
- Anime page: replaced sort buttons with LocalSortDropdown
- Opening detail page: replaced iframe embed with patterned thumbnail card linking to YouTube; added "More from Anime" and "More from Singer" horizontal scroll rails fetched in SSR

## Test plan
- [ ] Visit /singers/:id — verify hero stats, type filter tabs, sort dropdown work
- [ ] Visit /anime/:id — verify sort dropdown replaces old buttons
- [ ] Visit /openings/:id — thumbnail card shows patterned background with play icon, links to YouTube
- [ ] Both rails render with correct cards; current opening highlighted with accent outline + "now playing" label

🤖 Generated with [Claude Code](https://claude.com/claude-code)