### PR TITLE
chore(submit): drop the descriptive text under each track type card

### DIFF
--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -283,9 +283,9 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
   };
 
   const TYPE_OPTIONS = [
-    { value: "opening" as TrackKind, tag: "OP", cls: "op", name: "Opening", desc: "Intro sequence · ~90 sec · plays at the start of every episode" },
-    { value: "ending"  as TrackKind, tag: "ED", cls: "ed", name: "Ending",  desc: "Outro sequence · ~90 sec · plays at the end of every episode" },
-    { value: "ost"     as TrackKind, tag: "OST", cls: "ost", name: "OST / insert", desc: "Score, insert song, or character song · any length" },
+    { value: "opening" as TrackKind, tag: "OP", cls: "op", name: "Opening" },
+    { value: "ending"  as TrackKind, tag: "ED", cls: "ed", name: "Ending" },
+    { value: "ost"     as TrackKind, tag: "OST", cls: "ost", name: "OST / insert" },
   ];
 
   const titleLabel = kind === "ost" ? "Track title" : kind === "ending" ? "Ending title" : "Opening title";
@@ -312,7 +312,6 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
                   <span className="tp-radio" />
                 </div>
                 <div className="tp-name">{opt.name}</div>
-                <div className="tp-desc">{opt.desc}</div>
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
Removes the descriptive line under each track-type pick on \`/submit\`:
- ~~Intro sequence · ~90 sec · plays at the start of every episode~~
- ~~Outro sequence · ~90 sec · plays at the end of every episode~~
- ~~Score, insert song, or character song · any length~~

The OP/ED/OST tag plus the type name already convey what each card is — the extra prose was visual noise.

## What stays
Tag (\`OP\` / \`ED\` / \`OST\`), name (\`Opening\` / \`Ending\` / \`OST / insert\`), radio dot, the section header (\`01 What kind of track?\`).

## Diff
3-line code change, no CSS touched. The \`.tp-desc\` rule in globals.css becomes dead but is harmless; leaving the rule in place since there might be other usages I haven't surveyed.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [ ] Open \`/submit\` → "Opening" tab → three cards render without the prose under the name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)