### PR TITLE
fix: UI cleanups across submit, catalog, detail, and edit pages

### DIFF
--- a/components/Autocomplete.tsx
+++ b/components/Autocomplete.tsx
@@ -4,6 +4,8 @@ export interface AutocompleteItem {
   id: string;
   label: string;
   sublabel?: string;
+  coverUrl?: string | null;
+  iconShape?: "square" | "circle";
 }
 
 interface Props {
@@ -77,6 +79,12 @@ export default function Autocomplete({ placeholder, fetchItems, selected, onSele
     <div className="auto" ref={wrapRef}>
       {selected ? (
         <div className="auto-selected">
+          <div className={`auto-ic${selected.iconShape === "circle" ? " circle" : ""}`}>
+            {selected.coverUrl && (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={selected.coverUrl} alt="" />
+            )}
+          </div>
           <span>{selected.label}</span>
           {selected.sublabel && <span style={{ color: "var(--fg-3)", fontSize: 11, fontFamily: "var(--mono)" }}>{selected.sublabel}</span>}
           <button type="button" className="x" onClick={() => onSelect(null)} aria-label="Clear">×</button>
@@ -100,7 +108,12 @@ export default function Autocomplete({ placeholder, fetchItems, selected, onSele
                   onMouseDown={() => handleSelect(item)}
                   onMouseEnter={() => setActiveIdx(i)}
                 >
-                  <div className="ic" />
+                  <div className={`ic${item.iconShape === "circle" ? " circle" : ""}`}>
+                    {item.coverUrl && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={item.coverUrl} alt="" />
+                    )}
+                  </div>
                   <div>
                     <div className="a-name">{item.label}</div>
                     {item.sublabel && <div className="a-sub">{item.sublabel}</div>}

--- a/components/CatalogTabs.tsx
+++ b/components/CatalogTabs.tsx
@@ -4,13 +4,12 @@ import type { TrackKind } from "@/lib/types";
 interface Tab {
   kind: TrackKind;
   label: string;
-  subtitle: string;
 }
 
 const TABS: Tab[] = [
-  { kind: "opening", label: "Openings", subtitle: "OP · INTRO · ~90s" },
-  { kind: "ending",  label: "Endings",  subtitle: "ED · OUTRO · ~90s" },
-  { kind: "ost",     label: "OSTs",     subtitle: "OST · TRACK" },
+  { kind: "opening", label: "Openings" },
+  { kind: "ending",  label: "Endings" },
+  { kind: "ost",     label: "OSTs" },
 ];
 
 interface Props {
@@ -46,7 +45,6 @@ export default function CatalogTabs({ activeKind, counts, q, sort }: Props) {
               {tab.label}
               <span className="cat-tab-count">{counts[tab.kind].toLocaleString()}</span>
             </span>
-            <span className="cat-tab-sub">{tab.subtitle}</span>
           </Link>
         );
       })}

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -5,6 +5,7 @@ import Layout from "@/components/Layout";
 import LocalSortDropdown from "@/components/LocalSortDropdown";
 import { getAnime } from "@/lib/api";
 import { loadSession } from "@/lib/session";
+import { youtubeThumbnail } from "@/lib/youtube";
 import type { AnimeDetail, AnimeOpening, TrackKind, User } from "@/lib/types";
 
 interface Props {
@@ -55,7 +56,7 @@ type FilterTab = "all" | TrackKind;
 
 export default function AnimePage({ user, modQueueCount, anime }: Props) {
   const [filter, setFilter] = useState<FilterTab>("all");
-  const [sort, setSort] = useState<"sequence" | "top" | "newest">("sequence");
+  const [sort, setSort] = useState<"sequence" | "top" | "newest">("top");
 
   const ops    = anime.openings.filter((o) => o.kind === "opening");
   const eds    = anime.openings.filter((o) => o.kind === "ending");
@@ -205,9 +206,15 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
           <div className="empty-state">No entries yet.</div>
         ) : (
           <div className="cat">
-            {visible.map((op, i) => (
+            {visible.map((op, i) => {
+              const thumb = youtubeThumbnail(op.youtube_url);
+              return (
               <article key={op.id} className="op-card">
-                <Link href={`/openings/${op.id}`} className={`op-thumb p-${(i % 6) + 1}`}>
+                <Link href={`/openings/${op.id}`} className={thumb ? "op-thumb" : `op-thumb p-${(i % 6) + 1}`}>
+                  {thumb && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={thumb} alt="" className="op-thumb-img" loading="lazy" />
+                  )}
                   <span className={`op-seq ${kindClass(op.kind)}`}>{kindLabel(op)}</span>
                   <span className="op-play">
                     <div>
@@ -234,7 +241,8 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
                   )}
                 </div>
               </article>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>

--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -258,14 +258,10 @@ interface RailItem {
 
 function Rail({
   heading,
-  pageHref,
-  pageLinkLabel,
   items,
   currentId,
 }: {
   heading: React.ReactNode;
-  pageHref: string;
-  pageLinkLabel: string;
   items: RailItem[];
   currentId: string;
 }) {
@@ -275,8 +271,6 @@ function Rail({
       <div className="sec-head">
         <h2 className="sec-h2">{heading}</h2>
         <span className="sec-count">{items.length}</span>
-        <span className="spacer" />
-        <Link href={pageHref} className="all-link">{pageLinkLabel} →</Link>
       </div>
       <div className="rail">
         {items.map((item, i) => {
@@ -478,17 +472,13 @@ export default function OpeningDetail({
             </div>
 
             <Rail
-              heading={<>More from <em>{animeName}</em></>}
-              pageHref={`/anime/${animeId}`}
-              pageLinkLabel="Anime page"
+              heading={<>More from <Link href={`/anime/${animeId}`} className="sec-h2-link"><em>{animeName}</em></Link></>}
               items={animeRailItems}
               currentId={op.id}
             />
 
             <Rail
-              heading={<>More from <em>{singerName}</em></>}
-              pageHref={`/singers/${singerId}`}
-              pageLinkLabel="Singer page"
+              heading={<>More from <Link href={`/singers/${singerId}`} className="sec-h2-link"><em>{singerName}</em></Link></>}
               items={singerRailItems}
               currentId={op.id}
             />

--- a/pages/openings/[id]/edit.tsx
+++ b/pages/openings/[id]/edit.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { useState, useCallback, useRef, useEffect } from "react";
 import Layout from "@/components/Layout";
-import { getOpening } from "@/lib/api";
+import { getAnime, getOpening, getSinger } from "@/lib/api";
 import { loadSession } from "@/lib/session";
 import { pushToast } from "@/lib/toast";
 import { youtubeEmbedURL } from "@/lib/youtube";
@@ -14,6 +14,8 @@ interface Props {
   modQueueCount: number;
   opening: Opening;
   embedUrl: string | null;
+  animeCoverUrl: string | null;
+  singerCoverUrl: string | null;
 }
 
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
@@ -24,12 +26,18 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const id = ctx.params?.id as string;
   try {
     const opening = await getOpening(id, session.cookie);
+    const [anime, singer] = await Promise.all([
+      getAnime(opening.anime.id, session.cookie).catch(() => null),
+      getSinger(opening.singer.id, session.cookie).catch(() => null),
+    ]);
     return {
       props: {
         user: session.user,
         modQueueCount: session.modQueueCount,
         opening,
         embedUrl: youtubeEmbedURL(opening.youtube_url),
+        animeCoverUrl: anime?.cover_image_url ?? null,
+        singerCoverUrl: singer?.cover_image_url ?? null,
       },
     };
   } catch {
@@ -41,7 +49,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 // Entity picker (anime / singer search inline dropdown)
 // ---------------------------------------------------------------------------
 
-interface EntityItem { id: string; name: string; sublabel?: string }
+interface EntityItem { id: string; name: string; sublabel?: string; coverUrl?: string | null }
 
 interface RelationPickerProps {
   label: string;
@@ -72,8 +80,8 @@ function RelationPicker({ label, kind, value, onChange }: RelationPickerProps) {
       setResults(
         items.map((x) =>
           kind === "anime"
-            ? { id: x.id, name: x.name, sublabel: x.year ? `${x.year} · ${(x.format ?? "").toUpperCase().replace("_", " ")}` : undefined }
-            : { id: x.id, name: x.name, sublabel: (x.type ?? "").replace(/_/g, " ") },
+            ? { id: x.id, name: x.name, coverUrl: x.cover_image_url ?? null, sublabel: x.year ? `${x.year} · ${(x.format ?? "").toUpperCase().replace("_", " ")}` : undefined }
+            : { id: x.id, name: x.name, coverUrl: x.cover_image_url ?? null, sublabel: (x.type ?? "").replace(/_/g, " ") },
         ),
       );
     } finally {
@@ -140,7 +148,12 @@ function RelationPicker({ label, kind, value, onChange }: RelationPickerProps) {
           </div>
         ) : (
           <div className={`edit-relation${kind === "singer" ? " singer" : ""}`}>
-            <div className="edit-relation-ic" />
+            <div className="edit-relation-ic">
+              {value.coverUrl && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={value.coverUrl} alt="" />
+              )}
+            </div>
             <div>
               <div className="edit-relation-name">{value.name}</div>
               {value.sublabel && <div className="edit-relation-sub">{value.sublabel}</div>}
@@ -163,14 +176,14 @@ const KIND_OPTIONS: { value: TrackKind; tag: string; label: string }[] = [
   { value: "ost",     tag: "OST", label: "OST / insert" },
 ];
 
-export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl }: Props) {
+export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl, animeCoverUrl, singerCoverUrl }: Props) {
   const router = useRouter();
 
   const [title, setTitle] = useState(opening.title);
   const [youtubeUrl, setYoutubeUrl] = useState(opening.youtube_url);
   const [kind, setKind] = useState<TrackKind>(opening.kind);
-  const [anime, setAnime] = useState<EntityItem>({ id: opening.anime.id, name: opening.anime.name });
-  const [singer, setSinger] = useState<EntityItem>({ id: opening.singer.id, name: opening.singer.name });
+  const [anime, setAnime] = useState<EntityItem>({ id: opening.anime.id, name: opening.anime.name, coverUrl: animeCoverUrl });
+  const [singer, setSinger] = useState<EntityItem>({ id: opening.singer.id, name: opening.singer.name, coverUrl: singerCoverUrl });
   const [notes, setNotes] = useState(opening.notes_for_moderator ?? "");
 
   const [saving, setSaving] = useState(false);
@@ -258,16 +271,6 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
     >
       <div className="wrap">
 
-        {/* Admin rolebar */}
-        <div className="edit-rolebar">
-          <span style={{ color: "var(--fg-2)" }}>Editing as admin</span>
-          <span style={{ color: "var(--fg-4)" }}>·</span>
-          <Link href="/mod">Moderation queue ({modQueueCount})</Link>
-          <span style={{ marginLeft: "auto" }}>
-            <Link href={`/openings/${opening.id}`}>← View public page</Link>
-          </span>
-        </div>
-
         {/* Breadcrumb */}
         <div className="edit-crumb">
           <Link href="/">Home</Link>
@@ -280,6 +283,10 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
         {/* Heading */}
         <div className="edit-head">
           <div>
+            <div className="edit-eyebrow">
+              <span className="edit-admin-badge">Admin · Editing</span>
+              <Link href="/mod" className="edit-eyebrow-link">Moderation queue ({modQueueCount})</Link>
+            </div>
             <h1 className="edit-h1">Editing <em>{displayName}</em></h1>
             <div className="edit-sub">
               <Link href={`/anime/${opening.anime.id}`}>{opening.anime.name}</Link>
@@ -315,7 +322,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
                         title={opening.title}
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                         allowFullScreen
-                        style={{ width: "100%", height: "100%", border: 0 }}
+                        frameBorder="0"
                       />
                     ) : (
                       <span className="edit-preview-ph">[ youtube ]</span>
@@ -505,9 +512,12 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
           </aside>
         </div>
 
-        {/* Sticky save bar */}
-        {isDirty && (
-          <div className="edit-save-bar">
+      </div>
+
+      {/* Sticky save bar — fixed to viewport so it spans full width */}
+      {isDirty && (
+        <div className="edit-save-bar">
+          <div className="edit-save-bar-inner wrap">
             <span className="edit-sb-status">
               <span className="edit-sb-dot" />
               <span className="edit-sb-lbl">Unsaved changes</span>
@@ -522,9 +532,8 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
               </button>
             </div>
           </div>
-        )}
-
-      </div>
+        </div>
+      )}
 
       {/* Delete confirm modal */}
       {confirmDelete && (

--- a/pages/singers/[id].tsx
+++ b/pages/singers/[id].tsx
@@ -5,6 +5,7 @@ import Layout from "@/components/Layout";
 import LocalSortDropdown from "@/components/LocalSortDropdown";
 import { getSinger } from "@/lib/api";
 import { loadSession } from "@/lib/session";
+import { youtubeThumbnail } from "@/lib/youtube";
 import type { SingerDetail, SingerOpening, TrackKind, User } from "@/lib/types";
 
 interface Props {
@@ -75,7 +76,7 @@ function sortOpenings(items: SingerOpening[], sort: SortKey): SingerOpening[] {
 
 export default function SingerPage({ user, modQueueCount, singer }: Props) {
   const [filter, setFilter] = useState<FilterTab>("all");
-  const [sort, setSort] = useState<SortKey>("sequence");
+  const [sort, setSort] = useState<SortKey>("top");
 
   const ops  = singer.openings.filter((o) => o.kind === "opening");
   const eds  = singer.openings.filter((o) => o.kind === "ending");
@@ -202,39 +203,44 @@ export default function SingerPage({ user, modQueueCount, singer }: Props) {
         {visible.length === 0 ? (
           <div className="empty-state">No entries yet.</div>
         ) : (
-          <div className="singer-entries">
-            {visible.map((op, i) => (
-              <Link key={op.id} href={`/openings/${op.id}`} className="singer-entry">
-                <div className={`singer-e-thumb p-${(i % 6) + 1}`}>
-                  <div className="singer-e-play">
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-                      <path d="M8 5v14l11-7z"/>
-                    </svg>
+          <div className="cat">
+            {visible.map((op, i) => {
+              const thumb = youtubeThumbnail(op.youtube_url);
+              return (
+                <article key={op.id} className="op-card">
+                  <Link href={`/openings/${op.id}`} className={thumb ? "op-thumb" : `op-thumb p-${(i % 6) + 1}`}>
+                    {thumb && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={thumb} alt="" className="op-thumb-img" loading="lazy" />
+                    )}
+                    <span className={`op-seq ${kindClass(op.kind)}`}>{kindLabel(op)}</span>
+                    <span className="op-play">
+                      <div>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+                          <path d="M8 5v14l11-7z"/>
+                        </svg>
+                      </div>
+                    </span>
+                  </Link>
+                  <div className="op-info">
+                    <div className="op-main">
+                      <h3 className="op-title">
+                        <Link href={`/openings/${op.id}`}>{op.title}</Link>
+                      </h3>
+                      <div className="op-meta">
+                        <Link href={`/anime/${op.anime.id}`} className="op-meta-link">{op.anime.name}</Link>
+                      </div>
+                    </div>
+                    {op.rating_count > 0 && (
+                      <div className="op-score">
+                        <div className="n">{op.avg_rating.toFixed(1)}<em>/10</em></div>
+                        <div className="ct">{op.rating_count}</div>
+                      </div>
+                    )}
                   </div>
-                </div>
-                <div className="singer-e-meta">
-                  <div className="singer-e-row">
-                    <span className={`e-tag ${kindClass(op.kind)}`}>{kindLabel(op)}</span>
-                    <span className="singer-e-title">{op.title}</span>
-                  </div>
-                  <div className="singer-e-sub">
-                    <Link
-                      href={`/anime/${op.anime.id}`}
-                      className="singer-e-anime"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {op.anime.name}
-                    </Link>
-                  </div>
-                </div>
-                {op.rating_count > 0 && (
-                  <div className="singer-e-score">
-                    <div className="n">{op.avg_rating.toFixed(1)}<em>/10</em></div>
-                    <div className="ct">{op.rating_count}</div>
-                  </div>
-                )}
-              </Link>
-            ))}
+                </article>
+              );
+            })}
           </div>
         )}
 

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -34,6 +34,8 @@ async function fetchAnimeItems(q: string): Promise<AutocompleteItem[]> {
   return items.map((a: any) => ({
     id: a.id,
     label: a.name,
+    coverUrl: a.cover_image_url ?? null,
+    iconShape: "square" as const,
     sublabel: a.year ? `${a.year} · ${(a.format ?? "").toUpperCase().replace("_", " ")}` : undefined,
   }));
 }
@@ -46,6 +48,8 @@ async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
   return items.map((s: any) => ({
     id: s.id,
     label: s.name,
+    coverUrl: s.cover_image_url ?? null,
+    iconShape: "circle" as const,
     sublabel: (s.type ?? "").replace(/_/g, " "),
   }));
 }
@@ -287,7 +291,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
       <div className="sub-form-card">
         <div className="sub-form-head">
           <h2>Submit an <em>{kind === "ost" ? "OST" : kind}</em>.</h2>
-          <p>OP, ED, or OST · We&apos;ll attach it to its anime + singer</p>
         </div>
         <div className="sub-form-body">
 
@@ -314,7 +317,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
           <div className="sub-row">
             <label>YouTube link <span className="req">*</span></label>
             <input type="url" value={youtubeUrl} onChange={(e) => setYoutubeUrl(e.target.value)} placeholder="https://youtube.com/watch?v=…" />
-            <span className="hint">Official upload preferred — Crunchyroll, the studio, the artist&apos;s channel.</span>
             {fieldErrors.youtube_url && <span className="ferr">{fieldErrors.youtube_url}</span>}
           </div>
           <div className="sub-row">
@@ -439,7 +441,6 @@ function AnimePane() {
       <div className="sub-form-card">
         <div className="sub-form-head">
           <h2>Submit an <em>anime</em>.</h2>
-          <p>So OPs, EDs, and OSTs can be attached to a real series</p>
         </div>
         <div className="sub-form-body">
 
@@ -586,7 +587,6 @@ function SingerPane() {
       <div className="sub-form-card">
         <div className="sub-form-head">
           <h2>Submit a <em>singer</em>.</h2>
-          <p>Solo artist, band, group, or producer whose work appears in anime</p>
         </div>
         <div className="sub-form-body">
 
@@ -658,24 +658,21 @@ function SingerPane() {
 // Page
 // ---------------------------------------------------------------------------
 
-const TABS: { id: Tab; icon: React.ReactNode; label: string; sub: string }[] = [
+const TABS: { id: Tab; icon: React.ReactNode; label: string }[] = [
   {
     id: "opening",
     icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m22 8-6 4 6 4V8Z"/><rect x="2" y="6" width="14" height="12" rx="2"/></svg>,
     label: "An opening",
-    sub: "OP, ED, or OST · 30 sec",
   },
   {
     id: "anime",
     icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18"/><path d="M9 21V9"/></svg>,
     label: "An anime",
-    sub: "New series · for OPs to attach to",
   },
   {
     id: "singer",
     icon: <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg>,
     label: "A singer",
-    sub: "Solo, band, or group · vocaloid",
   },
 ];
 
@@ -706,7 +703,6 @@ export default function SubmitPage({ user, modQueueCount }: Props) {
               onClick={() => setTab(t.id)}
             >
               <span className="st-label">{t.icon}{t.label}</span>
-              <span className="st-sub">{t.sub}</span>
             </button>
           ))}
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,8 @@
   --accent-ink: #0c0a14;
   --ok: #7dd38f;
   --warn: #e8b84a;
+  --danger: #ef6868;
+  --danger-ink: #1a0808;
   --serif: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --sans: "Inter", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --mono: "Geist Mono", ui-monospace, Menlo, monospace;
@@ -617,6 +619,19 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   width: 28px; height: 28px; border-radius: 4px;
   background-image: repeating-linear-gradient(45deg, #1a1628 0 6px, #241e36 6px 7px);
   border: 1px solid var(--line-2);
+  overflow: hidden; flex-shrink: 0;
+}
+.auto-row .ic.circle,
+.auto-row .ic.circle img,
+.auto-selected .auto-ic.circle,
+.auto-selected .auto-ic.circle img { border-radius: 50%; }
+.auto-row .ic img,
+.auto-selected .auto-ic img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.auto-selected .auto-ic {
+  width: 28px; height: 28px; border-radius: 4px;
+  background-image: repeating-linear-gradient(45deg, #1a1628 0 6px, #241e36 6px 7px);
+  border: 1px solid var(--line-2);
+  overflow: hidden; flex-shrink: 0;
 }
 .a-name { font-size: 13px; line-height: 1.2; }
 .a-sub { font-family: var(--mono); font-size: 10px; color: var(--fg-3); margin-top: 2px; }
@@ -2250,14 +2265,19 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 }
 
 /* ── Opening Edit page ────────────────────────────────────────────────────── */
-.edit-rolebar {
-  background: var(--bg-2); border-bottom: 1px solid var(--line);
-  margin: 0 calc(-1 * var(--pad)); padding: 0 var(--pad);
-  display: flex; gap: 14px; align-items: center; height: 34px;
-  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+.edit-eyebrow {
+  display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+  font-family: var(--mono); font-size: 11px;
 }
-.edit-rolebar a { color: var(--fg-2); transition: color .15s; }
-.edit-rolebar a:hover { color: var(--fg); }
+.edit-admin-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 8px; border-radius: 4px;
+  background: color-mix(in oklab, var(--warn) 18%, transparent);
+  color: var(--warn); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase;
+  border: 1px solid color-mix(in oklab, var(--warn) 40%, transparent);
+}
+.edit-eyebrow-link { color: var(--fg-3); transition: color .15s; }
+.edit-eyebrow-link:hover { color: var(--fg); }
 
 .edit-crumb {
   padding: 22px 0 14px; font-family: var(--mono); font-size: 12px;
@@ -2294,11 +2314,16 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .edit-card-body { padding: 18px; }
 
 /* Preview strip */
-.edit-preview-strip { display: grid; grid-template-columns: 220px 1fr; gap: 16px; align-items: stretch; }
+.edit-preview-strip { display: grid; grid-template-columns: 220px 1fr; gap: 16px; align-items: start; }
 .edit-preview-thumb {
-  aspect-ratio: 16/9; border-radius: 6px;
+  width: 100%; aspect-ratio: 16/9; border-radius: 6px;
   border: 1px solid var(--line); overflow: hidden;
-  background: var(--bg-3); display: grid; place-items: center;
+  background: var(--bg-3); position: relative;
+}
+.edit-preview-thumb iframe,
+.edit-preview-thumb > span {
+  position: absolute; inset: 0; width: 100%; height: 100%;
+  display: grid; place-items: center;
 }
 .edit-preview-ph { font-family: var(--mono); font-size: 9px; color: var(--fg-3); letter-spacing: 0.14em; text-transform: uppercase; }
 .edit-preview-info { display: flex; flex-direction: column; justify-content: space-between; gap: 10px; }
@@ -2365,11 +2390,14 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   display: grid; grid-template-columns: 32px 1fr auto; gap: 10px; align-items: center;
   padding: 10px 14px; border: 1px solid var(--line); border-radius: 6px; background: var(--bg-3);
 }
-.edit-relation.singer .edit-relation-ic { border-radius: 50%; }
+.edit-relation.singer .edit-relation-ic,
+.edit-relation.singer .edit-relation-ic img { border-radius: 50%; }
 .edit-relation-ic {
   width: 32px; height: 32px; border-radius: 5px; border: 1px solid var(--line-2);
   background-image: repeating-linear-gradient(135deg, #1a1628 0 8px, #221c33 8px 9px);
+  overflow: hidden; flex-shrink: 0;
 }
+.edit-relation-ic img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .edit-relation-name { font-size: 14px; font-weight: 600; }
 .edit-relation-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); margin-top: 2px; }
 .edit-change-btn {
@@ -2401,17 +2429,27 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 
 /* Danger zone */
 .edit-danger-zone {
-  border: 1px solid color-mix(in oklab, var(--danger) 25%, var(--line));
-  background: color-mix(in oklab, var(--danger) 4%, var(--bg-2));
+  border: 1px solid color-mix(in oklab, var(--danger) 55%, var(--line));
+  background: color-mix(in oklab, var(--danger) 8%, var(--bg-2));
   border-radius: 10px; overflow: hidden; margin-bottom: 18px;
 }
-.edit-danger-zone .edit-card-head { border-bottom: 1px solid color-mix(in oklab, var(--danger) 25%, var(--line)); }
+.edit-danger-zone .edit-card-head {
+  background: color-mix(in oklab, var(--danger) 14%, var(--bg-2));
+  border-bottom: 1px solid color-mix(in oklab, var(--danger) 45%, var(--line));
+  color: var(--danger);
+}
+.edit-danger-zone .edit-card-head .edit-card-step { color: var(--danger); }
 .edit-dz-row {
   display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: center;
   padding: 14px 18px;
 }
-.edit-dz-title { font-weight: 600; font-size: 14px; margin-bottom: 2px; }
-.edit-dz-sub { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
+.edit-dz-title { font-weight: 600; font-size: 14px; margin-bottom: 2px; color: var(--danger); }
+.edit-dz-sub { font-family: var(--mono); font-size: 11px; color: color-mix(in oklab, var(--danger) 40%, var(--fg-2)); }
+.btn.danger {
+  background: var(--danger); color: var(--danger-ink);
+  border-color: var(--danger); font-weight: 500;
+}
+.btn.danger:hover { background: color-mix(in oklab, var(--danger) 88%, white); }
 
 /* Sidebar */
 .edit-side { position: sticky; top: 100px; align-self: start; }
@@ -2436,14 +2474,16 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .edit-act-text { font-size: 13px; color: var(--fg-2); }
 .edit-act-time { font-family: var(--mono); font-size: 10px; color: var(--fg-4); margin-top: 2px; }
 
-/* Sticky save bar */
+/* Fixed save bar — spans full viewport, content centered to wrap */
 .edit-save-bar {
-  position: sticky; bottom: 0; z-index: 30;
-  margin: 0 calc(-1 * var(--pad));
-  padding: 14px var(--pad);
-  background: color-mix(in oklab, var(--bg-2) 96%, transparent);
+  position: fixed; bottom: 0; left: 0; right: 0; z-index: 30;
+  background: color-mix(in oklab, var(--bg-2) 92%, transparent);
   backdrop-filter: blur(10px);
   border-top: 1px solid var(--line-2);
+  box-shadow: 0 -8px 24px rgba(0,0,0,.25);
+}
+.edit-save-bar-inner {
+  padding-top: 14px; padding-bottom: 14px;
   display: flex; align-items: center; gap: 14px;
 }
 .edit-sb-status { display: flex; align-items: center; gap: 8px; font-family: var(--mono); font-size: 12px; }
@@ -2462,15 +2502,11 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   font-size: 18px; font-weight: 700; letter-spacing: -0.02em; margin: 0;
 }
 .sec-h2 em { font-style: normal; color: var(--accent); }
+.sec-h2-link { text-decoration: none; border-bottom: 1px dashed color-mix(in oklab, var(--accent) 50%, transparent); transition: border-color .15s; }
+.sec-h2-link:hover { border-bottom-color: var(--accent); }
 .sec-count {
   font-family: var(--mono); font-size: 11px; color: var(--fg-4);
 }
-.all-link {
-  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
-  transition: color .15s;
-}
-.all-link:hover { color: var(--accent); }
-
 .rail {
   display: grid;
   grid-auto-flow: column;


### PR DESCRIPTION
## Summary

Thirteen small UI fixes across the catalog, detail, submit, and edit pages.

### Submit page
- Drop the subtitle row on the three submission tabs and the descriptive paragraph under each "Submit an X." heading.
- Drop the "Official upload preferred…" hint under the YouTube URL field.
- Wire anime/singer covers through the autocomplete: rows and the selected pill now render an image (square for anime, circle for singer).

### Home
- Drop the "OP · INTRO · ~90s"-style subtitles on the Openings/Endings/OSTs catalog tabs.

### Anime detail
- Cards now render real YouTube thumbnails; the hatched `p-N` pattern is only the fallback when no video ID is parseable.
- Default sort is `top` instead of `sequence`.

### Singer detail
- Replace the bespoke flat list with the same `op-card` grid the anime page uses. Default sort is `top` to match.

### Opening detail
- "More from {anime}" / "More from {singer}" headings are now the links (dashed-underline indicator). Removed the redundant "Anime page →" / "Singer page →" links.

### Opening edit (admin)
- Fix the preview iframe bleeding into the title/anime/score column: pin the iframe inside a `position: relative` thumb and switch the strip to `align-items: start`.
- Attribution avatars: SSR fetches anime + singer details to seed cover URLs; the search results also carry `cover_image_url` through. `RelationPicker` renders the image in the chip and dropdown.
- Replace the full-width "Editing as admin" rolebar (which was visibly cut off at the wrap edges) with a compact "Admin · Editing" pill in the heading eyebrow alongside the mod-queue link.
- Save bar is now `position: fixed` and spans the viewport, with content centered to the wrap — no more mid-page cut.
- Define `--danger` / `--danger-ink` and style the danger zone red (border, header, text) plus a `.btn.danger` style for the delete CTA.

## Test plan
- [ ] Home page — kind tabs render without sub-text under "Openings / Endings / OSTs".
- [ ] Submit page — tabs and form headers show no subtitle copy; YouTube URL hint is gone.
- [ ] Submit page — search "anime" / "singer" in the picker and confirm covers render in the dropdown rows and the selected pill.
- [ ] Anime detail — confirm card grid shows real YouTube thumbnails and default sort is "Top rated".
- [ ] Singer detail — confirm cards use the same layout as the anime page and default sort is "Top rated".
- [ ] Opening detail — confirm the anime/singer names in the "More from" headings link to their pages and have a dashed underline; the "Anime page → / Singer page →" links are gone.
- [ ] Opening edit (as admin) — confirm:
  - The admin role bar is replaced with a compact pill in the heading.
  - The preview iframe stays inside its thumb cell and doesn't overlap title/anime/score.
  - The attribution rows show anime/singer covers.
  - The danger zone reads as red (border, header, text, button).
  - The "Unsaved changes" save bar spans the full viewport width.