### PR TITLE
feat: singer page, opening edit, sort dropdowns, More from rails

### DIFF
--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -1,7 +1,7 @@
 import type { GetServerSideProps } from "next";
 import Link from "next/link";
 import Layout from "@/components/Layout";
-import { youtubeEmbedURL } from "@/lib/youtube";
+import { youtubeEmbedURL, youtubeThumbnail } from "@/lib/youtube";
 import RatingPopup from "@/components/RatingPopup";
 import CommentsSection from "@/components/CommentsSection";
 import GroupAddMenu from "@/components/GroupAddMenu";
@@ -248,6 +248,7 @@ function kindClass(kind: TrackKind): string {
 interface RailItem {
   id: string;
   title: string;
+  youtube_url: string;
   kind: TrackKind;
   sequence_number: number | null;
   avg_rating: number;
@@ -286,19 +287,28 @@ function Rail({
               href={`/openings/${item.id}`}
               className={`rail-card${isCurrent ? " current-card" : ""}`}
             >
-              <div className={`rail-thumb p-${(i % 6) + 1}${isCurrent ? " current" : ""}`}>
-                <span className={`rail-seq ${kindClass(item.kind)}${isCurrent ? " current" : ""}`}>
-                  {kindLabel(item.kind, item.sequence_number)}
-                </span>
-                {isCurrent && <span className="rail-now">now playing</span>}
-                {!isCurrent && (
-                  <span className="rail-play">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                      <path d="M8 5v14l11-7z"/>
-                    </svg>
-                  </span>
-                )}
-              </div>
+              {(() => {
+                const thumb = youtubeThumbnail(item.youtube_url);
+                return (
+                  <div className={`rail-thumb p-${(i % 6) + 1}${isCurrent ? " current" : ""}`}>
+                    {thumb && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={thumb} alt="" className="rail-thumb-img" />
+                    )}
+                    <span className={`rail-seq ${kindClass(item.kind)}${isCurrent ? " current" : ""}`}>
+                      {kindLabel(item.kind, item.sequence_number)}
+                    </span>
+                    {isCurrent && <span className="rail-now">now playing</span>}
+                    {!isCurrent && (
+                      <span className="rail-play">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M8 5v14l11-7z"/>
+                        </svg>
+                      </span>
+                    )}
+                  </div>
+                );
+              })()}
               <div className="rail-meta">
                 <div className="rail-title">{item.title}</div>
                 <div className="rail-sub">{item.subtitle}</div>
@@ -344,6 +354,7 @@ export default function OpeningDetail({
   const animeRailItems = animeOpenings.map((ao) => ({
     id: ao.id,
     title: ao.title,
+    youtube_url: ao.youtube_url,
     kind: ao.kind,
     sequence_number: ao.sequence_number,
     avg_rating: ao.avg_rating,
@@ -354,6 +365,7 @@ export default function OpeningDetail({
   const singerRailItems = singerOpenings.map((so) => ({
     id: so.id,
     title: so.title,
+    youtube_url: so.youtube_url,
     kind: so.kind,
     sequence_number: so.sequence_number,
     avg_rating: so.avg_rating,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2474,8 +2474,8 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .rail {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: 200px;
-  gap: 14px;
+  grid-auto-columns: 280px;
+  gap: 16px;
   overflow-x: auto;
   scroll-snap-type: x mandatory;
   padding-bottom: 8px;
@@ -2496,6 +2496,10 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 }
 .rail-card:hover .rail-thumb { border-color: var(--line-2); }
 .rail-thumb.current { outline: 2px solid var(--accent); outline-offset: -2px; }
+.rail-thumb-img {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  object-fit: cover; display: block;
+}
 .rail-thumb.p-1 { background-image: repeating-linear-gradient(45deg, #1a1628 0 10px, #221c33 10px 11px); }
 .rail-thumb.p-2 { background-image: repeating-linear-gradient(90deg, #1a1628 0 10px, #241e36 10px 11px); }
 .rail-thumb.p-3 { background-image: repeating-linear-gradient(-45deg, #1a1628 0 10px, #1f1a30 10px 11px); }


### PR DESCRIPTION
## Summary
- **Opening edit page** (/openings/:id/edit): type picker, attribution pickers with inline search, notes field, delete danger zone, activity sidebar, sticky save bar (admin only)
- **Singer page** (/singers/:id): portrait hero, type pill, flat OP/ED/OST track list, type-filter tabs, sort dropdown
- **LocalSortDropdown** component: client-side Sequence / Top rated / Newest sort
- **Anime page**: sort buttons replaced with LocalSortDropdown
- **Opening detail**: "More from Anime" and "More from Singer" horizontal scroll rails above comments; YouTube thumbnail previews on rail cards (280px wide); iframe embed preserved

## Test plan
- [ ] /openings/:id/edit — admin only; save bar on change; delete modal works
- [ ] /singers/:id — hero stats, type tabs, sort dropdown
- [ ] /anime/:id — sort dropdown replaces old buttons
- [ ] /openings/:id — iframe plays; rails show YouTube thumbnails; current card highlighted with accent outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)