### PR TITLE
fix: dropdown clipping, queue tab counts, strip optional form fields

### DIFF
--- a/pages/mod/queue.tsx
+++ b/pages/mod/queue.tsx
@@ -15,6 +15,7 @@ interface Props {
   type: ModerationItemType;
   items: ModerationItem[];
   total: number;
+  totalsByType: Record<ModerationItemType, number>;
   page: number;
   perPage: number;
   hasNext: boolean;
@@ -50,13 +51,29 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   let hasNext = false;
   let perPage = 20;
   let apiOnline = true;
+  const totalsByType: Record<ModerationItemType, number> = {
+    opening: 0,
+    anime: 0,
+    singer: 0,
+  };
 
   try {
-    const res = await listModerationQueue({ type, page, cookie: session.cookie });
-    items = res.items as ModerationItem[];
-    total = res.total;
-    perPage = res.per_page;
-    hasNext = res.has_next;
+    // Active type — full page of items. Other types — pageSize=1 so we only
+    // need the total count for the tab badge, not the rows themselves.
+    const fetches = TYPES.map(async (t) => {
+      if (t === type) {
+        const res = await listModerationQueue({ type: t, page, cookie: session.cookie });
+        items = res.items as ModerationItem[];
+        total = res.total;
+        perPage = res.per_page;
+        hasNext = res.has_next;
+        totalsByType[t] = res.total;
+      } else {
+        const res = await listModerationQueue({ type: t, page: 1, pageSize: 1, cookie: session.cookie });
+        totalsByType[t] = res.total;
+      }
+    });
+    await Promise.all(fetches);
   } catch {
     apiOnline = false;
   }
@@ -76,6 +93,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
       type,
       items,
       total,
+      totalsByType,
       page,
       perPage,
       hasNext,
@@ -295,6 +313,7 @@ export default function ModQueuePage({
   type,
   items,
   total,
+  totalsByType,
   page,
   hasNext,
   apiOnline,
@@ -334,15 +353,19 @@ export default function ModQueuePage({
         </header>
 
         <nav className="mod-tabs">
-          {TYPES.map((t) => (
-            <Link
-              key={t}
-              href={`/mod/queue?type=${t}`}
-              className={`mod-tab${type === t ? " on" : ""}`}
-            >
-              {TYPE_LABEL[t]}
-            </Link>
-          ))}
+          {TYPES.map((t) => {
+            const count = totalsByType[t] ?? 0;
+            return (
+              <Link
+                key={t}
+                href={`/mod/queue?type=${t}`}
+                className={`mod-tab${type === t ? " on" : ""}`}
+              >
+                <span>{TYPE_LABEL[t]}</span>
+                <span className={`mod-tab-count${count > 0 ? " on" : ""}`}>{count}</span>
+              </Link>
+            );
+          })}
         </nav>
 
         {!apiOnline ? (

--- a/pages/openings/[id]/edit.tsx
+++ b/pages/openings/[id]/edit.tsx
@@ -184,7 +184,6 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
   const [kind, setKind] = useState<TrackKind>(opening.kind);
   const [anime, setAnime] = useState<EntityItem>({ id: opening.anime.id, name: opening.anime.name, coverUrl: animeCoverUrl });
   const [singer, setSinger] = useState<EntityItem>({ id: opening.singer.id, name: opening.singer.name, coverUrl: singerCoverUrl });
-  const [notes, setNotes] = useState(opening.notes_for_moderator ?? "");
 
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
@@ -195,8 +194,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
     youtubeUrl !== opening.youtube_url ||
     kind !== opening.kind ||
     anime.id !== opening.anime.id ||
-    singer.id !== opening.singer.id ||
-    notes !== (opening.notes_for_moderator ?? "");
+    singer.id !== opening.singer.id;
 
   // Esc closes delete confirm
   useEffect(() => {
@@ -220,7 +218,6 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
           kind,
           anime_id: anime.id,
           singer_id: singer.id,
-          notes_for_moderator: notes || null,
         }),
       });
       if (!res.ok && res.status !== 204) {
@@ -420,7 +417,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
             </div>
 
             {/* 03 Attribution */}
-            <div className="edit-card">
+            <div className="edit-card edit-card-pop">
               <div className="edit-card-head"><span className="edit-card-step">03</span> Attribution</div>
               <div className="edit-card-body edit-attr-grid">
                 <RelationPicker
@@ -434,22 +431,6 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
                   kind="singer"
                   value={singer}
                   onChange={setSinger}
-                />
-              </div>
-            </div>
-
-            {/* 04 Notes */}
-            <div className="edit-card">
-              <div className="edit-card-head">
-                <span className="edit-card-step">04</span> Notes
-                <span className="edit-card-meta" style={{ marginLeft: 8 }}>internal · not shown publicly</span>
-              </div>
-              <div className="edit-card-body">
-                <textarea
-                  className="edit-textarea"
-                  placeholder="Mod notes about this entry…"
-                  value={notes}
-                  onChange={(e) => setNotes(e.target.value)}
                 />
               </div>
             </div>

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -232,7 +232,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
   const [youtubeUrl, setYoutubeUrl] = useState("");
   const [selectedAnime, setSelectedAnime] = useState<AutocompleteItem | null>(null);
   const [selectedSinger, setSelectedSinger] = useState<AutocompleteItem | null>(null);
-  const [notes, setNotes] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -262,7 +261,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
         kind,
         anime_id: selectedAnime!.id,
         singer_id: selectedSinger!.id,
-        notes_for_moderator: notes.trim(),
       }),
     });
 
@@ -357,12 +355,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
             </div>
           </div>
 
-          <div className="sub-section"><span className="sub-step">04</span> Anything else?</div>
-          <div className="sub-row">
-            <label>Notes for moderator <span className="opt">(optional)</span></label>
-            <textarea value={notes} onChange={(e) => setNotes(e.target.value)} rows={3} placeholder="Sources, alternate titles, why this video over another upload…" />
-          </div>
-
         </div>
         <div className="sub-form-foot">
           <span className="sub-foot-note">⌘ + Enter to submit</span>
@@ -391,9 +383,9 @@ function AnimePane() {
   ];
 
   const [f, setF] = useState({
-    title_romaji: "", title_english: "", title_native: "",
-    year: "", format: "tv" as AnimeFormat, episodes: "",
-    studio: "", reference_url: "", notes_for_moderator: "",
+    title_english: "",
+    year: "", format: "tv" as AnimeFormat,
+    reference_url: "",
   });
   const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
     setF((prev) => ({ ...prev, [k]: e.target.value }));
@@ -406,6 +398,13 @@ function AnimePane() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const errs: Record<string, string> = {};
+    if (!coverKey) errs.cover_image_key = "Cover image is required";
+    if (!f.title_english.trim()) errs.title_english = "English title is required";
+    if (!f.year.trim()) errs.year = "Year is required";
+    if (!f.reference_url.trim()) errs.reference_url = "Reference link is required";
+    if (Object.keys(errs).length > 0) { setFieldErrors(errs); return; }
+
     setSubmitting(true);
     setError(null);
     setFieldErrors({});
@@ -413,7 +412,7 @@ function AnimePane() {
     const res = await fetch("/api/anime", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...f, year: Number(f.year) || 0, episodes: f.episodes ? Number(f.episodes) : undefined, cover_image_key: coverKey }),
+      body: JSON.stringify({ ...f, year: Number(f.year) || 0, cover_image_key: coverKey }),
     });
 
     setSubmitting(false);
@@ -432,7 +431,7 @@ function AnimePane() {
         <div className="sub-form-body" style={{ textAlign: "center", padding: "48px 26px" }}>
           <p style={{ fontSize: 16, marginBottom: 20 }}>Anime submitted for review ✓</p>
           <p className="hint" style={{ marginBottom: 24 }}>Once a mod approves it, it will appear in the anime picker on the Opening tab.</p>
-          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ title_romaji: "", title_english: "", title_native: "", year: "", format: "tv", episodes: "", studio: "", reference_url: "", notes_for_moderator: "" }); }}>
+          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ title_english: "", year: "", format: "tv", reference_url: "" }); setCoverKey(""); }}>
             Submit another
           </button>
         </div>
@@ -448,52 +447,34 @@ function AnimePane() {
         </div>
         <div className="sub-form-body">
 
-          <div className="sub-section"><span className="sub-step">01</span> Cover image <span className="opt">(optional)</span></div>
+          <div className="sub-section"><span className="sub-step">01</span> Cover image <span className="req">*</span></div>
           <CoverUpload
             entityType="anime"
             aspect="poster"
             onUploaded={(key) => setCoverKey(key)}
           />
+          {fieldErrors.cover_image_key && <span className="ferr">{fieldErrors.cover_image_key}</span>}
 
-          <div className="sub-section"><span className="sub-step">02</span> Titles</div>
+          <div className="sub-section"><span className="sub-step">02</span> Title</div>
           <div className="sub-row">
             <label>English title <span className="req">*</span></label>
             <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />
             {fieldErrors.title_english && <span className="ferr">{fieldErrors.title_english}</span>}
           </div>
-          <div className="sub-grid-2">
-            <div className="sub-row">
-              <label>Romaji title <span className="opt">(optional)</span></label>
-              <input type="text" value={f.title_romaji} onChange={set("title_romaji")} placeholder="Shingeki no Kyojin" />
-              <span className="hint">Latin-script transliteration, if different from English.</span>
-            </div>
-            <div className="sub-row">
-              <label>Native (日本語) <span className="opt">(optional)</span></label>
-              <input type="text" value={f.title_native} onChange={set("title_native")} placeholder="進撃の巨人" />
-            </div>
-          </div>
 
           <div className="sub-section"><span className="sub-step">03</span> Production</div>
-          <div className="sub-grid-3">
+          <div className="sub-grid-2">
             <div className="sub-row">
               <label>Year <span className="req">*</span></label>
               <input type="text" inputMode="numeric" value={f.year} onChange={set("year")} placeholder="2013" />
               {fieldErrors.year && <span className="ferr">{fieldErrors.year}</span>}
             </div>
             <div className="sub-row">
-              <label>Format</label>
+              <label>Format <span className="req">*</span></label>
               <select value={f.format} onChange={set("format")}>
                 {FORMATS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
               </select>
             </div>
-            <div className="sub-row">
-              <label>Episodes <span className="opt">(optional)</span></label>
-              <input type="text" inputMode="numeric" value={f.episodes} onChange={set("episodes")} placeholder="25" />
-            </div>
-          </div>
-          <div className="sub-row">
-            <label>Studio <span className="opt">(optional)</span></label>
-            <input type="text" value={f.studio} onChange={set("studio")} placeholder="Wit Studio · MAPPA" />
           </div>
 
           <div className="sub-section"><span className="sub-step">04</span> Verification</div>
@@ -502,10 +483,6 @@ function AnimePane() {
             <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="https://anilist.co/anime/… or MyAnimeList / official site" />
             <span className="hint">Helps the moderator verify the entry. AniList preferred.</span>
             {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
-          </div>
-          <div className="sub-row">
-            <label>Notes for moderator <span className="opt">(optional)</span></label>
-            <textarea value={f.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Sequel/prequel relationships, alternate titles…" />
           </div>
 
         </div>
@@ -538,8 +515,8 @@ function SingerPane() {
   ];
 
   const [f, setF] = useState({
-    name: "", name_native: "", type: "solo" as SingerType,
-    active_since: "", bio: "", reference_url: "", notes_for_moderator: "",
+    name: "", type: "solo" as SingerType,
+    reference_url: "",
   });
   const set = (k: keyof typeof f) => (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) =>
     setF((prev) => ({ ...prev, [k]: e.target.value }));
@@ -552,6 +529,12 @@ function SingerPane() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const errs: Record<string, string> = {};
+    if (!coverKey) errs.cover_image_key = "Photo is required";
+    if (!f.name.trim()) errs.name = "Name is required";
+    if (!f.reference_url.trim()) errs.reference_url = "Reference link is required";
+    if (Object.keys(errs).length > 0) { setFieldErrors(errs); return; }
+
     setSubmitting(true);
     setError(null);
     setFieldErrors({});
@@ -559,7 +542,7 @@ function SingerPane() {
     const res = await fetch("/api/singers", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...f, active_since: f.active_since ? Number(f.active_since) : undefined, cover_image_key: coverKey }),
+      body: JSON.stringify({ ...f, cover_image_key: coverKey }),
     });
 
     setSubmitting(false);
@@ -578,7 +561,7 @@ function SingerPane() {
         <div className="sub-form-body" style={{ textAlign: "center", padding: "48px 26px" }}>
           <p style={{ fontSize: 16, marginBottom: 20 }}>Singer submitted for review ✓</p>
           <p className="hint" style={{ marginBottom: 24 }}>Once approved, they will appear in the singer picker on the Opening tab.</p>
-          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ name: "", name_native: "", type: "solo", active_since: "", bio: "", reference_url: "", notes_for_moderator: "" }); }}>
+          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ name: "", type: "solo", reference_url: "" }); setCoverKey(""); }}>
             Submit another
           </button>
         </div>
@@ -594,12 +577,13 @@ function SingerPane() {
         </div>
         <div className="sub-form-body">
 
-          <div className="sub-section"><span className="sub-step">01</span> Photo <span className="opt">(optional)</span></div>
+          <div className="sub-section"><span className="sub-step">01</span> Photo <span className="req">*</span></div>
           <CoverUpload
             entityType="singer"
             aspect="square"
             onUploaded={(key) => setCoverKey(key)}
           />
+          {fieldErrors.cover_image_key && <span className="ferr">{fieldErrors.cover_image_key}</span>}
 
           <div className="sub-section"><span className="sub-step">02</span> Identity</div>
           <div className="sub-row">
@@ -608,28 +592,14 @@ function SingerPane() {
             <span className="hint">Romaji or English — whichever is the canonical form.</span>
             {fieldErrors.name && <span className="ferr">{fieldErrors.name}</span>}
           </div>
-          <div className="sub-row">
-            <label>Native (日本語) <span className="opt">(optional)</span></label>
-            <input type="text" value={f.name_native} onChange={set("name_native")} placeholder="ヨアソビ" />
-          </div>
 
           <div className="sub-section"><span className="sub-step">03</span> About</div>
-          <div className="sub-grid-2">
-            <div className="sub-row">
-              <label>Type <span className="req">*</span></label>
-              <select value={f.type} onChange={set("type")}>
-                {TYPES.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
-              </select>
-              {fieldErrors.type && <span className="ferr">{fieldErrors.type}</span>}
-            </div>
-            <div className="sub-row">
-              <label>Active since <span className="opt">(optional)</span></label>
-              <input type="text" inputMode="numeric" value={f.active_since} onChange={set("active_since")} placeholder="2019" />
-            </div>
-          </div>
           <div className="sub-row">
-            <label>Short bio <span className="opt">(optional)</span></label>
-            <textarea value={f.bio} onChange={set("bio")} rows={3} placeholder="One or two sentences. Genres, notable works, anything that helps recognize them." />
+            <label>Type <span className="req">*</span></label>
+            <select value={f.type} onChange={set("type")}>
+              {TYPES.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+            </select>
+            {fieldErrors.type && <span className="ferr">{fieldErrors.type}</span>}
           </div>
 
           <div className="sub-section"><span className="sub-step">04</span> Verification</div>
@@ -637,10 +607,6 @@ function SingerPane() {
             <label>Reference link <span className="req">*</span></label>
             <input type="url" value={f.reference_url} onChange={set("reference_url")} placeholder="Official site, Spotify, Wikipedia…" />
             {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
-          </div>
-          <div className="sub-row">
-            <label>Notes for moderator <span className="opt">(optional)</span></label>
-            <textarea value={f.notes_for_moderator} onChange={set("notes_for_moderator")} rows={3} placeholder="Anything that helps the reviewer" />
           </div>
 
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1858,6 +1858,7 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   border-bottom: 1px solid var(--line);
 }
 .mod-tab {
+  display: inline-flex; align-items: center; gap: 8px;
   padding: 8px 14px; border-radius: 6px 6px 0 0;
   font-family: var(--mono); font-size: 12px; color: var(--fg-3);
   border-bottom: 2px solid transparent;
@@ -1865,6 +1866,17 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 }
 .mod-tab:hover { color: var(--fg-2); }
 .mod-tab.on { color: var(--fg); border-bottom-color: var(--accent); }
+.mod-tab-count {
+  min-width: 22px; padding: 1px 7px; border-radius: 999px;
+  background: var(--bg-3); border: 1px solid var(--line);
+  font-family: var(--mono); font-size: 11px; line-height: 1.4;
+  color: var(--fg-3); text-align: center;
+}
+.mod-tab-count.on {
+  background: color-mix(in oklab, var(--accent) 18%, var(--bg-3));
+  border-color: color-mix(in oklab, var(--accent) 55%, var(--line));
+  color: var(--accent);
+}
 
 .mod-list {
   list-style: none; padding: 0; margin: 0;
@@ -2347,6 +2359,10 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   border: 1px solid var(--line); border-radius: 10px;
   background: var(--bg-2); overflow: hidden; margin-bottom: 18px;
 }
+/* Cards that host a floating dropdown (autocomplete) can't clip their
+   children, otherwise the dropdown gets cut off at the card edge and
+   slides under whatever sits below. */
+.edit-card.edit-card-pop { overflow: visible; }
 .edit-card-head {
   display: flex; align-items: center; gap: 10px;
   padding: 14px 18px; border-bottom: 1px solid var(--line);


### PR DESCRIPTION
## Summary
Three frontend fixes batched.

### 1. Anime/singer dropdown on edit-opening was getting clipped
The dropdown lives inside an `.edit-card` (Attribution), which had `overflow: hidden` for rounded-corner reasons. The autocomplete dropdown is `position: absolute` below the input, so it was cut off at the card edge and slid under whatever sat below.

Fix: opt-in `.edit-card-pop` modifier on the Attribution card → `overflow: visible`. Other cards keep their clipping for safety (e.g. tinted-head danger zone).

### 2. Moderation queue tabs show per-type counts
Server-side fetches all three totals in parallel — the inactive types are fetched with `pageSize=1` so we only get the count, not the rows. Tab badges color when count > 0.

### 3. Strip optional fields from submit + edit forms
Product call: only strictly-required fields remain. Cover image stays — promoted to required.

| Entity | Removed | Notes |
|---|---|---|
| Opening (submit + edit) | Notes for moderator | — |
| Anime (submit) | Romaji, Native, Episodes, Studio, Notes | Cover **kept**, now required + validated |
| Singer (submit) | Native, Active since, Bio, Notes | Photo **kept**, now required + validated |

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual: open `/openings/<id>/edit` → click "Change…" on Anime → confirm the dropdown shows in full and overlays the next card instead of being cut off
- [ ] Manual: navigate to `/mod/queue` → confirm each tab shows a count badge that matches the total once you switch to that tab
- [ ] Manual: submit anime without uploading a cover → confirm the "Cover image is required" validation error blocks submission; same for singer photo
- [ ] Manual: edit an opening → confirm there is no "Notes" section and saving works without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)