### PR TITLE
feat(play): solo Endless hub + run page

### DIFF
--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -8,6 +8,7 @@ interface Props {
 
 const NAV = [
   { href: "/",       label: "Home",   match: (p: string) => p === "/" },
+  { href: "/play",   label: "Play",   match: (p: string) => p.startsWith("/play") },
   { href: "/groups", label: "Groups", match: (p: string) => p.startsWith("/groups") || p.startsWith("/g/") },
 ];
 

--- a/components/solo/atoms.tsx
+++ b/components/solo/atoms.tsx
@@ -1,0 +1,148 @@
+// Shared design tokens + tiny atoms for the Solo Endless screens.
+// Palette and typography come from the design HTML in
+// `~/Downloads/Solo Mode.html` (the "Twilight palette"). Keeping the
+// tokens in one module means the hub and the run pages stay visually
+// locked together as the design evolves.
+
+import type { CSSProperties, ReactNode } from "react";
+
+export const SOLO = {
+  bg: "#0c0a14",
+  bg2: "#15121f",
+  bg3: "#1d1929",
+  line: "#26223a",
+  line2: "#36314e",
+  fg: "#ece8f5",
+  fg2: "#bcb4cf",
+  fg3: "#7a7295",
+  fg4: "#524c6a",
+  accent: "#a78bfa",
+  accentDim: "#7c5cf2",
+  ok: "#7dd38f",
+  warn: "#e8b84a",
+  danger: "#ff6b7a",
+  mono: "'Geist Mono', ui-monospace, Menlo, monospace",
+  sans: "'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+};
+
+interface EyebrowProps {
+  children: ReactNode;
+  color?: string;
+  dotColor?: string;
+  style?: CSSProperties;
+}
+
+export function Eyebrow({ children, color = SOLO.fg3, dotColor = SOLO.accent, style }: EyebrowProps) {
+  return (
+    <div style={{
+      fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.16em",
+      textTransform: "uppercase", color, display: "flex", alignItems: "center", gap: 8,
+      ...style,
+    }}>
+      <span style={{ width: 6, height: 6, borderRadius: "50%", background: dotColor, boxShadow: `0 0 10px ${dotColor}` }} />
+      {children}
+    </div>
+  );
+}
+
+interface HeartProps {
+  filled?: boolean;
+  broken?: boolean;
+  size?: number;
+}
+
+export function Heart({ filled = true, broken = false, size = 22 }: HeartProps) {
+  const stroke = filled ? SOLO.danger : SOLO.line2;
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ display: "block", flexShrink: 0 }} aria-hidden>
+      <path
+        d="M12 21s-7-4.5-9.5-9C.8 8.3 3 4 7 4c2 0 3.5 1.2 5 3 1.5-1.8 3-3 5-3 4 0 6.2 4.3 4.5 8-2.5 4.5-9.5 9-9.5 9z"
+        fill={filled ? SOLO.danger : "none"}
+        stroke={stroke}
+        strokeWidth={1.6}
+        opacity={filled ? 1 : 0.45}
+      />
+      {broken && (
+        <path d="M12 4l-1.5 5 3-1 -2 4 1.5 4" stroke={SOLO.bg} strokeWidth={1.4} fill="none" />
+      )}
+    </svg>
+  );
+}
+
+interface BigNumProps {
+  value: ReactNode;
+  label?: string;
+  color?: string;
+  size?: number;
+  align?: "left" | "right" | "center";
+}
+
+export function BigNum({ value, label, color = SOLO.accent, size = 88, align = "right" }: BigNumProps) {
+  return (
+    <div style={{ textAlign: align, lineHeight: 1 }}>
+      <div style={{
+        fontFamily: SOLO.mono, fontWeight: 500, fontSize: size, color,
+        letterSpacing: "-0.04em", lineHeight: 0.9,
+        textShadow: `0 0 30px ${color}55`,
+      }}>{value}</div>
+      {label && (
+        <div style={{
+          fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.16em",
+          textTransform: "uppercase", color: SOLO.fg3, marginTop: 6,
+        }}>{label}</div>
+      )}
+    </div>
+  );
+}
+
+interface TimerBarProps {
+  pct: number; // 0–1, played fraction
+  danger?: boolean;
+}
+
+export function TimerBar({ pct, danger = false }: TimerBarProps) {
+  const clamped = Math.max(0, Math.min(1, pct));
+  return (
+    <div style={{ height: 3, background: SOLO.line, position: "relative", overflow: "hidden" }}>
+      <div style={{
+        position: "absolute", inset: 0, right: `${(1 - clamped) * 100}%`,
+        background: danger ? SOLO.danger : SOLO.accent,
+        boxShadow: `0 0 14px ${danger ? SOLO.danger : SOLO.accent}`,
+        transition: "right .15s linear",
+      }} />
+    </div>
+  );
+}
+
+interface WaveformProps {
+  played: number; // 0–1
+  bars?: number;
+}
+
+// Deterministic bar heights — index → height via a stable hash so the
+// shape doesn't shuffle between renders.
+export function Waveform({ played, bars = 64 }: WaveformProps) {
+  const data = Array.from({ length: bars }, (_, i) => {
+    const seed = Math.sin(i * 12.9898) * 43758.5453;
+    return 0.18 + (seed - Math.floor(seed)) * 0.82;
+  });
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "center",
+      gap: 4, height: 180, padding: "0 32px",
+    }}>
+      {data.map((h, i) => {
+        const playedBar = i / bars < played;
+        return (
+          <div key={i} style={{
+            width: 4, height: `${h * 100}%`,
+            background: playedBar ? SOLO.accent : SOLO.line2,
+            borderRadius: 2,
+            boxShadow: playedBar ? `0 0 8px ${SOLO.accent}88` : "none",
+            opacity: playedBar ? 0.5 + h * 0.5 : 0.6,
+          }} />
+        );
+      })}
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -520,3 +520,20 @@ export function deleteOpeningComment(
     cookie,
   });
 }
+
+// ---------------------------------------------------------------------------
+// Solo Endless — read-only SSR helpers. Mutating calls (start run, submit
+// answer) go through the browser-side playClient in lib/play.ts so the
+// session cookie + CSRF flow matches the rest of the mutating API.
+// ---------------------------------------------------------------------------
+
+import type { SoloLeaderboard, SoloMyStats } from "./play";
+
+export function getSoloLeaderboard(date?: string, cookie?: string): Promise<SoloLeaderboard> {
+  const qs = date ? `?date=${encodeURIComponent(date)}` : "";
+  return apiFetchData<SoloLeaderboard>(`/play/solo/leaderboard${qs}`, { cookie });
+}
+
+export function getSoloMyStats(cookie?: string): Promise<SoloMyStats> {
+  return apiFetchData<SoloMyStats>("/play/solo/me/stats", { cookie });
+}

--- a/lib/play.ts
+++ b/lib/play.ts
@@ -1,0 +1,161 @@
+// Solo Endless mode — client-side fetch helpers.
+//
+// The hub page loads stats + leaderboard through getServerSideProps via
+// lib/api.ts. The run page is interactive and drives all calls from
+// the browser through the Next API proxy under /api/play/* (so the
+// session cookie + CSRF flow matches every other mutating route on the
+// site).
+
+import type { Opening, Anime, Singer } from "./types";
+
+export interface SoloRun {
+  id: string;
+  status: "active" | "ended" | "abandoned";
+  score: number;
+  lives: number;
+  streak: number;
+  longest_streak: number;
+  lives_regen: number;
+  started_at: string;
+  ended_at: string | null;
+}
+
+export interface SoloRound {
+  round_id: string;
+  round_token: string;
+  round_no: number;
+  mode: "audio" | "visual" | "lyrics";
+  clip_url: string;
+  clip_duration_ms: number;
+  server_now_ms: number;
+  expires_at_ms: number;
+}
+
+// The reveal card shape — opening + the catalog data the user already
+// sees on the detail page, plus the gameplay-shaped stats (your time,
+// avg player time, score delta).
+export interface SoloOpening extends Opening {
+  anime: Pick<Anime, "id" | "name"> & { title_romaji?: string; year?: number };
+  singer: Pick<Singer, "id" | "name">;
+}
+
+export interface SoloRoundResult {
+  round_id: string;
+  correct: boolean;
+  correct_opening: SoloOpening | null;
+  your_response_ms: number;
+  avg_player_response_ms: number;
+  score_delta: number;
+  score: number;
+  streak: number;
+  lives: number;
+  life_regen: boolean;
+}
+
+export interface SoloModeSummary {
+  mode: string;
+  hits: number;
+  total: number;
+  avg_response_ms: number;
+}
+
+export interface SoloMissedClip {
+  opening_id: string;
+  title: string;
+  anime_name: string;
+  year: number;
+  mode: string;
+}
+
+export interface SoloRunSummary {
+  run_id: string;
+  score: number;
+  longest_streak: number;
+  lives_regen: number;
+  started_at: string;
+  ended_at: string;
+  by_mode: SoloModeSummary[];
+  missed_clips: SoloMissedClip[];
+}
+
+export interface SoloAnswerResponse {
+  run: SoloRun;
+  round_result: SoloRoundResult;
+  next_round?: SoloRound;
+  run_summary?: SoloRunSummary;
+}
+
+export interface SoloStartResponse {
+  run: SoloRun;
+  round: SoloRound;
+}
+
+export interface SoloLeaderboardEntry {
+  rank: number;
+  user_id: string;
+  display_name: string;
+  score: number;
+  run_id: string;
+  ended_at: string;
+}
+
+export interface SoloLeaderboard {
+  entries: SoloLeaderboardEntry[];
+  you?: SoloLeaderboardEntry;
+  resets_in_sec: number;
+}
+
+export interface SoloMyStats {
+  best_score: number;
+  longest_streak: number;
+  avg_response_ms: number;
+  runs_played: number;
+  todays_best: number;
+  todays_rank: number;
+  on_leaderboard: boolean;
+}
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api/play${path}`, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  if (!res.ok) {
+    // Surface the backend's error.code so the run UI can branch on it
+    // (e.g. round_token_invalid → soft-recover to GET /runs/{id}).
+    const body = await res.json().catch(() => ({}));
+    const code = body?.error?.code ?? "request_failed";
+    const msg = body?.error?.message ?? `HTTP ${res.status}`;
+    throw Object.assign(new Error(msg), { code, status: res.status });
+  }
+  const body = await res.json();
+  return body.data as T;
+}
+
+export const playClient = {
+  startRun: () => call<SoloStartResponse>("/solo/runs", { method: "POST" }),
+  getRun: (id: string) => call<{ run: SoloRun; current_round?: SoloRound }>(`/solo/runs/${encodeURIComponent(id)}`),
+  submitAnswer: (id: string, body: { round_token: string; opening_id: string | null; client_response_ms: number }) =>
+    call<SoloAnswerResponse>(`/solo/runs/${encodeURIComponent(id)}/answer`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  leaderboard: (date?: string) =>
+    call<SoloLeaderboard>(`/solo/leaderboard${date ? `?date=${encodeURIComponent(date)}` : ""}`),
+  myStats: () => call<SoloMyStats>("/solo/me/stats"),
+};
+
+// Formatting helpers shared between hub and run-end pages.
+export function formatResetCountdown(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h <= 0) return `${m}m`;
+  return `${String(h).padStart(2, "0")}h ${String(m).padStart(2, "0")}m`;
+}
+
+export function formatResponseMs(ms: number): string {
+  if (!ms || ms <= 0) return "—";
+  const s = ms / 1000;
+  return s < 10 ? s.toFixed(1) + "s" : Math.round(s) + "s";
+}

--- a/pages/api/play/solo/leaderboard.ts
+++ b/pages/api/play/solo/leaderboard.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  const date = typeof req.query.date === "string" ? req.query.date : "";
+  const path = `/play/solo/leaderboard${date ? `?date=${encodeURIComponent(date)}` : ""}`;
+  const upstream = await fetch(backendUrl(path), {
+    headers: buildCsrfHeaders(req.headers.cookie),
+  });
+  const body = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(body);
+}

--- a/pages/api/play/solo/me/stats.ts
+++ b/pages/api/play/solo/me/stats.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  const upstream = await fetch(backendUrl("/play/solo/me/stats"), {
+    headers: buildCsrfHeaders(req.headers.cookie),
+  });
+  const body = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(body);
+}

--- a/pages/api/play/solo/runs/[id].ts
+++ b/pages/api/play/solo/runs/[id].ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+// GET /api/play/solo/runs/{id} — fetch a run + its currently-pending
+// round for crash recovery. The frontend calls this on mount of the
+// run page when it has a run_id in the URL but no in-memory state.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  const id = String(req.query.id ?? "");
+  if (!id) return res.status(400).json({ error: "id is required" });
+
+  const upstream = await fetch(backendUrl(`/play/solo/runs/${encodeURIComponent(id)}`), {
+    headers: buildCsrfHeaders(req.headers.cookie),
+  });
+  copyBackendCookies(res, upstream);
+  const body = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(body);
+}

--- a/pages/api/play/solo/runs/[id]/answer.ts
+++ b/pages/api/play/solo/runs/[id]/answer.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+// POST /api/play/solo/runs/{id}/answer — submit the round answer.
+// opening_id may be null for "no guess / timeout"; round_token is
+// required and the backend rejects mismatches with 401.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const id = String(req.query.id ?? "");
+  if (!id) return res.status(400).json({ error: "id is required" });
+
+  const body = req.body ?? {};
+  const upstream = await fetch(backendUrl(`/play/solo/runs/${encodeURIComponent(id)}/answer`), {
+    method: "POST",
+    headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+    body: JSON.stringify({
+      round_token: body.round_token ?? "",
+      opening_id: body.opening_id ?? null,
+      client_response_ms: Number(body.client_response_ms ?? 0) | 0,
+    }),
+  });
+  copyBackendCookies(res, upstream);
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(text);
+}

--- a/pages/api/play/solo/runs/index.ts
+++ b/pages/api/play/solo/runs/index.ts
@@ -1,0 +1,20 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+// POST /api/play/solo/runs — start a new solo Endless run.
+// Proxied straight through so cookies + CSRF survive. The backend
+// closes any prior active run for this user before issuing the first
+// round, so the client doesn't need to clean up on its side.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+
+  const upstream = await fetch(backendUrl("/play/solo/runs"), {
+    method: "POST",
+    headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+  });
+  copyBackendCookies(res, upstream);
+  const body = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(body);
+}

--- a/pages/play/index.tsx
+++ b/pages/play/index.tsx
@@ -1,0 +1,223 @@
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+import Layout from "@/components/Layout";
+
+import { getSoloLeaderboard, getSoloMyStats } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import { SOLO, Eyebrow } from "@/components/solo/atoms";
+import { formatResetCountdown, formatResponseMs } from "@/lib/play";
+import type { SoloLeaderboard, SoloMyStats } from "@/lib/play";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+  stats: SoloMyStats | null;
+  leaderboard: SoloLeaderboard;
+  apiOnline: boolean;
+}
+
+const FALLBACK_LEADERBOARD: SoloLeaderboard = {
+  entries: [],
+  resets_in_sec: 6 * 3600,
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+
+  // The hub renders whether or not the user is signed in — the
+  // leaderboard is public. Stats only make sense for a logged-in
+  // viewer, so the helper returns null on 401.
+  let stats: SoloMyStats | null = null;
+  let leaderboard: SoloLeaderboard = FALLBACK_LEADERBOARD;
+  let apiOnline = true;
+  try {
+    leaderboard = await getSoloLeaderboard(undefined, session.cookie);
+    if (session.user) {
+      stats = await getSoloMyStats(session.cookie).catch(() => null);
+    }
+  } catch {
+    apiOnline = false;
+  }
+  return {
+    props: {
+      user: session.user,
+      modQueueCount: session.modQueueCount,
+      stats,
+      leaderboard,
+      apiOnline,
+    },
+  };
+};
+
+export default function SoloHub({ user, modQueueCount, stats, leaderboard, apiOnline }: Props) {
+  return (
+    <Layout user={user} modQueueCount={modQueueCount} title="Solo (Endless) — Opening Wiki">
+      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 40px 60px" }}>
+          <header style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 32, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+            <div>
+              <Eyebrow>Play · solo</Eyebrow>
+              <h1 style={{ margin: "12px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.98 }}>
+                Guess the opening. <span style={{ color: SOLO.accent }}>Alone.</span>
+              </h1>
+              <p style={{ margin: "12px 0 0", color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55 }}>
+                One run, three lives, a streak that keeps regenerating them. Daily leaderboard resets at midnight UTC.
+              </p>
+            </div>
+            {stats && stats.runs_played > 0 && (
+              <div style={{ display: "flex", gap: 24, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.06em" }}>
+                <div>
+                  <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>{stats.runs_played} runs</div>
+                  all time
+                </div>
+                {stats.todays_rank > 0 && (
+                  <div>
+                    <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>#{stats.todays_rank}</div>
+                    today
+                  </div>
+                )}
+              </div>
+            )}
+          </header>
+
+          {!apiOnline && (
+            <div style={{ marginTop: 24, padding: 16, borderRadius: 8, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, color: SOLO.fg2 }}>
+              The play backend is unreachable. The leaderboard below is empty until the API comes back.
+            </div>
+          )}
+
+          {/* Endless — sole mode, full width */}
+          <section style={{
+            background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
+            border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
+            position: "relative", overflow: "hidden", minHeight: 280, marginTop: 32,
+            display: "flex", flexDirection: "column",
+          }}>
+            <div style={{
+              position: "absolute", top: -60, right: -60, width: 420, height: 420, borderRadius: "50%",
+              background: `radial-gradient(circle, ${SOLO.accent}22 0%, transparent 70%)`,
+            }} />
+            <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>Endless · live</Eyebrow>
+            <h2 style={{ margin: "14px 0 10px", fontWeight: 800, fontSize: 48, letterSpacing: "-0.04em", lineHeight: 1, maxWidth: 640 }}>
+              How far can you go before you slip?
+            </h2>
+            <p style={{ margin: 0, color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55 }}>
+              Three lives. Earn one back every five in a row. Difficulty climbs as you do. Run ends when you&apos;re out.
+            </p>
+            <div style={{ flex: 1, minHeight: 32 }} />
+            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8 }}>
+              {user ? (
+                <Link href="/play/run" style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
+                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
+                  textDecoration: "none",
+                  boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  Start run
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              ) : (
+                <Link href={`/login?next=${encodeURIComponent("/play")}`} style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
+                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
+                  textDecoration: "none",
+                  boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  Log in to play
+                </Link>
+              )}
+              <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, lineHeight: 1.4 }}>
+                ~ 8 min<br />top-1000 pool
+              </div>
+            </div>
+          </section>
+
+          <section style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
+            {stats && (
+              <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
+                <Eyebrow>Your endless · all-time</Eyebrow>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px 36px", marginTop: 18 }}>
+                  {[
+                    [String(stats.best_score), "best run"],
+                    [String(stats.longest_streak), "longest streak"],
+                    [formatResponseMs(stats.avg_response_ms), "avg response"],
+                    [String(stats.runs_played), "runs played"],
+                  ].map(([v, l]) => (
+                    <div key={l}>
+                      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 32, letterSpacing: "-0.03em", color: SOLO.fg, lineHeight: 1 }}>{v}</div>
+                      <div style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, marginTop: 6 }}>{l}</div>
+                    </div>
+                  ))}
+                </div>
+                <div style={{ marginTop: 22, paddingTop: 18, borderTop: `1px dashed ${SOLO.line}`, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+                    Today&apos;s best · <span style={{ color: SOLO.accent }}>{stats.todays_best}</span>
+                  </div>
+                  {stats.todays_rank > 0 && (
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+                      You&apos;re <span style={{ color: SOLO.fg }}>#{stats.todays_rank}</span> today
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+                <Eyebrow>Daily leaderboard</Eyebrow>
+                <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.08em" }}>
+                  resets in {formatResetCountdown(leaderboard.resets_in_sec)}
+                </div>
+              </div>
+              {leaderboard.entries.length === 0 && (
+                <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, padding: 12 }}>
+                  No runs today yet. Be the first.
+                </div>
+              )}
+              {leaderboard.entries.slice(0, 10).map((e) => {
+                const you = e.user_id === user?.id;
+                return (
+                  <LeaderboardRow key={e.run_id} rank={e.rank} name={e.display_name} score={e.score} you={you} />
+                );
+              })}
+              {leaderboard.you && !leaderboard.entries.some((e) => e.user_id === user?.id) && (
+                <>
+                  <div style={{
+                    display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
+                    padding: "8px 12px", marginBottom: 2, fontFamily: SOLO.mono, fontSize: 13, color: SOLO.fg4,
+                  }}>
+                    <div>…</div><div /><div />
+                  </div>
+                  <LeaderboardRow rank={leaderboard.you.rank} name="you" score={leaderboard.you.score} you />
+                </>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+function LeaderboardRow({ rank, name, score, you }: { rank: number | string; name: string; score: number; you?: boolean }) {
+  return (
+    <div style={{
+      display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
+      padding: "8px 12px", borderRadius: 6,
+      background: you ? `${SOLO.accent}14` : "transparent",
+      border: you ? `1px solid ${SOLO.accent}44` : "1px solid transparent",
+      marginBottom: 2,
+    }}>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 13, color: you ? SOLO.accent : SOLO.fg3, fontWeight: you ? 600 : 400 }}>{rank}</div>
+      <div style={{ fontFamily: SOLO.sans, fontSize: 13, color: you ? SOLO.fg : SOLO.fg2, fontWeight: you ? 600 : 400 }}>
+        {name}{you ? " (you)" : ""}
+      </div>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 14, color: you ? SOLO.accent : SOLO.fg, fontWeight: 500 }}>{score}</div>
+    </div>
+  );
+}

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -1,0 +1,620 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { loadSession } from "@/lib/session";
+import { SOLO, Eyebrow, BigNum, Heart, TimerBar, Waveform } from "@/components/solo/atoms";
+import { playClient, formatResponseMs } from "@/lib/play";
+import type {
+  SoloAnswerResponse, SoloOpening, SoloRound, SoloRun, SoloRunSummary,
+} from "@/lib/play";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user) {
+    return {
+      redirect: { destination: `/login?next=${encodeURIComponent("/play/run")}`, permanent: false },
+    };
+  }
+  return { props: { user: session.user, modQueueCount: session.modQueueCount } };
+};
+
+// Run-flow state machine. Each phase is a distinct screen and only one
+// is in-DOM at a time.
+type Phase =
+  | { kind: "starting" }
+  | { kind: "mode-reveal"; countdownMs: number; round: SoloRound; run: SoloRun }
+  | { kind: "in-match"; round: SoloRound; run: SoloRun; clipPlayedMs: number }
+  | { kind: "reveal"; result: SoloAnswerResponse; nextAt: number; run: SoloRun }
+  | { kind: "ended"; run: SoloRun; summary: SoloRunSummary }
+  | { kind: "error"; message: string };
+
+const MODE_REVEAL_MS = 2000;
+const REVEAL_HOLD_MS = 3500;
+
+export default function SoloRunPage({ user, modQueueCount }: Props) {
+  const [phase, setPhase] = useState<Phase>({ kind: "starting" });
+  // The browser-decoded audio element. We keep one across rounds so the
+  // user-gesture autoplay grant carries over the run.
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // 1. start run on mount. CSRF + session cookies already in scope.
+  useEffect(() => {
+    let abandoned = false;
+    playClient.startRun()
+      .then(({ run, round }) => {
+        if (abandoned) return;
+        setPhase({ kind: "mode-reveal", countdownMs: MODE_REVEAL_MS, round, run });
+      })
+      .catch((err) => {
+        if (abandoned) return;
+        setPhase({ kind: "error", message: err.message ?? "Failed to start run" });
+      });
+    return () => { abandoned = true; };
+  }, []);
+
+  // 2. mode-reveal tick — counts down to 0, then drops us into in-match.
+  useEffect(() => {
+    if (phase.kind !== "mode-reveal") return;
+    if (phase.countdownMs <= 0) {
+      setPhase({ kind: "in-match", round: phase.round, run: phase.run, clipPlayedMs: 0 });
+      return;
+    }
+    const t = setTimeout(() => {
+      setPhase((p) => p.kind === "mode-reveal" ? { ...p, countdownMs: Math.max(0, p.countdownMs - 100) } : p);
+    }, 100);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  // 3. in-match: start the clip and tick the timer. Server tells us
+  // the duration; we render the waveform progress from a local
+  // wall-clock counter so seeking the audio mid-round doesn't desync.
+  const inMatchStart = useRef<number>(0);
+  useEffect(() => {
+    if (phase.kind !== "in-match") return;
+    inMatchStart.current = Date.now();
+    if (audioRef.current) {
+      try {
+        audioRef.current.src = phase.round.clip_url;
+        audioRef.current.currentTime = 0;
+        audioRef.current.play().catch(() => {});
+      } catch { /* autoplay block — UI is still usable */ }
+    }
+    const id = setInterval(() => {
+      setPhase((p) => {
+        if (p.kind !== "in-match") return p;
+        const played = Date.now() - inMatchStart.current;
+        if (played >= p.round.clip_duration_ms) {
+          // 20s elapsed without an answer → server-side timeout (we
+          // POST null and let the backend mark it wrong + decrement
+          // lives, single source of truth).
+          submitTimeout(p);
+          return p;
+        }
+        return { ...p, clipPlayedMs: played };
+      });
+    }, 100);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase.kind, phase.kind === "in-match" ? phase.round.round_id : null]);
+
+  // 4. reveal → auto-advance after REVEAL_HOLD_MS. If the result was
+  // run-over the server has already attached a summary; we land on the
+  // ended phase directly.
+  useEffect(() => {
+    if (phase.kind !== "reveal") return;
+    const timeUntilAdvance = phase.nextAt - Date.now();
+    if (timeUntilAdvance <= 0) {
+      advanceFromReveal(phase);
+      return;
+    }
+    const t = setTimeout(() => advanceFromReveal(phase), timeUntilAdvance);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase]);
+
+  const advanceFromReveal = (rev: Phase & { kind: "reveal" }) => {
+    if (rev.result.run_summary) {
+      setPhase({ kind: "ended", run: rev.result.run, summary: rev.result.run_summary });
+      return;
+    }
+    if (rev.result.next_round) {
+      setPhase({ kind: "mode-reveal", countdownMs: MODE_REVEAL_MS, round: rev.result.next_round, run: rev.result.run });
+    }
+  };
+
+  const submitTimeout = useCallback((p: Phase & { kind: "in-match" }) => {
+    // Don't fire if we already moved on (e.g. user submitted in the
+    // same tick).
+    submitAnswer(p, null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const submitAnswer = useCallback(async (p: Phase & { kind: "in-match" }, openingId: string | null) => {
+    setPhase({ kind: "starting" });
+    try {
+      const response = await playClient.submitAnswer(p.run.id, {
+        round_token: p.round.round_token,
+        opening_id: openingId,
+        client_response_ms: Date.now() - inMatchStart.current,
+      });
+      if (audioRef.current) {
+        try { audioRef.current.pause(); } catch { /* */ }
+      }
+      setPhase({ kind: "reveal", result: response, nextAt: Date.now() + REVEAL_HOLD_MS, run: response.run });
+    } catch (err: any) {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to submit answer" });
+    }
+  }, []);
+
+  return (
+    <>
+      <Head><title>Solo run · Opening Wiki</title></Head>
+      <audio ref={audioRef} preload="auto" />
+      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100vh", fontFamily: SOLO.sans, display: "flex", flexDirection: "column" }}>
+        <TopbarSolo />
+        {phase.kind === "starting" && <CenterMessage text="Loading run…" />}
+        {phase.kind === "error" && <ErrorScreen message={phase.message} />}
+        {phase.kind === "mode-reveal" && (
+          <ModeRevealScreen
+            mode={phase.round.mode}
+            countdownMs={phase.countdownMs}
+            run={phase.run}
+            round={phase.round}
+          />
+        )}
+        {phase.kind === "in-match" && (
+          <InMatchScreen
+            round={phase.round}
+            run={phase.run}
+            playedMs={phase.clipPlayedMs}
+            onSubmit={(openingId) => submitAnswer(phase, openingId)}
+          />
+        )}
+        {phase.kind === "reveal" && (
+          <RevealScreen result={phase.result} run={phase.result.run} />
+        )}
+        {phase.kind === "ended" && (
+          <RunEndScreen run={phase.run} summary={phase.summary} user={user} />
+        )}
+      </div>
+    </>
+  );
+}
+
+function TopbarSolo() {
+  // Local topbar — the global Topbar is 60px and themed for the
+  // catalog; we want the run page to feel like a distinct arcade
+  // surface. Brand link goes back to /play so the user can drop out
+  // without abandoning at random.
+  return (
+    <div style={{
+      height: 60, borderBottom: `1px solid ${SOLO.line}`,
+      background: "rgba(12,10,20,0.92)", backdropFilter: "blur(14px)",
+      display: "flex", alignItems: "center", padding: "0 40px", gap: 36,
+      position: "relative", zIndex: 5,
+    }}>
+      <Link href="/play" style={{ display: "flex", alignItems: "center", gap: 9, fontWeight: 700, fontSize: 16, letterSpacing: "-0.02em", color: SOLO.fg, textDecoration: "none" }}>
+        <span style={{ width: 18, height: 18, borderRadius: 5, background: SOLO.accent }} />
+        Opening<span style={{ color: SOLO.accent }}>Wiki</span>
+      </Link>
+    </div>
+  );
+}
+
+function CenterMessage({ text }: { text: string }) {
+  return (
+    <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: SOLO.fg3, fontFamily: SOLO.mono, fontSize: 14, letterSpacing: "0.12em" }}>
+      {text}
+    </div>
+  );
+}
+
+function ErrorScreen({ message }: { message: string }) {
+  return (
+    <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 16 }}>
+      <Eyebrow color={SOLO.danger} dotColor={SOLO.danger}>Something went wrong</Eyebrow>
+      <div style={{ color: SOLO.fg, fontSize: 18 }}>{message}</div>
+      <Link href="/play" style={{ color: SOLO.accent, fontFamily: SOLO.mono, fontSize: 13, textDecoration: "none" }}>back to hub →</Link>
+    </div>
+  );
+}
+
+function Hud({ run, mode, label }: { run: SoloRun; mode?: string; label?: string }) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", justifyContent: "space-between",
+      padding: "18px 40px", borderBottom: `1px solid ${SOLO.line}`,
+    }}>
+      <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+        {[0, 1, 2].map((i) => (
+          <Heart key={i} filled={i < run.lives} broken={i === run.lives && run.lives < 3} />
+        ))}
+        <span style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginLeft: 8, letterSpacing: "0.1em" }}>
+          {run.lives} left
+        </span>
+      </div>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4 }}>
+        <div style={{ fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", color: SOLO.fg3 }}>
+          Round {String(run.score + (run.lives_regen ?? 0) + (3 - run.lives) + 1).padStart(2, "0")}
+        </div>
+        {mode && (
+          <div style={{ fontFamily: SOLO.mono, fontSize: 12, color: SOLO.accent, letterSpacing: "0.2em", fontWeight: 600 }}>
+            ● {mode.toUpperCase()}
+          </div>
+        )}
+      </div>
+      <BigNum value={`× ${run.streak}`} label={label ?? "streak"} size={36} align="right" />
+    </div>
+  );
+}
+
+function ModeRevealScreen({ mode, countdownMs, run, round }: { mode: string; countdownMs: number; run: SoloRun; round: SoloRound }) {
+  const countdown = Math.ceil(countdownMs / 1000);
+  return (
+    <>
+      <TimerBar pct={0} />
+      <Hud run={run} />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", position: "relative", overflow: "hidden" }}>
+        <div style={{
+          position: "absolute", width: 800, height: 800, borderRadius: "50%",
+          background: `radial-gradient(circle, ${SOLO.accent}26 0%, transparent 60%)`,
+          filter: "blur(20px)", pointerEvents: "none",
+        }} />
+        <div style={{ fontFamily: SOLO.mono, fontSize: 13, letterSpacing: "0.4em", color: SOLO.fg3, marginBottom: 24 }}>— MODE —</div>
+        <div style={{
+          fontFamily: SOLO.sans, fontWeight: 900, fontSize: 200,
+          letterSpacing: "-0.06em", lineHeight: 0.85, color: SOLO.fg,
+          textShadow: `0 0 60px ${SOLO.accent}66`, position: "relative",
+        }}>{mode.toUpperCase()}</div>
+        <div style={{ fontFamily: SOLO.sans, fontSize: 17, color: SOLO.fg2, marginTop: 18, maxWidth: 480, textAlign: "center", lineHeight: 1.5 }}>
+          {mode === "audio" ? "Ears only. No video. Just the sound of the opening." :
+           mode === "visual" ? "A still frame. No music." :
+           "Lyrics only — instrumental stripped out."}
+        </div>
+        <div style={{ marginTop: 60, display: "flex", alignItems: "center", gap: 16 }}>
+          <div style={{
+            width: 56, height: 56, borderRadius: "50%",
+            border: `2px solid ${SOLO.accent}`, display: "grid", placeItems: "center",
+            fontFamily: SOLO.mono, fontSize: 28, fontWeight: 600, color: SOLO.accent,
+            boxShadow: `0 0 30px ${SOLO.accent}55, inset 0 0 20px ${SOLO.accent}22`,
+          }}>{countdown}</div>
+          <div style={{ fontFamily: SOLO.mono, fontSize: 12, letterSpacing: "0.16em", textTransform: "uppercase", color: SOLO.fg3 }}>
+            clip starts in
+          </div>
+        </div>
+        <div style={{ position: "absolute", bottom: 24, right: 40, fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4 }}>
+          round {round.round_no}
+        </div>
+      </div>
+    </>
+  );
+}
+
+function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; run: SoloRun; playedMs: number; onSubmit: (openingId: string | null) => void }) {
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; anime: string; year: number | null }>>([]);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  // Debounced autocomplete fetch — backend /api/v1/search returns
+  // openings + anime + singer; we project openings only for the
+  // suggestion list.
+  useEffect(() => {
+    if (query.trim().length < 2) { setSuggestions([]); return; }
+    const handle = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}&types=opening&limit=8`, { credentials: "include" });
+        if (!res.ok) return;
+        const body = await res.json();
+        if (queryRef.current !== query) return;
+        const items = (body?.data?.openings ?? []).slice(0, 8).map((o: any) => ({
+          id: o.id, title: o.title,
+          anime: o.anime?.name ?? "—",
+          year: o.anime?.year ?? null,
+        }));
+        setSuggestions(items);
+        setActiveIdx(0);
+      } catch { /* swallow — typing isn't worth a toast */ }
+    }, 120);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(suggestions.length - 1, i + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const pick = suggestions[activeIdx];
+      if (pick) onSubmit(pick.id);
+    } else if (e.key === "Escape") {
+      setQuery("");
+      setSuggestions([]);
+    }
+  };
+
+  const pct = Math.min(1, playedMs / round.clip_duration_ms);
+  const secsLeft = Math.max(0, (round.clip_duration_ms - playedMs) / 1000);
+
+  return (
+    <>
+      <TimerBar pct={pct} danger={secsLeft < 5} />
+      <Hud run={run} mode={round.mode} />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "40px 0 30px", position: "relative" }}>
+        <div style={{
+          position: "absolute", top: 20, right: 40,
+          fontFamily: SOLO.mono, fontSize: 56, fontWeight: 500,
+          letterSpacing: "-0.04em", color: secsLeft < 5 ? SOLO.danger : SOLO.fg, lineHeight: 1,
+        }}>
+          {secsLeft.toFixed(1)}<span style={{ color: SOLO.fg4, fontSize: 32 }}>s</span>
+        </div>
+        <div style={{
+          position: "absolute", top: 28, left: 40,
+          fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3,
+          letterSpacing: "0.14em", textTransform: "uppercase",
+        }}>
+          clip · {(round.clip_duration_ms / 1000).toFixed(0)}s
+        </div>
+        <Waveform played={pct} />
+        <div style={{ textAlign: "center", marginTop: 22, fontFamily: SOLO.sans, fontSize: 14, color: SOLO.fg3 }}>
+          Type the opening you hear. ↵ to submit.
+        </div>
+      </div>
+      <div style={{ padding: "0 40px 32px", position: "relative" }}>
+        {suggestions.length > 0 && (
+          <div style={{
+            position: "absolute", bottom: "100%", left: 40, right: 40,
+            background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 10,
+            marginBottom: 8, overflow: "hidden",
+            boxShadow: "0 -20px 50px -10px rgba(0,0,0,0.5)",
+          }}>
+            <div style={{ padding: "10px 16px", fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, borderBottom: `1px solid ${SOLO.line}` }}>
+              Matches by song · anime
+            </div>
+            {suggestions.map((s, i) => (
+              <div
+                key={s.id}
+                onClick={() => onSubmit(s.id)}
+                onMouseEnter={() => setActiveIdx(i)}
+                style={{
+                  display: "flex", alignItems: "center", gap: 14, padding: "12px 16px",
+                  background: i === activeIdx ? SOLO.bg3 : "transparent",
+                  borderLeft: i === activeIdx ? `2px solid ${SOLO.accent}` : "2px solid transparent",
+                  cursor: "pointer",
+                }}
+              >
+                <div style={{
+                  width: 38, height: 52, background: SOLO.bg2, borderRadius: 4,
+                  border: `1px solid ${SOLO.line}`, flexShrink: 0,
+                  backgroundImage: `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 6px, ${SOLO.bg2} 6px 7px)`,
+                }} />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
+                  <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>
+                    {s.anime}{s.year ? ` · ${s.year}` : ""}
+                  </div>
+                </div>
+                {i === activeIdx && (
+                  <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "2px 6px", borderRadius: 3 }}>↵</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+        <div style={{
+          background: SOLO.bg2, border: `1px solid ${SOLO.accent}`,
+          borderRadius: 10, padding: "16px 18px",
+          boxShadow: `0 0 0 4px ${SOLO.accent}22, 0 -20px 60px -20px ${SOLO.accent}22`,
+          display: "flex", alignItems: "center", gap: 14,
+        }}>
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" style={{ color: SOLO.accent, flexShrink: 0 }} aria-hidden>
+            <circle cx="11" cy="11" r="7" stroke="currentColor" strokeWidth="2" />
+            <path d="M20 20l-3-3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+          </svg>
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKey}
+            placeholder="Start typing the song or anime…"
+            style={{
+              flex: 1, fontSize: 18, fontWeight: 500, color: SOLO.fg,
+              letterSpacing: "-0.01em", fontFamily: SOLO.sans,
+              background: "transparent", border: "none", outline: "none",
+            }}
+          />
+          <span style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ submit</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRun }) {
+  const correct = result.round_result.correct;
+  const op = result.round_result.correct_opening;
+  return (
+    <>
+      <div style={{ position: "absolute", top: 60, left: 0, right: 0, bottom: 0, background: correct ? `${SOLO.ok}10` : `${SOLO.danger}0d`, pointerEvents: "none" }} />
+      <TimerBar pct={0.4} danger={!correct} />
+      <Hud run={run} label={correct && result.round_result.life_regen ? "streak +1 · ♥+1" : correct ? "streak +1" : "streak reset"} />
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
+        <div style={{ position: "absolute", top: 30, left: 40 }}>
+          <Eyebrow color={correct ? SOLO.ok : SOLO.danger} dotColor={correct ? SOLO.ok : SOLO.danger}>
+            {correct ? `Correct · ${formatResponseMs(result.round_result.your_response_ms)}` : "Time's up · 20.0s"}
+          </Eyebrow>
+        </div>
+        <div style={{
+          display: "grid", gridTemplateColumns: "auto 1fr", gap: 40, maxWidth: 880,
+          background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 14,
+          padding: 36, position: "relative", overflow: "hidden",
+        }}>
+          <div style={{
+            position: "absolute", inset: -1, borderRadius: 14, pointerEvents: "none",
+            border: `1px solid ${correct ? SOLO.ok : SOLO.danger}55`,
+            boxShadow: `0 0 40px ${correct ? SOLO.ok : SOLO.danger}33, inset 0 0 60px ${correct ? SOLO.ok : SOLO.danger}0a`,
+          }} />
+          <div style={{
+            width: 200, height: 280, borderRadius: 8, background: SOLO.bg3,
+            border: `1px solid ${SOLO.line2}`,
+            backgroundImage: `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 14px, #221c33 14px 15px)`,
+            display: "grid", placeItems: "center",
+            fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.14em", textTransform: "uppercase",
+          }}>cover · 2:3</div>
+          <div style={{ display: "flex", flexDirection: "column", justifyContent: "center" }}>
+            <div style={{ fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", color: correct ? SOLO.ok : SOLO.danger, marginBottom: 10 }}>
+              {correct ? `✓ ${op?.title ?? "—"}` : "✕ The answer was"}
+            </div>
+            <h2 style={{ margin: 0, fontFamily: SOLO.sans, fontWeight: 800, fontSize: correct ? 56 : 48, letterSpacing: "-0.04em", lineHeight: 0.95, color: SOLO.fg }}>
+              {correct ? op?.anime?.name ?? "—" : op?.title ?? "—"}
+            </h2>
+            <div style={{ fontFamily: SOLO.sans, fontSize: 17, color: SOLO.fg2, marginTop: 6 }}>
+              {correct
+                ? <>{op?.anime?.name ?? ""}</>
+                : <>from <em style={{ fontStyle: "normal", color: SOLO.accent }}>{op?.anime?.name ?? "—"}</em></>}
+            </div>
+            <div style={{ display: "flex", gap: 36, marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line2}` }}>
+              <StatCell value={correct ? `+${result.round_result.score_delta}` : "+0"} label="score" color={correct ? SOLO.ok : SOLO.danger} />
+              <StatCell value={formatResponseMs(result.round_result.your_response_ms)} label="your time" />
+              <StatCell value={formatResponseMs(result.round_result.avg_player_response_ms)} label="avg player" />
+              {op && (
+                <StatCell value={op.avg_rating ? op.avg_rating.toFixed(1) : "—"} label="community" color={SOLO.accent} />
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function StatCell({ value, label, color = SOLO.fg }: { value: string; label: string; color?: string }) {
+  return (
+    <div>
+      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 28, color, letterSpacing: "-0.03em", lineHeight: 1 }}>{value}</div>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, marginTop: 6 }}>{label}</div>
+    </div>
+  );
+}
+
+function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSummary; user: User | null }) {
+  const lengthMs = useMemo(() => {
+    const ended = run.ended_at ? new Date(run.ended_at).getTime() : Date.now();
+    return ended - new Date(run.started_at).getTime();
+  }, [run]);
+  const lengthStr = useMemo(() => {
+    const total = Math.max(0, Math.floor(lengthMs / 1000));
+    const m = Math.floor(total / 60);
+    const s = total % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+  }, [lengthMs]);
+
+  return (
+    <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100%", fontFamily: SOLO.sans }}>
+      <div style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
+        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+          <div>
+            <Eyebrow color={SOLO.danger} dotColor={SOLO.danger}>Run over · all lives spent</Eyebrow>
+            <h1 style={{ margin: "14px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 88, letterSpacing: "-0.05em", lineHeight: 0.9 }}>
+              <span style={{ color: SOLO.accent }}>{summary.score}</span> correct.
+            </h1>
+            <p style={{ margin: "14px 0 0", color: SOLO.fg2, fontSize: 16, maxWidth: 520, lineHeight: 1.55 }}>
+              {user ? `Run as ${user.display_name}.` : "Anonymous run."} Longest streak this run: {summary.longest_streak}.
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 12 }}>
+            <Link href="/play/run" style={{
+              background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+              padding: "14px 22px", fontWeight: 600, fontSize: 14, cursor: "pointer",
+              display: "inline-flex", alignItems: "center", gap: 8, textDecoration: "none",
+              boxShadow: `0 0 30px ${SOLO.accent}55`,
+            }}>
+              Run again
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+                <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </Link>
+            <Link href="/play" style={{
+              background: "transparent", border: `1px solid ${SOLO.line2}`, color: SOLO.fg2,
+              borderRadius: 8, padding: "14px 22px", fontWeight: 500, fontSize: 14, textDecoration: "none",
+            }}>Back to hub</Link>
+          </div>
+        </header>
+
+        <section style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 20, marginTop: 32 }}>
+          <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 28 }}>
+            <Eyebrow>This run · by mode</Eyebrow>
+            {summary.by_mode.length === 0 && (
+              <div style={{ marginTop: 18, color: SOLO.fg3, fontFamily: SOLO.mono, fontSize: 12 }}>No rounds played.</div>
+            )}
+            {summary.by_mode.map((m) => {
+              const pct = m.total > 0 ? m.hits / m.total : 0;
+              return (
+                <div key={m.mode} style={{ marginTop: 22 }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: 8 }}>
+                    <span style={{ fontFamily: SOLO.mono, fontSize: 13, letterSpacing: "0.16em", textTransform: "uppercase", color: SOLO.fg, fontWeight: 500 }}>{m.mode}</span>
+                    <div style={{ display: "flex", gap: 18, fontFamily: SOLO.mono, fontSize: 12, color: SOLO.fg3 }}>
+                      <span>
+                        <strong style={{ color: SOLO.fg, fontWeight: 500, fontSize: 14 }}>{m.hits}/{m.total}</strong>
+                      </span>
+                      <span>avg <strong style={{ color: SOLO.fg, fontWeight: 500, fontSize: 14 }}>{formatResponseMs(m.avg_response_ms)}</strong></span>
+                    </div>
+                  </div>
+                  <div style={{ height: 8, background: SOLO.bg3, borderRadius: 4, overflow: "hidden", position: "relative" }}>
+                    <div style={{
+                      position: "absolute", inset: 0, right: `${(1 - pct) * 100}%`,
+                      background: SOLO.accent, boxShadow: `0 0 12px ${SOLO.accent}88`,
+                      borderRadius: 4,
+                    }} />
+                  </div>
+                </div>
+              );
+            })}
+            <div style={{ marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line}`, display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr", gap: 20 }}>
+              <StatCell value={String(summary.longest_streak)} label="longest streak" />
+              <StatCell value={String(summary.lives_regen)} label="lives regen'd" />
+              <StatCell value={lengthStr} label="run length" />
+              <StatCell value={String(summary.score)} label="final score" color={SOLO.accent} />
+            </div>
+          </div>
+
+          {summary.missed_clips.length > 0 && (
+            <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 28 }}>
+              <Eyebrow color={SOLO.fg3} dotColor={SOLO.warn}>Clips you missed · review</Eyebrow>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginTop: 16 }}>
+                {summary.missed_clips.slice(0, 6).map((m) => (
+                  <Link href={`/openings/${encodeURIComponent(m.opening_id)}`} key={m.opening_id} style={{
+                    background: SOLO.bg3, border: `1px solid ${SOLO.line2}`, borderRadius: 8, padding: 12,
+                    textDecoration: "none", color: SOLO.fg,
+                  }}>
+                    <div style={{ fontFamily: SOLO.sans, fontSize: 13, fontWeight: 600, color: SOLO.fg, lineHeight: 1.2 }}>{m.title}</div>
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, marginTop: 4, letterSpacing: "0.06em" }}>{m.anime_name}{m.year ? ` · ${m.year}` : ""}</div>
+                  </Link>
+                ))}
+                {summary.missed_clips.length > 6 && (
+                  <div style={{
+                    background: "transparent", border: `1px dashed ${SOLO.line2}`, borderRadius: 8, padding: 12,
+                    display: "flex", alignItems: "center", justifyContent: "center", minHeight: 60,
+                    fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, letterSpacing: "0.08em",
+                  }}>+ {summary.missed_clips.length - 6} more</div>
+                )}
+              </div>
+            </div>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/play` hub: SSR-rendered Endless CTA, all-time stats, daily leaderboard preview (resets-in countdown). Falls back to a quiet "API offline" notice if the backend is unreachable.
- New `/play/run` page driving the full run flow client-side: starts a run on mount, 2s mode reveal, audio playback against the backend's new `/clips/*` origin, debounced autocomplete via the existing search endpoint, server-authoritative answer submission, reveal card with response-time + community stats, and a run-end summary (per-mode hits/avg, longest streak, missed-clips review).
- Twilight palette + atoms (Heart, BigNum, Waveform, Eyebrow, TimerBar) extracted into `components/solo/atoms.tsx` so the hub and run pages stay visually locked.
- API proxy routes under `/api/play/solo/*` reuse the existing CSRF + cookie helpers — the run page never touches the Go API directly.
- "Play" added to the global nav.

Wiki rationale: openingwiki/obsidian#2 → `decision-solo-endless-mvp`.
Pairs with: openingwiki/backend#27.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [ ] `npm run build` smoke.
- [ ] Run the backend branch (with `cmd/clipgen` having populated a few clips) and play a run end-to-end: mode reveal → audio → autocomplete pick → reveal card → next round → eventually run-end with summary + missed clips.
- [ ] Verify the audio autoplay grant carries across rounds (single `<audio>` element).
- [ ] Verify autocomplete `ArrowUp/Down/Enter/Escape` keyboard nav works as expected.
- [ ] Verify the hub still renders cleanly for logged-out viewers (CTA → /login).

🤖 Generated with [Claude Code](https://claude.com/claude-code)