### PR TITLE
feat: render every submission field on the moderation card

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -266,20 +266,38 @@ export interface ModerationItem {
   status: SubmissionStatus;
   submitted_at: string;
   submitted_by: ModerationSubmitter | null;
+  notes_for_moderator?: string | null;
+
   // Set when type === "opening"
   title?: string;
   youtube_url?: string;
   kind?: TrackKind;
+  sequence_number?: number | null;
+  anime?: { id: string; name: string };
+  singer?: { id: string; name: string };
+  // Flat aliases kept for backwards compatibility with older clients.
   anime_name?: string;
   singer_name?: string;
+
   // Set when type === "anime" | "singer"
   name?: string;
   cover_image_url?: string | null;
+  reference_url?: string;
+
   // Set when type === "anime"
+  title_romaji?: string;
+  title_english?: string | null;
+  title_native?: string | null;
   year?: number;
   format?: AnimeFormat;
+  episodes?: number | null;
+  studio?: string | null;
+
   // Set when type === "singer"
+  name_native?: string | null;
   singer_type?: SingerType;
+  active_since?: number | null;
+  bio?: string | null;
 }
 
 export interface ModerationQueuePage {

--- a/pages/mod/queue.tsx
+++ b/pages/mod/queue.tsx
@@ -119,6 +119,15 @@ const SINGER_TYPE_LABEL: Record<string, string> = {
   other: "Other",
 };
 
+function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="mod-card-row">
+      <span className="mod-card-row-k">{label}</span>
+      <span className="mod-card-row-v">{value}</span>
+    </div>
+  );
+}
+
 function ItemCard({ item }: { item: ModerationItem }) {
   const isOpening = item.type === "opening";
   const isAnime = item.type === "anime";
@@ -128,6 +137,11 @@ function ItemCard({ item }: { item: ModerationItem }) {
     : item.cover_image_url ?? null;
   const title = isOpening ? item.title : item.name;
   const thumbShape = isSinger ? "circle" : isAnime ? "poster" : "video";
+
+  const animeName = item.anime?.name ?? item.anime_name;
+  const animeId = item.anime?.id;
+  const singerName = item.singer?.name ?? item.singer_name;
+  const singerId = item.singer?.id;
 
   return (
     <li className="mod-card">
@@ -154,38 +168,88 @@ function ItemCard({ item }: { item: ModerationItem }) {
         </div>
 
         {isOpening && (
-          <p className="mod-card-meta">
-            <span className="mod-card-meta-k">Anime</span>
-            <span className="mod-card-meta-v">{item.anime_name ?? "—"}</span>
-            <span className="mod-card-sep">·</span>
-            <span className="mod-card-meta-k">Singer</span>
-            <span className="mod-card-meta-v">{item.singer_name ?? "—"}</span>
-          </p>
+          <div className="mod-card-rows">
+            <DetailRow
+              label="Anime"
+              value={animeId ? (
+                <Link href={`/anime/${animeId}`} target="_blank" rel="noreferrer">{animeName ?? "—"}</Link>
+              ) : (animeName ?? "—")}
+            />
+            <DetailRow
+              label="Singer"
+              value={singerId ? (
+                <Link href={`/singers/${singerId}`} target="_blank" rel="noreferrer">{singerName ?? "—"}</Link>
+              ) : (singerName ?? "—")}
+            />
+            <DetailRow label="Kind" value={(item.kind ?? "opening").toUpperCase()} />
+            {item.sequence_number != null && (
+              <DetailRow label="Sequence #" value={item.sequence_number} />
+            )}
+            {item.youtube_url && (
+              <DetailRow
+                label="YouTube"
+                value={
+                  <a href={item.youtube_url} target="_blank" rel="noopener noreferrer">
+                    ↗ Open video
+                  </a>
+                }
+              />
+            )}
+          </div>
         )}
 
         {isAnime && (
-          <p className="mod-card-meta">
-            {item.year != null && (
-              <>
-                <span className="mod-card-meta-k">Year</span>
-                <span className="mod-card-meta-v">{item.year}</span>
-              </>
-            )}
+          <div className="mod-card-rows">
+            {item.title_romaji && <DetailRow label="Romaji" value={item.title_romaji} />}
+            {item.title_english && <DetailRow label="English" value={item.title_english} />}
+            {item.title_native && <DetailRow label="Native" value={item.title_native} />}
+            {item.year != null && <DetailRow label="Year" value={item.year} />}
             {item.format && (
-              <>
-                <span className="mod-card-sep">·</span>
-                <span className="mod-card-meta-k">Format</span>
-                <span className="mod-card-meta-v">{FORMAT_LABEL[item.format] ?? item.format}</span>
-              </>
+              <DetailRow label="Format" value={FORMAT_LABEL[item.format] ?? item.format} />
             )}
-          </p>
+            {item.episodes != null && <DetailRow label="Episodes" value={item.episodes} />}
+            {item.studio && <DetailRow label="Studio" value={item.studio} />}
+            {item.reference_url && (
+              <DetailRow
+                label="Reference"
+                value={
+                  <a href={item.reference_url} target="_blank" rel="noopener noreferrer">
+                    ↗ {item.reference_url}
+                  </a>
+                }
+              />
+            )}
+          </div>
         )}
 
-        {isSinger && item.singer_type && (
-          <p className="mod-card-meta">
-            <span className="mod-card-meta-k">Type</span>
-            <span className="mod-card-meta-v">{SINGER_TYPE_LABEL[item.singer_type] ?? item.singer_type}</span>
-          </p>
+        {isSinger && (
+          <div className="mod-card-rows">
+            {item.name_native && <DetailRow label="Native" value={item.name_native} />}
+            {item.singer_type && (
+              <DetailRow label="Type" value={SINGER_TYPE_LABEL[item.singer_type] ?? item.singer_type} />
+            )}
+            {item.active_since != null && (
+              <DetailRow label="Active since" value={item.active_since} />
+            )}
+            {item.bio && <DetailRow label="Bio" value={<span className="mod-card-bio">{item.bio}</span>} />}
+            {item.reference_url && (
+              <DetailRow
+                label="Reference"
+                value={
+                  <a href={item.reference_url} target="_blank" rel="noopener noreferrer">
+                    ↗ {item.reference_url}
+                  </a>
+                }
+              />
+            )}
+          </div>
+        )}
+
+        {item.notes_for_moderator && (
+          <div className="mod-card-notes">
+            <span className="mod-card-notes-k">Note to moderator</span>
+            <p className="mod-card-notes-v">{item.notes_for_moderator}</p>
+          </div>
         )}
 
         <p className="mod-card-by">
@@ -197,17 +261,6 @@ function ItemCard({ item }: { item: ModerationItem }) {
             <em>Submitted by unknown user</em>
           )}
         </p>
-
-        {isOpening && item.youtube_url && (
-          <a
-            className="mod-card-link"
-            href={item.youtube_url}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ↗ Open video on YouTube
-          </a>
-        )}
 
         <div className="mod-card-actions">
           <form action="/api/mod/decide" method="post" className="mod-form">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1932,6 +1932,46 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .mod-card-meta-v { color: var(--fg-2); }
 .mod-card-sep    { color: var(--fg-4); }
 
+/* Detail-row table for the expanded moderation card */
+.mod-card-rows {
+  display: grid; grid-template-columns: 100px 1fr; gap: 4px 14px;
+  margin: 4px 0 2px;
+  font-family: var(--mono); font-size: 12px;
+  word-break: break-word;
+}
+.mod-card-row { display: contents; }
+.mod-card-row-k {
+  color: var(--fg-4); text-transform: uppercase; letter-spacing: 0.08em;
+  font-size: 10px; padding-top: 2px;
+}
+.mod-card-row-v { color: var(--fg-2); min-width: 0; }
+.mod-card-row-v a { color: var(--accent); }
+.mod-card-row-v a:hover { text-decoration: underline; }
+.mod-card-bio {
+  display: block; color: var(--fg-2); font-family: var(--sans);
+  font-size: 13px; line-height: 1.45; white-space: pre-wrap;
+}
+
+.mod-card-notes {
+  margin-top: 2px; padding: 8px 10px;
+  border: 1px dashed var(--line-2); border-radius: 6px;
+  background: color-mix(in oklab, var(--warn) 5%, var(--bg-3));
+}
+.mod-card-notes-k {
+  display: block; font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--warn);
+  margin-bottom: 4px;
+}
+.mod-card-notes-v {
+  margin: 0; font-family: var(--sans); font-size: 13px; line-height: 1.45;
+  color: var(--fg); white-space: pre-wrap; word-break: break-word;
+}
+
+@media (max-width: 600px) {
+  .mod-card-rows { grid-template-columns: 1fr; gap: 0 0; }
+  .mod-card-row-k { margin-top: 6px; }
+}
+
 .mod-card-by { margin: 0; font-family: var(--mono); font-size: 11px; color: var(--fg-4); }
 .mod-card-by strong { color: var(--fg-3); font-weight: 600; }
 


### PR DESCRIPTION
## Summary

Paired with [openingwiki/backend#18](https://github.com/openingwiki/backend/pull/18). The queue now returns the entire submission record per row, so the card shows it all.

> Merge the backend PR first — these UI changes assume the new payload shape.

### What the card now shows

**Opening rows**
- Anime + Singer **linked** to their catalog pages (open in new tab) — moderators can verify the picker chose the right entity.
- Kind (OP / ED / OST), sequence number, YouTube link.
- "Note to moderator" call-out box (warn-tinted) if present.

**Anime rows**
- Cover (2/3 poster), all three titles (romaji / english / native), year, format, episodes, studio, reference URL (clickable), moderator note.

**Singer rows**
- Cover (1/1 circle), native name, type, active since, full bio, reference URL (clickable), moderator note.

### Implementation
- `ModerationItem` mirrors the new backend shape (every optional field is properly typed as `string | null` / `number | null` etc.).
- Card body rebuilt around a tiny `DetailRow` component → label + value laid out in a two-column grid. Collapses to a single column under 600px so it stays readable on mobile.
- Notes get their own dashed, warn-tinted box; long bios wrap with `white-space: pre-wrap`.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] Manual (after backend deploys): submit an anime with every optional field filled, open `/mod/queue?type=anime`, confirm all of them render.
- [ ] Manual: same for singers (especially long bio + active_since + native name).
- [ ] Manual: open an opening queue card, click the anime / singer name — confirm it opens the catalog page in a new tab.
- [ ] Manual: viewport <600px — confirm the detail rows collapse to a single column.