### PR TITLE
fix(security): block open-redirect via protocol-relative next= values

### DIFF
--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -1,0 +1,16 @@
+// safeRedirect coerces a user-supplied `next=` value into a same-origin path
+// or returns "/" as a safe fallback.
+//
+// The naive `value.startsWith("/")` check accepts `//evil.com`, which browsers
+// resolve as `https://evil.com` — an open redirect. We also reject
+// `/\evil.com` (some browsers interpret backslash as a path separator) and
+// anything that isn't a string.
+//
+// Rules: the value must be exactly "/", or begin with "/" followed by a
+// character that is neither "/" nor "\". Everything else collapses to "/".
+export function safeRedirect(value: unknown): string {
+  if (typeof value !== "string") return "/";
+  if (value === "/") return "/";
+  if (!/^\/[^/\\]/.test(value)) return "/";
+  return value;
+}

--- a/pages/api/auth/login.ts
+++ b/pages/api/auth/login.ts
@@ -5,6 +5,7 @@ import {
   copyBackendCookies,
   readBackendError,
 } from "@/lib/api-proxy";
+import { safeRedirect } from "@/lib/redirect";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -13,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const email = typeof req.body?.email === "string" ? req.body.email : "";
   const password = typeof req.body?.password === "string" ? req.body.password : "";
-  const next = typeof req.body?.next === "string" && req.body.next.startsWith("/") ? req.body.next : "/";
+  const next = safeRedirect(req.body?.next);
 
   const upstream = await fetch(backendUrl("/auth/login"), {
     method: "POST",

--- a/pages/api/auth/signup.ts
+++ b/pages/api/auth/signup.ts
@@ -5,6 +5,7 @@ import {
   copyBackendCookies,
   readBackendError,
 } from "@/lib/api-proxy";
+import { safeRedirect } from "@/lib/redirect";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const password = typeof req.body?.password === "string" ? req.body.password : "";
   const displayName =
     typeof req.body?.display_name === "string" ? req.body.display_name : "";
-  const next = typeof req.body?.next === "string" && req.body.next.startsWith("/") ? req.body.next : "/";
+  const next = safeRedirect(req.body?.next);
 
   const upstream = await fetch(backendUrl("/auth/signup"), {
     method: "POST",


### PR DESCRIPTION
## Summary
The `next=` redirect parameter on login/signup was validated with `value.startsWith("/")`. That accepts `//evil.com` — browsers resolve that as `https://evil.com`, so a victim who clicks `https://openingwiki.ru/login?next=//evil.com` logs in, gets `302 Location: //evil.com`, and lands on the attacker-controlled domain believing they're still on the legit site. Classic open-redirect → phishing pivot.

## Fix
New shared `lib/redirect.ts` with `safeRedirect()`:

```ts
if (typeof value !== "string") return "/";
if (value === "/") return "/";
if (!/^\/[^/\\]/.test(value)) return "/";  // blocks // and /\
return value;
```

Wired into both [pages/api/auth/login.ts](pages/api/auth/login.ts) and [pages/api/auth/signup.ts](pages/api/auth/signup.ts). The two callsites now share one validator so the next protocol-relative variant gets fixed in one place.

Closes [#29](https://github.com/openingwiki/frontend/issues/29).

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual: `curl -i -X POST /api/auth/login -d 'next=//evil.com&email=...&password=...'` → response `Location: /`, not `//evil.com`
- [ ] Manual: `curl -i -X POST /api/auth/login -d 'next=/\\evil.com&...'` → `Location: /`
- [ ] Manual: `next=/me` still works (legit same-origin redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)