### PR TITLE
fix: PUBLIC pill no longer overlaps group name

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -334,7 +334,9 @@ input, select { font: inherit; color: inherit; }
 /* Groups list */
 .grp-list { display: flex; flex-direction: column; }
 .grp-item {
-  display: grid; grid-template-columns: 22px 1fr auto; gap: 10px; align-items: center;
+  /* minmax(0, 1fr) so the name column can shrink below its content width
+     and the truncation rules on .grp-name actually take effect. */
+  display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center;
   padding: 10px 14px; border-bottom: 1px solid var(--line);
   transition: background .1s;
 }
@@ -346,7 +348,14 @@ input, select { font: inherit; color: inherit; }
 .grp-icon { color: var(--fg-4); display: grid; place-items: center; }
 .grp-item.system .grp-icon { color: var(--accent); }
 .grp-item.public .grp-icon { color: var(--ok); }
-.grp-name { font-size: 13px; color: var(--fg); line-height: 1.2; }
+.grp-name {
+  font-size: 13px; color: var(--fg); line-height: 1.2;
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* The PUBLIC pill is absolute over the row at right:46px — without
+   reserving space the name slides under it. 80px = pill width + offset
+   + a little breathing room. */
+.grp-item.public .grp-name { padding-right: 80px; }
 .grp-count { font-family: var(--mono); font-size: 11px; color: var(--fg-3); }
 .grp-public-link {
   position: absolute;


### PR DESCRIPTION
## Bug
In the Your Groups panel, the `PUBLIC` pill was rendering on top of the group name when the name was even moderately long — \"Power and energy\" overlapping the pill is the reported case.

## Why
`.grp-public-link` is `position: absolute` at `right: 46px`, but the row's grid template was `22px 1fr auto` (icon | name | count). The grid didn't know the pill existed, so the `1fr` name column extended its full natural width, and on \"public\" rows the trailing text slid under the pill.

## Fix
Pure CSS, no DOM change. Two parts:

1. `.grp-name` gets the standard truncation set (`min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap`). The grid's name column becomes `minmax(0, 1fr)` so it can actually shrink below content width (without this, ellipsis never triggers).
2. `.grp-item.public .grp-name` gets `padding-right: 80px` reserving exactly the strip the floating pill occupies.

Net: any long group name now truncates with `…` instead of wrapping/overflowing, and public rows specifically cannot collide with the pill regardless of name length.

## Considered alternatives
- Move the pill into the grid as a real column → pill ends up *after* the count, visual change.
- Restructure the wrapper into a two-column grid (row + pill as siblings) → larger DOM/refactor, same visual change.

Kept the current visual (pill inside the row, before the count) because the surgical fix preserves it.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Visual: panel shows \"Power and energy\" + PUBLIC pill without overlap
- [ ] Visual: a very long name (e.g. 40+ chars) truncates with `…` and the PUBLIC pill stays clean
- [ ] Visual: private/system rows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)