### PR TITLE
fix: richer moderation cards, mobile rail scroll, approval-gate UX

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -269,10 +269,17 @@ export interface ModerationItem {
   // Set when type === "opening"
   title?: string;
   youtube_url?: string;
+  kind?: TrackKind;
   anime_name?: string;
   singer_name?: string;
   // Set when type === "anime" | "singer"
   name?: string;
+  cover_image_url?: string | null;
+  // Set when type === "anime"
+  year?: number;
+  format?: AnimeFormat;
+  // Set when type === "singer"
+  singer_type?: SingerType;
 }
 
 export interface ModerationQueuePage {

--- a/pages/mod/queue.tsx
+++ b/pages/mod/queue.tsx
@@ -97,16 +97,42 @@ function formatDate(iso: string): string {
   });
 }
 
+const KIND_BADGE: Record<string, string> = {
+  opening: "OP",
+  ending: "ED",
+  ost: "OST",
+};
+
+const FORMAT_LABEL: Record<string, string> = {
+  tv: "TV series",
+  film: "Film",
+  ova_ona: "OVA / ONA",
+  special: "Special",
+};
+
+const SINGER_TYPE_LABEL: Record<string, string> = {
+  solo: "Solo artist",
+  band: "Band",
+  idol_group: "Idol group",
+  vocaloid_producer: "Vocaloid producer",
+  composer: "Composer",
+  other: "Other",
+};
+
 function ItemCard({ item }: { item: ModerationItem }) {
   const isOpening = item.type === "opening";
-  const thumb = isOpening && item.youtube_url ? youtubeThumbnail(item.youtube_url) : null;
+  const isAnime = item.type === "anime";
+  const isSinger = item.type === "singer";
+  const thumb = isOpening && item.youtube_url
+    ? youtubeThumbnail(item.youtube_url)
+    : item.cover_image_url ?? null;
   const title = isOpening ? item.title : item.name;
+  const thumbShape = isSinger ? "circle" : isAnime ? "poster" : "video";
 
   return (
     <li className="mod-card">
-      {/* Left: visual — YouTube thumbnail for openings, fallback tile for
-          anime/singer (cover images aren't sent in the queue payload). */}
-      <div className="mod-card-thumb" aria-hidden>
+      {/* Left: visual — YouTube thumbnail for openings, cover for anime/singer. */}
+      <div className={`mod-card-thumb mod-card-thumb-${thumbShape}`} aria-hidden>
         {thumb ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img src={thumb} alt="" loading="lazy" />
@@ -115,7 +141,9 @@ function ItemCard({ item }: { item: ModerationItem }) {
             {(title ?? item.type).slice(0, 2).toUpperCase()}
           </span>
         )}
-        <span className={`mod-card-pill mod-card-pill-${item.type}`}>{item.type}</span>
+        <span className={`mod-card-pill mod-card-pill-${item.type}`}>
+          {isOpening && item.kind ? KIND_BADGE[item.kind] ?? item.type : item.type}
+        </span>
       </div>
 
       {/* Right: meta + actions */}
@@ -132,6 +160,31 @@ function ItemCard({ item }: { item: ModerationItem }) {
             <span className="mod-card-sep">·</span>
             <span className="mod-card-meta-k">Singer</span>
             <span className="mod-card-meta-v">{item.singer_name ?? "—"}</span>
+          </p>
+        )}
+
+        {isAnime && (
+          <p className="mod-card-meta">
+            {item.year != null && (
+              <>
+                <span className="mod-card-meta-k">Year</span>
+                <span className="mod-card-meta-v">{item.year}</span>
+              </>
+            )}
+            {item.format && (
+              <>
+                <span className="mod-card-sep">·</span>
+                <span className="mod-card-meta-k">Format</span>
+                <span className="mod-card-meta-v">{FORMAT_LABEL[item.format] ?? item.format}</span>
+              </>
+            )}
+          </p>
+        )}
+
+        {isSinger && item.singer_type && (
+          <p className="mod-card-meta">
+            <span className="mod-card-meta-k">Type</span>
+            <span className="mod-card-meta-v">{SINGER_TYPE_LABEL[item.singer_type] ?? item.singer_type}</span>
           </p>
         )}
 

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -270,8 +270,12 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
 
     if (!res.ok) {
       const payload = await res.json().catch(() => ({}));
-      setError(payload.error ?? "Submission failed");
-      if (payload.fields) setFieldErrors(payload.fields);
+      const err = payload.error;
+      const message = typeof err === "string"
+        ? err
+        : (err?.message ?? "Submission failed");
+      setError(message);
+      if (err?.fields) setFieldErrors(err.fields);
       return;
     }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -712,9 +712,10 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 
 /* Main grid */
 .detail-grid {
-  display: grid; grid-template-columns: 1fr 300px; gap: 40px;
+  display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 40px;
   padding: 24px 0 40px;
 }
+.detail-grid > * { min-width: 0; }
 
 /* Video */
 .detail-video {
@@ -1871,28 +1872,31 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 }
 
 .mod-card {
-  display: grid; grid-template-columns: 200px 1fr; gap: 20px;
-  padding: 16px;
-  border: 1px solid var(--line); border-radius: 12px;
+  display: grid; grid-template-columns: 160px 1fr; gap: 16px;
+  padding: 14px;
+  border: 1px solid var(--line); border-radius: 10px;
   background: var(--bg-2);
-  transition: border-color .15s, transform .15s, box-shadow .15s;
+  transition: border-color .15s, box-shadow .15s;
 }
 .mod-card:hover {
   border-color: var(--line-2);
-  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
 }
 
 .mod-card-thumb {
   position: relative;
-  aspect-ratio: 16 / 9;
-  border-radius: 8px; overflow: hidden;
+  border-radius: 6px; overflow: hidden;
   border: 1px solid var(--line);
   background: var(--bg-3);
   display: grid; place-items: center;
+  align-self: start;
 }
+.mod-card-thumb-video { aspect-ratio: 16 / 9; }
+.mod-card-thumb-poster { aspect-ratio: 2 / 3; max-width: 110px; justify-self: start; }
+.mod-card-thumb-circle { aspect-ratio: 1 / 1; max-width: 110px; border-radius: 50%; justify-self: start; }
 .mod-card-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .mod-card-thumb-fallback {
-  font-family: var(--sans); font-weight: 800; font-size: 32px;
+  font-family: var(--sans); font-weight: 800; font-size: 28px;
   letter-spacing: -0.02em; color: var(--fg-4);
 }
 .mod-card-pill {
@@ -1908,12 +1912,12 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .mod-card-pill-anime   { color: #6fe89a;       border-color: #6fe89a; }
 .mod-card-pill-singer  { color: #ffb547;       border-color: #ffb547; }
 
-.mod-card-body { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+.mod-card-body { display: flex; flex-direction: column; gap: 6px; min-width: 0; }
 .mod-card-head {
   display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
 }
 .mod-card-title {
-  margin: 0; font-size: 18px; font-weight: 700;
+  margin: 0; font-size: 16px; font-weight: 700;
   letter-spacing: -0.01em; color: var(--fg);
   line-height: 1.25;
 }
@@ -1939,9 +1943,9 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .mod-card-link:hover { text-decoration: underline; }
 
 .mod-card-actions {
-  display: flex; flex-wrap: wrap; gap: 12px;
+  display: flex; flex-wrap: wrap; gap: 10px;
   margin-top: auto;
-  padding-top: 12px; border-top: 1px solid var(--line);
+  padding-top: 10px; border-top: 1px solid var(--line);
 }
 .mod-form { display: inline-flex; gap: 6px; align-items: stretch; }
 .mod-form-reject { flex: 1; min-width: 240px; }
@@ -2494,7 +2498,10 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 /* ---------------------------------------------------------------------------
    Opening detail — "More from" rails
    --------------------------------------------------------------------------- */
-.rail-section { margin-top: 48px; }
+.rail-section { margin-top: 48px; min-width: 0; }
+@media (max-width: 600px) {
+  .rail { grid-auto-columns: 220px; scroll-snap-type: x proximity; }
+}
 .sec-head {
   display: flex; align-items: baseline; gap: 10px; margin-bottom: 16px;
 }


### PR DESCRIPTION
## Summary

Four frontend fixes (one of them paired with the backend PR in [openingwiki/backend#17](https://github.com/openingwiki/backend/pull/17)).

> The backend PR must merge first — the new fields and behaviors below depend on its payload changes.

### 1. Moderation cards
- Thumb is now type-shaped: **16/9 video** for openings, **2/3 poster** for anime, **1/1 circle** for singers. Anime/singer covers render from the new `cover_image_url` field in the queue payload.
- Opening pills now show **OP / ED / OST** when the payload includes `kind`.
- Anime cards surface **year + format**; singer cards surface **type** (solo / band / idol_group / vocaloid_producer / composer / other).
- Card visually tightened — 160px thumb, 16px title, 6px body gap — so a short queue doesn't waste vertical space.

### 2. Mobile "More from" rail
- `.detail-grid` is now `minmax(0, 1fr) 300px` with `min-width: 0` on all grid children, so the rail scrolls **horizontally inside its column** instead of pushing the page wider than the viewport. On viewports <600px, rail cards shrink to 220px and scroll-snap softens to `proximity` for better touch feel.

### 3 & 4. Submit-page UX
- The autocomplete now renders real anime/singer covers (the picker already supported this; backend now provides the payload).
- Error rendering: `payload.error` is the envelope object, not a string. We now read `payload.error.message`, so the new backend `pending_entity` 422 displays as readable text instead of `[object Object]`.

### Types
- `ModerationItem` extended with `kind`, `cover_image_url`, `year`, `format`, `singer_type` to match the new payload.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] Manual (after backend PR is deployed):
  - [ ] Visit `/mod/queue?type=anime` and `/mod/queue?type=singer` — confirm cards show covers, year/format, and singer type.
  - [ ] Visit `/mod/queue?type=opening` — confirm opening pill shows OP/ED/OST.
  - [ ] Open an opening detail page in a narrow viewport with many "More from" entries — the page should NOT scroll horizontally; the rails should scroll within their column.
  - [ ] Open `/submit`, search for an anime/singer — confirm avatars render in the dropdown row and selected pill.
  - [ ] Try to submit an opening referencing a pending anime — confirm a clear error message renders.