### PR TITLE
feat(admin): editable anime + singer pages

### DIFF
--- a/components/CoverUpload.tsx
+++ b/components/CoverUpload.tsx
@@ -1,0 +1,107 @@
+import { useCallback, useRef, useState } from "react";
+
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export interface CoverUploadProps {
+  entityType: "anime" | "singer";
+  aspect?: "poster" | "square"; // poster = 2:3, square = 1:1
+  // The current cover URL when editing — shown as the initial preview so the
+  // admin can see what's there and decide whether to swap. Undefined means
+  // "no existing cover" (new submission path).
+  initialPreviewUrl?: string | null;
+  onUploaded: (objectKey: string, previewUrl: string) => void;
+}
+
+export default function CoverUpload({
+  entityType,
+  aspect = "poster",
+  initialPreviewUrl,
+  onUploaded,
+}: CoverUploadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [preview, setPreview] = useState<string | null>(initialPreviewUrl ?? null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadErr, setUploadErr] = useState<string | null>(null);
+
+  const handleFile = useCallback(async (file: File) => {
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      setUploadErr("JPEG, PNG, or WebP only");
+      return;
+    }
+    setUploading(true);
+    setUploadErr(null);
+    const localUrl = URL.createObjectURL(file);
+    setPreview(localUrl);
+    try {
+      const fd = new FormData();
+      fd.append("file", file, file.name);
+      const res = await fetch(`/api/uploads/cover?entity_type=${entityType}`, {
+        method: "POST",
+        body: fd,
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.error ?? `Upload failed (${res.status})`);
+      }
+      const { object_key, public_url } = await res.json();
+      onUploaded(object_key, public_url || localUrl);
+    } catch (err) {
+      setUploadErr(err instanceof Error ? err.message : "Upload failed");
+      setPreview(null);
+      URL.revokeObjectURL(localUrl);
+    } finally {
+      setUploading(false);
+    }
+  }, [entityType, onUploaded]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  return (
+    <div className={`cover-upload ${aspect}`}>
+      <div
+        className={`cover-zone${preview ? " has-preview" : ""}`}
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={handleDrop}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => e.key === "Enter" && inputRef.current?.click()}
+      >
+        {preview ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={preview} alt="Cover preview" className="cover-preview-img" />
+        ) : (
+          <div className="cover-ph">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+              <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
+              <path d="m21 15-5-5L5 21"/>
+            </svg>
+            <span>{uploading ? "Uploading…" : "Click or drop image"}</span>
+            <span className="cover-ph-sub">JPEG · PNG · WebP</span>
+          </div>
+        )}
+      </div>
+      {!preview && (
+        <button type="button" className="btn sm" onClick={() => inputRef.current?.click()} disabled={uploading}>
+          {uploading ? "Uploading…" : "Choose file"}
+        </button>
+      )}
+      {preview && (
+        <button type="button" className="btn sm ghost" onClick={() => { setPreview(null); onUploaded("", ""); }}>
+          Remove
+        </button>
+      )}
+      {uploadErr && <span className="ferr">{uploadErr}</span>}
+      <input ref={inputRef} type="file" accept="image/jpeg,image/png,image/webp" style={{ display: "none" }} onChange={handleChange} />
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -5,6 +5,7 @@
 import type {
   AdjacentOpenings,
   AnimeDetail,
+  AnimeFormat,
   Group,
   GroupDetail,
   Opening,
@@ -14,6 +15,7 @@ import type {
   RateResponse,
   SearchResults,
   SingerDetail,
+  SingerType,
   SortKey,
   TrackKind,
   User,
@@ -316,6 +318,39 @@ export interface AdminUpdateOpeningInput {
 
 export function adminUpdateOpening(openingId: string, input: AdminUpdateOpeningInput, cookie?: string): Promise<void> {
   return apiFetchData<void>(`/admin/openings/${encodeURIComponent(openingId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cookie,
+  });
+}
+
+export interface AdminUpdateAnimeInput {
+  title_english: string;
+  year: number;
+  format: AnimeFormat;
+  reference_url: string;
+  cover_image_key: string;
+}
+
+export function adminUpdateAnime(animeId: string, input: AdminUpdateAnimeInput, cookie?: string): Promise<void> {
+  return apiFetchData<void>(`/admin/anime/${encodeURIComponent(animeId)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+    cookie,
+  });
+}
+
+export interface AdminUpdateSingerInput {
+  name: string;
+  type: SingerType;
+  reference_url: string;
+  cover_image_key: string;
+}
+
+export function adminUpdateSinger(singerId: string, input: AdminUpdateSingerInput, cookie?: string): Promise<void> {
+  return apiFetchData<void>(`/admin/singers/${encodeURIComponent(singerId)}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -189,6 +189,9 @@ export interface AnimeDetail {
   studio: string | null;
   reference_url: string;
   cover_image_url: string | null;
+  // Internal storage key for the cover — used by the admin edit form so the
+  // existing cover is preserved when only other fields change.
+  cover_image_key: string;
   openings: AnimeOpening[];
 }
 
@@ -197,7 +200,11 @@ export interface SingerDetail {
   name: string;
   name_native: string | null;
   type: SingerType;
+  active_since: number | null;
+  bio: string | null;
+  reference_url: string;
   cover_image_url: string | null;
+  cover_image_key: string;
   openings: SingerOpening[];
 }
 

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -174,6 +174,11 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
                   ↗ Reference
                 </a>
               )}
+              {user?.role === "admin" && (
+                <Link href={`/anime/${anime.id}/edit`} className="btn">
+                  Edit
+                </Link>
+              )}
             </div>
           </div>
         </section>

--- a/pages/anime/[id]/edit.tsx
+++ b/pages/anime/[id]/edit.tsx
@@ -1,0 +1,228 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import CoverUpload from "@/components/CoverUpload";
+import { getAnime } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import { pushToast } from "@/lib/toast";
+import type { AnimeDetail, AnimeFormat, User } from "@/lib/types";
+
+interface Props {
+  user: User;
+  modQueueCount: number;
+  anime: AnimeDetail;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user || session.user.role !== "admin") {
+    return { notFound: true };
+  }
+  const id = ctx.params?.id as string;
+  try {
+    const anime = await getAnime(id, session.cookie);
+    return {
+      props: {
+        user: session.user,
+        modQueueCount: session.modQueueCount,
+        anime,
+      },
+    };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+const FORMATS: { value: AnimeFormat; label: string }[] = [
+  { value: "tv",      label: "TV series" },
+  { value: "film",    label: "Film" },
+  { value: "ova_ona", label: "OVA / ONA" },
+  { value: "special", label: "Special" },
+];
+
+export default function AnimeEditPage({ user, modQueueCount, anime }: Props) {
+  const router = useRouter();
+
+  const initialTitle = anime.title_english ?? anime.name;
+
+  const [titleEnglish, setTitleEnglish] = useState(initialTitle);
+  const [year, setYear] = useState(String(anime.year ?? ""));
+  const [format, setFormat] = useState<AnimeFormat>(anime.format);
+  const [referenceUrl, setReferenceUrl] = useState(anime.reference_url);
+  const [coverKey, setCoverKey] = useState(anime.cover_image_key ?? "");
+
+  const [saving, setSaving] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const isDirty =
+    titleEnglish !== initialTitle ||
+    year !== String(anime.year ?? "") ||
+    format !== anime.format ||
+    referenceUrl !== anime.reference_url ||
+    coverKey !== (anime.cover_image_key ?? "");
+
+  const save = async () => {
+    if (saving) return;
+    const errs: Record<string, string> = {};
+    if (!titleEnglish.trim()) errs.title_english = "English title is required";
+    const yearNum = Number(year);
+    if (!Number.isFinite(yearNum) || yearNum < 1900) errs.year = "Year is required";
+    if (!referenceUrl.trim()) errs.reference_url = "Reference link is required";
+    if (!coverKey) errs.cover_image_key = "Cover image is required";
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      return;
+    }
+
+    setSaving(true);
+    setFieldErrors({});
+    try {
+      const res = await fetch("/api/admin/anime-update", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: anime.id,
+          title_english: titleEnglish.trim(),
+          year: yearNum,
+          format,
+          reference_url: referenceUrl.trim(),
+          cover_image_key: coverKey,
+        }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Save failed (${res.status})`);
+      }
+      pushToast({ kind: "success", message: "Anime updated" });
+      router.push(`/anime/${anime.id}`);
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Save failed" });
+      setSaving(false);
+    }
+  };
+
+  const discard = () => router.push(`/anime/${anime.id}`);
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`Edit · ${initialTitle} · Opening Wiki`}
+    >
+      <div className="wrap">
+
+        <div className="edit-crumb">
+          <Link href="/">Home</Link>
+          <span className="edit-crumb-sep">/</span>
+          <Link href={`/anime/${anime.id}`}>{initialTitle}</Link>
+          <span className="edit-crumb-sep">/</span>
+          <span className="edit-crumb-here">Edit</span>
+        </div>
+
+        <div className="edit-head">
+          <div>
+            <div className="edit-eyebrow">
+              <span className="edit-admin-badge">Admin · Editing</span>
+            </div>
+            <h1 className="edit-h1">Editing <em>{initialTitle}</em></h1>
+            <div className="edit-sub" style={{ color: "var(--fg-4)" }}>id: {anime.id}</div>
+          </div>
+          <span style={{ flex: 1 }} />
+          <div className="edit-head-actions">
+            <Link href={`/anime/${anime.id}`} target="_blank" rel="noreferrer" className="btn">
+              ↗ View page
+            </Link>
+          </div>
+        </div>
+
+        <div className="edit-page-grid">
+          <main>
+
+            {/* 01 Cover */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">01</span> Cover image</div>
+              <div className="edit-card-body">
+                <CoverUpload
+                  entityType="anime"
+                  aspect="poster"
+                  initialPreviewUrl={anime.cover_image_url}
+                  onUploaded={(key) => setCoverKey(key)}
+                />
+                {fieldErrors.cover_image_key && <span className="ferr">{fieldErrors.cover_image_key}</span>}
+              </div>
+            </div>
+
+            {/* 02 Title */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">02</span> Title</div>
+              <div className="edit-card-body">
+                <div className={`edit-row${titleEnglish !== initialTitle ? " dirty" : ""}`}>
+                  <label className="edit-label">
+                    English title <span className="edit-req">*</span>
+                    {titleEnglish !== initialTitle && <span className="edit-changed">unsaved</span>}
+                  </label>
+                  <input type="text" className="edit-input" value={titleEnglish} onChange={(e) => setTitleEnglish(e.target.value)} />
+                  {fieldErrors.title_english && <span className="ferr">{fieldErrors.title_english}</span>}
+                </div>
+              </div>
+            </div>
+
+            {/* 03 Production */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">03</span> Production</div>
+              <div className="edit-card-body">
+                <div className="sub-grid-2">
+                  <div className={`edit-row${year !== String(anime.year ?? "") ? " dirty" : ""}`}>
+                    <label className="edit-label">Year <span className="edit-req">*</span></label>
+                    <input type="text" inputMode="numeric" className="edit-input" value={year} onChange={(e) => setYear(e.target.value)} />
+                    {fieldErrors.year && <span className="ferr">{fieldErrors.year}</span>}
+                  </div>
+                  <div className="edit-row">
+                    <label className="edit-label">Format <span className="edit-req">*</span></label>
+                    <select className="edit-input" value={format} onChange={(e) => setFormat(e.target.value as AnimeFormat)}>
+                      {FORMATS.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* 04 Verification */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">04</span> Verification</div>
+              <div className="edit-card-body">
+                <div className={`edit-row${referenceUrl !== anime.reference_url ? " dirty" : ""}`}>
+                  <label className="edit-label">Reference link <span className="edit-req">*</span></label>
+                  <input type="url" className="edit-input" value={referenceUrl} onChange={(e) => setReferenceUrl(e.target.value)} />
+                  <span className="edit-hint">AniList preferred — helps moderators verify the entry.</span>
+                  {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
+                </div>
+              </div>
+            </div>
+
+          </main>
+        </div>
+      </div>
+
+      {isDirty && (
+        <div className="edit-save-bar">
+          <div className="edit-save-bar-inner wrap">
+            <span className="edit-sb-status">
+              <span className="edit-sb-dot" />
+              <span className="edit-sb-lbl">Unsaved changes</span>
+            </span>
+            <span style={{ flex: 1 }} />
+            <div className="edit-sb-actions">
+              <button type="button" className="btn" onClick={discard} disabled={saving}>Discard</button>
+              <button type="button" className="btn primary" onClick={save} disabled={saving}>
+                {saving ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/pages/api/admin/anime-update.ts
+++ b/pages/api/admin/anime-update.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { adminUpdateAnime, ApiError } from "@/lib/api";
+
+// PATCH /api/admin/anime-update  { id, title_english, year, format, reference_url, cover_image_key }
+//   → PATCH /api/v1/admin/anime/{id}
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "PATCH");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  const { id, ...input } = req.body ?? {};
+  if (!id || typeof id !== "string") return res.status(400).json({ error: "id is required" });
+
+  try {
+    await adminUpdateAnime(id, input, req.headers.cookie);
+    return res.status(204).end();
+  } catch (err) {
+    if (err instanceof ApiError) {
+      let message = err.message;
+      try {
+        const parsed = JSON.parse(err.body) as { error?: { message?: string; fields?: Record<string, string> } };
+        if (parsed?.error?.message) message = parsed.error.message;
+      } catch {
+        if (err.body) message = err.body;
+      }
+      return res.status(err.status || 502).json({ error: message });
+    }
+    return res.status(502).json({ error: "Backend unreachable" });
+  }
+}

--- a/pages/api/admin/singer-update.ts
+++ b/pages/api/admin/singer-update.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { adminUpdateSinger, ApiError } from "@/lib/api";
+
+// PATCH /api/admin/singer-update  { id, name, type, reference_url, cover_image_key }
+//   → PATCH /api/v1/admin/singers/{id}
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "PATCH") {
+    res.setHeader("Allow", "PATCH");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+  const { id, ...input } = req.body ?? {};
+  if (!id || typeof id !== "string") return res.status(400).json({ error: "id is required" });
+
+  try {
+    await adminUpdateSinger(id, input, req.headers.cookie);
+    return res.status(204).end();
+  } catch (err) {
+    if (err instanceof ApiError) {
+      let message = err.message;
+      try {
+        const parsed = JSON.parse(err.body) as { error?: { message?: string; fields?: Record<string, string> } };
+        if (parsed?.error?.message) message = parsed.error.message;
+      } catch {
+        if (err.body) message = err.body;
+      }
+      return res.status(err.status || 502).json({ error: message });
+    }
+    return res.status(502).json({ error: "Backend unreachable" });
+  }
+}

--- a/pages/singers/[id].tsx
+++ b/pages/singers/[id].tsx
@@ -172,6 +172,11 @@ export default function SingerPage({ user, modQueueCount, singer }: Props) {
                 </svg>
                 Submit a track
               </Link>
+              {user?.role === "admin" && (
+                <Link href={`/singers/${singer.id}/edit`} className="btn">
+                  Edit
+                </Link>
+              )}
             </div>
           </div>
         </section>

--- a/pages/singers/[id]/edit.tsx
+++ b/pages/singers/[id]/edit.tsx
@@ -1,0 +1,215 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import CoverUpload from "@/components/CoverUpload";
+import { getSinger } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import { pushToast } from "@/lib/toast";
+import type { SingerDetail, SingerType, User } from "@/lib/types";
+
+interface Props {
+  user: User;
+  modQueueCount: number;
+  singer: SingerDetail;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user || session.user.role !== "admin") {
+    return { notFound: true };
+  }
+  const id = ctx.params?.id as string;
+  try {
+    const singer = await getSinger(id, session.cookie);
+    return {
+      props: {
+        user: session.user,
+        modQueueCount: session.modQueueCount,
+        singer,
+      },
+    };
+  } catch {
+    return { notFound: true };
+  }
+};
+
+const TYPES: { value: SingerType; label: string }[] = [
+  { value: "solo",              label: "Solo artist" },
+  { value: "band",              label: "Band" },
+  { value: "idol_group",        label: "Idol group" },
+  { value: "vocaloid_producer", label: "Vocaloid producer" },
+  { value: "composer",          label: "Composer" },
+  { value: "other",             label: "Other" },
+];
+
+export default function SingerEditPage({ user, modQueueCount, singer }: Props) {
+  const router = useRouter();
+
+  const [name, setName] = useState(singer.name);
+  const [type, setType] = useState<SingerType>(singer.type ?? "solo");
+  const [referenceUrl, setReferenceUrl] = useState(singer.reference_url ?? "");
+  const [coverKey, setCoverKey] = useState(singer.cover_image_key ?? "");
+
+  const [saving, setSaving] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  const isDirty =
+    name !== singer.name ||
+    type !== (singer.type ?? "solo") ||
+    referenceUrl !== (singer.reference_url ?? "") ||
+    coverKey !== (singer.cover_image_key ?? "");
+
+  const save = async () => {
+    if (saving) return;
+    const errs: Record<string, string> = {};
+    if (!name.trim()) errs.name = "Name is required";
+    if (!referenceUrl.trim()) errs.reference_url = "Reference link is required";
+    if (!coverKey) errs.cover_image_key = "Photo is required";
+    if (Object.keys(errs).length > 0) {
+      setFieldErrors(errs);
+      return;
+    }
+
+    setSaving(true);
+    setFieldErrors({});
+    try {
+      const res = await fetch("/api/admin/singer-update", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: singer.id,
+          name: name.trim(),
+          type,
+          reference_url: referenceUrl.trim(),
+          cover_image_key: coverKey,
+        }),
+      });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Save failed (${res.status})`);
+      }
+      pushToast({ kind: "success", message: "Singer updated" });
+      router.push(`/singers/${singer.id}`);
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Save failed" });
+      setSaving(false);
+    }
+  };
+
+  const discard = () => router.push(`/singers/${singer.id}`);
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`Edit · ${singer.name} · Opening Wiki`}
+    >
+      <div className="wrap">
+
+        <div className="edit-crumb">
+          <Link href="/">Home</Link>
+          <span className="edit-crumb-sep">/</span>
+          <Link href={`/singers/${singer.id}`}>{singer.name}</Link>
+          <span className="edit-crumb-sep">/</span>
+          <span className="edit-crumb-here">Edit</span>
+        </div>
+
+        <div className="edit-head">
+          <div>
+            <div className="edit-eyebrow">
+              <span className="edit-admin-badge">Admin · Editing</span>
+            </div>
+            <h1 className="edit-h1">Editing <em>{singer.name}</em></h1>
+            <div className="edit-sub" style={{ color: "var(--fg-4)" }}>id: {singer.id}</div>
+          </div>
+          <span style={{ flex: 1 }} />
+          <div className="edit-head-actions">
+            <Link href={`/singers/${singer.id}`} target="_blank" rel="noreferrer" className="btn">
+              ↗ View page
+            </Link>
+          </div>
+        </div>
+
+        <div className="edit-page-grid">
+          <main>
+
+            {/* 01 Photo */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">01</span> Photo</div>
+              <div className="edit-card-body">
+                <CoverUpload
+                  entityType="singer"
+                  aspect="square"
+                  initialPreviewUrl={singer.cover_image_url}
+                  onUploaded={(key) => setCoverKey(key)}
+                />
+                {fieldErrors.cover_image_key && <span className="ferr">{fieldErrors.cover_image_key}</span>}
+              </div>
+            </div>
+
+            {/* 02 Identity */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">02</span> Identity</div>
+              <div className="edit-card-body">
+                <div className={`edit-row${name !== singer.name ? " dirty" : ""}`}>
+                  <label className="edit-label">
+                    Name <span className="edit-req">*</span>
+                    {name !== singer.name && <span className="edit-changed">unsaved</span>}
+                  </label>
+                  <input type="text" className="edit-input" value={name} onChange={(e) => setName(e.target.value)} />
+                  {fieldErrors.name && <span className="ferr">{fieldErrors.name}</span>}
+                </div>
+              </div>
+            </div>
+
+            {/* 03 About */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">03</span> About</div>
+              <div className="edit-card-body">
+                <div className="edit-row">
+                  <label className="edit-label">Type <span className="edit-req">*</span></label>
+                  <select className="edit-input" value={type} onChange={(e) => setType(e.target.value as SingerType)}>
+                    {TYPES.map((opt) => <option key={opt.value} value={opt.value}>{opt.label}</option>)}
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            {/* 04 Verification */}
+            <div className="edit-card">
+              <div className="edit-card-head"><span className="edit-card-step">04</span> Verification</div>
+              <div className="edit-card-body">
+                <div className={`edit-row${referenceUrl !== (singer.reference_url ?? "") ? " dirty" : ""}`}>
+                  <label className="edit-label">Reference link <span className="edit-req">*</span></label>
+                  <input type="url" className="edit-input" value={referenceUrl} onChange={(e) => setReferenceUrl(e.target.value)} />
+                  {fieldErrors.reference_url && <span className="ferr">{fieldErrors.reference_url}</span>}
+                </div>
+              </div>
+            </div>
+
+          </main>
+        </div>
+      </div>
+
+      {isDirty && (
+        <div className="edit-save-bar">
+          <div className="edit-save-bar-inner wrap">
+            <span className="edit-sb-status">
+              <span className="edit-sb-dot" />
+              <span className="edit-sb-lbl">Unsaved changes</span>
+            </span>
+            <span style={{ flex: 1 }} />
+            <div className="edit-sb-actions">
+              <button type="button" className="btn" onClick={discard} disabled={saving}>Discard</button>
+              <button type="button" className="btn primary" onClick={save} disabled={saving}>
+                {saving ? "Saving…" : "Save changes"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -1,9 +1,10 @@
 import type { GetServerSideProps } from "next";
 import Link from "next/link";
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/router";
 import Layout from "@/components/Layout";
 import Autocomplete, { type AutocompleteItem } from "@/components/Autocomplete";
+import CoverUpload from "@/components/CoverUpload";
 import { loadSession } from "@/lib/session";
 import type { TrackKind, AnimeFormat, SingerType, User } from "@/lib/types";
 
@@ -52,107 +53,6 @@ async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
     iconShape: "circle" as const,
     sublabel: (s.type ?? "").replace(/_/g, " "),
   }));
-}
-
-// ---------------------------------------------------------------------------
-// Cover upload
-// ---------------------------------------------------------------------------
-
-const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp"];
-
-interface CoverUploadProps {
-  entityType: "anime" | "singer";
-  aspect?: "poster" | "square"; // poster = 2:3, square = 1:1
-  onUploaded: (objectKey: string, previewUrl: string) => void;
-}
-
-function CoverUpload({ entityType, aspect = "poster", onUploaded }: CoverUploadProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const [preview, setPreview] = useState<string | null>(null);
-  const [uploading, setUploading] = useState(false);
-  const [uploadErr, setUploadErr] = useState<string | null>(null);
-
-  const handleFile = useCallback(async (file: File) => {
-    if (!ALLOWED_TYPES.includes(file.type)) {
-      setUploadErr("JPEG, PNG, or WebP only");
-      return;
-    }
-    setUploading(true);
-    setUploadErr(null);
-    const localUrl = URL.createObjectURL(file);
-    setPreview(localUrl);
-    try {
-      const fd = new FormData();
-      fd.append("file", file, file.name);
-      const res = await fetch(`/api/uploads/cover?entity_type=${entityType}`, {
-        method: "POST",
-        body: fd,
-      });
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err?.error ?? `Upload failed (${res.status})`);
-      }
-      const { object_key, public_url } = await res.json();
-      onUploaded(object_key, public_url || localUrl);
-    } catch (err) {
-      setUploadErr(err instanceof Error ? err.message : "Upload failed");
-      setPreview(null);
-      URL.revokeObjectURL(localUrl);
-    } finally {
-      setUploading(false);
-    }
-  }, [entityType, onUploaded]);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) handleFile(file);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const file = e.dataTransfer.files?.[0];
-    if (file) handleFile(file);
-  };
-
-  return (
-    <div className={`cover-upload ${aspect}`}>
-      <div
-        className={`cover-zone${preview ? " has-preview" : ""}`}
-        onClick={() => inputRef.current?.click()}
-        onDragOver={(e) => e.preventDefault()}
-        onDrop={handleDrop}
-        role="button"
-        tabIndex={0}
-        onKeyDown={(e) => e.key === "Enter" && inputRef.current?.click()}
-      >
-        {preview ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={preview} alt="Cover preview" className="cover-preview-img" />
-        ) : (
-          <div className="cover-ph">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-              <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/>
-              <path d="m21 15-5-5L5 21"/>
-            </svg>
-            <span>{uploading ? "Uploading…" : "Click or drop image"}</span>
-            <span className="cover-ph-sub">JPEG · PNG · WebP</span>
-          </div>
-        )}
-      </div>
-      {!preview && (
-        <button type="button" className="btn sm" onClick={() => inputRef.current?.click()} disabled={uploading}>
-          {uploading ? "Uploading…" : "Choose file"}
-        </button>
-      )}
-      {preview && (
-        <button type="button" className="btn sm ghost" onClick={() => { setPreview(null); onUploaded("", ""); }}>
-          Remove
-        </button>
-      )}
-      {uploadErr && <span className="ferr">{uploadErr}</span>}
-      <input ref={inputRef} type="file" accept="image/jpeg,image/png,image/webp" style={{ display: "none" }} onChange={handleChange} />
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Mirrors the existing opening edit flow for anime and singer. Admin-only.

### New
- **Pages** — `/anime/[id]/edit` and `/singers/[id]/edit`. Each is admin-gated in `getServerSideProps` the same way `/openings/[id]/edit` is.
- **API proxies** — `pages/api/admin/anime-update.ts` and `pages/api/admin/singer-update.ts`. They wrap the backend's new `PATCH /admin/anime/{id}` and `PATCH /admin/singers/{id}` (see openingwiki/backend#26).
- **Edit button** — rendered in the action row on each detail page when `user.role === \"admin\"`.

### Refactor
- `CoverUpload` was extracted from `pages/submit.tsx` to `components/CoverUpload.tsx` and given an `initialPreviewUrl` prop so the edit page can show the existing cover and let the admin swap or keep it. Submit page now imports the shared component — no behavior change.

### Field set
Same fields as the simplified submission form (per the earlier \"strip optional fields\" cleanup):

| Anime | Singer |
|---|---|
| cover image (req) | photo (req) |
| English title | Name |
| Year | Type |
| Format | Reference URL |
| Reference URL | |

`AnimeDetail` and `SingerDetail` types gain a `cover_image_key` field — newly returned by the backend in #26 — so the edit form can round-trip the existing cover when the admin only edits other fields. `SingerDetail` also picks up the type/name_native/active_since/bio/reference_url fields that were already referenced by the singer page but had been silently undefined.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Manual (as admin): open `/anime/<id>`, click Edit → form pre-populates with current values; change English title; Save → toast \"Anime updated\", redirect to detail page, change is visible.
- [ ] Manual: same flow for `/singers/<id>`.
- [ ] Manual (as non-admin): visiting `/anime/<id>/edit` returns 404; Edit button is not rendered on the detail page.
- [ ] Manual: leave cover unchanged → form keeps the existing cover (round-trip via `cover_image_key`).
- [ ] Manual: clear the cover → validation error \"Cover image is required\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)