### PR TITLE
fix: kind bucketing, compact rail card, mobile portrait

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -65,13 +65,27 @@ function getCsrfTokenFromCookieHeader(cookieHeader?: string): string | null {
   return null;
 }
 
+const VALID_KINDS = new Set(["opening", "ending", "ost"]);
+
+function normalizeKind(value: unknown): "opening" | "ending" | "ost" {
+  if (typeof value === "string") {
+    const lower = value.toLowerCase();
+    if (VALID_KINDS.has(lower)) return lower as "opening" | "ending" | "ost";
+  }
+  return "opening";
+}
+
 function normalizeOpening(opening: any): Opening {
   return {
     ...opening,
-    kind: opening.kind ?? "opening",
+    kind: normalizeKind(opening.kind),
     status: opening.status ?? "approved",
     submitted_at: opening.submitted_at ?? opening.approved_at ?? new Date(0).toISOString(),
   };
+}
+
+function normalizeNestedOpening<T extends { kind?: unknown }>(item: T): T & { kind: "opening" | "ending" | "ost" } {
+  return { ...item, kind: normalizeKind(item.kind) };
 }
 
 async function apiFetch<T>(path: string, opts: FetchOpts = {}): Promise<T> {
@@ -170,11 +184,17 @@ export function getOpening(id: string, cookie?: string): Promise<Opening> {
 }
 
 export function getAnime(id: string, cookie?: string): Promise<AnimeDetail> {
-  return apiFetchData<AnimeDetail>(`/anime/${encodeURIComponent(id)}`, { cookie });
+  return apiFetchData<AnimeDetail>(`/anime/${encodeURIComponent(id)}`, { cookie }).then((d) => ({
+    ...d,
+    openings: (d.openings ?? []).map(normalizeNestedOpening),
+  }));
 }
 
 export function getSinger(id: string, cookie?: string): Promise<SingerDetail> {
-  return apiFetchData<SingerDetail>(`/singers/${encodeURIComponent(id)}`, { cookie });
+  return apiFetchData<SingerDetail>(`/singers/${encodeURIComponent(id)}`, { cookie }).then((d) => ({
+    ...d,
+    openings: (d.openings ?? []).map(normalizeNestedOpening),
+  }));
 }
 
 export interface SearchParams {

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -37,15 +37,21 @@ const FORMAT_LABEL: Record<string, string> = {
   special: "Special",
 };
 
+function kindTag(kind: TrackKind): "OP" | "ED" | "OST" {
+  if (kind === "ending") return "ED";
+  if (kind === "ost") return "OST";
+  return "OP";
+}
+
 function kindLabel(op: AnimeOpening): string {
-  const tag = op.kind === "opening" ? "OP" : op.kind === "ending" ? "ED" : "OST";
+  const tag = kindTag(op.kind);
   return op.sequence_number != null ? `${tag} ${op.sequence_number}` : tag;
 }
 
-function kindClass(kind: TrackKind): string {
-  if (kind === "opening") return "op";
+function kindClass(kind: TrackKind): "op" | "ed" | "ost" {
   if (kind === "ending") return "ed";
-  return "ost";
+  if (kind === "ost") return "ost";
+  return "op";
 }
 
 // ---------------------------------------------------------------------------

--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -305,13 +305,14 @@ function Rail({
               })()}
               <div className="rail-meta">
                 <div className="rail-title">{item.title}</div>
-                <div className="rail-sub">{item.subtitle}</div>
-                {item.rating_count > 0 && (
-                  <div className="rail-rating">
-                    {item.avg_rating.toFixed(1)}<em>/10</em>
-                    <span className="rail-ct">{item.rating_count}</span>
-                  </div>
-                )}
+                <div className="rail-sub-row">
+                  <span className="rail-sub">{item.subtitle}</span>
+                  {item.rating_count > 0 && (
+                    <span className="rail-rating">
+                      {item.avg_rating.toFixed(1)}<em>/10</em>
+                    </span>
+                  )}
+                </div>
               </div>
             </Link>
           );

--- a/pages/singers/[id].tsx
+++ b/pages/singers/[id].tsx
@@ -29,15 +29,21 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+function kindTag(kind: TrackKind): "OP" | "ED" | "OST" {
+  if (kind === "ending") return "ED";
+  if (kind === "ost") return "OST";
+  return "OP";
+}
+
 function kindLabel(op: SingerOpening): string {
-  const tag = op.kind === "opening" ? "OP" : op.kind === "ending" ? "ED" : "OST";
+  const tag = kindTag(op.kind);
   return op.sequence_number != null ? `${tag} ${op.sequence_number}` : tag;
 }
 
-function kindClass(kind: TrackKind): string {
-  if (kind === "opening") return "op";
+function kindClass(kind: TrackKind): "op" | "ed" | "ost" {
   if (kind === "ending") return "ed";
-  return "ost";
+  if (kind === "ost") return "ost";
+  return "op";
 }
 
 const TYPE_LABEL: Record<string, string> = {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2171,7 +2171,7 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   border-bottom: 1px solid var(--line);
 }
 .singer-portrait {
-  width: 180px; height: 180px; border-radius: 50%;
+  width: 100%; aspect-ratio: 1/1; border-radius: 50%;
   border: 1px solid var(--line-2); background: var(--bg-2);
   background-image: repeating-linear-gradient(60deg, #1a1628 0 12px, #2a2240 12px 13px);
   overflow: hidden; display: grid; place-items: center;
@@ -2564,19 +2564,22 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 }
 .rail-card:hover .rail-play { opacity: 1; }
 
-.rail-meta { display: flex; flex-direction: column; gap: 3px; }
+.rail-meta { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .rail-title {
   font-size: 13px; font-weight: 600; color: var(--fg);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .current-card .rail-title { color: var(--accent); }
+.rail-sub-row {
+  display: flex; align-items: baseline; gap: 8px; min-width: 0;
+}
 .rail-sub {
   font-family: var(--mono); font-size: 11px; color: var(--fg-3);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  flex: 1; min-width: 0;
 }
 .rail-rating {
-  font-family: var(--mono); font-size: 12px; color: var(--fg-2); font-weight: 600;
-  display: flex; align-items: baseline; gap: 6px; margin-top: 2px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-2); font-weight: 600;
+  flex-shrink: 0;
 }
-.rail-rating em { font-style: normal; font-size: 10px; color: var(--fg-4); }
-.rail-ct { font-size: 10px; color: var(--fg-4); }
+.rail-rating em { font-style: normal; font-size: 10px; color: var(--fg-4); margin-left: 1px; }


### PR DESCRIPTION
## Summary

Three small fixes spotted on the singer page + opening detail.

### 1. Singer page bucketed openings into the wrong type
- `kindLabel` / `kindClass` on the singer (and anime) detail page fell through to **"OST" / "ost"** whenever `op.kind` was anything unexpected. They now default to **"OP" / "op"** (matches the DB default).
- Hardened the API client too: a new `normalizeKind()` lowercases + validates the incoming value, and `getAnime` / `getSinger` run every nested opening through it. The per-tab counts can no longer drift if the backend ever sends back a stray null or differently cased value.

### 2. "More from …" rail card was too tall
- Collapsed the three stacked rows (title / subtitle / rating) into two: title on its own line, then **subtitle + rating** sharing a baseline row, with the rating pinned to the right.

### 3. Singer portrait overflowed text on mobile
- `.singer-portrait` had a fixed `180×180`. Below `768px` the grid column shrinks to `120px` but the portrait stayed at 180, bleeding into the text column. Changed to `width: 100%` + `aspect-ratio: 1/1` so it always fits its grid track.

## Test plan
- [ ] Visit a singer detail page — confirm openings sit under the **right** tab (an opening shows "OP", not "OST"), and the OP / ED / OST tag colors are correct.
- [ ] Visit an opening detail page — confirm the "More from {anime}" / "More from {singer}" cards are visibly shorter, with the rating on the same line as the anime/singer name.
- [ ] Open the singer page on a phone (or DevTools narrow viewport) — confirm the portrait stays inside its column and the eyebrow / title / native name are not covered by it.