### PR TITLE
feat(pvp): hub card + new-battle page + lobby/match runtime

### DIFF
--- a/lib/pvp.ts
+++ b/lib/pvp.ts
@@ -1,0 +1,241 @@
+// PvP types + client. The REST helpers go through Next API routes
+// (so the cookie + CSRF flow matches the rest of the mutating API);
+// the WebSocket client opens directly against /api/v1/play/pvp/socket
+// with a one-shot token minted by /socket/token.
+
+export type MatchFormat = "ft5" | "ft10" | "ft15";
+export type PoolKind = "top_default" | "group";
+export type MatchStatus =
+  | "lobby"
+  | "countdown"
+  | "playing"
+  | "ended"
+  | "cancelled"
+  | "abandoned";
+
+export interface PvPMatch {
+  id: string;
+  room_code: string;
+  host_user_id: string;
+  status: MatchStatus;
+  format: MatchFormat;
+  target_score: number;
+  mode: string;
+  pool: { kind: PoolKind; group_id?: string | null };
+  winner_user_id: string | null;
+  by_forfeit: boolean;
+  expires_at: string;
+  created_at: string;
+}
+
+export interface PvPPlayer {
+  user_id: string;
+  display_name: string;
+  avatar_url: string | null;
+  seat: 1 | 2;
+  ready: boolean;
+  joined_at: string;
+}
+
+export interface PvPMatchView {
+  match: PvPMatch;
+  players: PvPPlayer[];
+  you_are: "host" | "opponent" | "guest";
+  h2h?: { wins: number; losses: number };
+}
+
+// Wire frames — server → client.
+export type FrameType =
+  | "lobby.state"
+  | "match.countdown"
+  | "round.start"
+  | "round.end"
+  | "match.end"
+  | "player.disconnected"
+  | "player.reconnected"
+  | "input.typing.opp"
+  | "server.pong"
+  | "error";
+
+export interface Frame<T = unknown> {
+  type: FrameType;
+  server_now_ms?: number;
+  data?: T;
+}
+
+export interface RoundStartData {
+  round_id: string;
+  round_no: number;
+  mode: string;
+  clip_url: string;
+  play_at_ms: number;
+  clip_duration_ms: number;
+  expires_at_ms: number;
+}
+
+export interface OpeningReveal {
+  id: string;
+  title: string;
+  anime_name: string;
+  singer_name: string;
+  year?: number;
+  avg_rating?: number;
+  rating_count?: number;
+}
+
+export interface RoundEndData {
+  round_id: string;
+  winner_user_id?: string | null;
+  no_score: boolean;
+  correct_opening: OpeningReveal;
+  responses: Record<
+    string,
+    {
+      status: "answered" | "locked" | "timeout";
+      picked_opening_id?: string | null;
+      was_correct?: boolean;
+      response_ms?: number;
+    }
+  >;
+  score: Record<string, number>;
+}
+
+export interface MatchEndData {
+  winner_user_id?: string | null;
+  by_forfeit: boolean;
+  final_score: Record<string, number>;
+  rounds: Array<{
+    round_no: number;
+    winner_user_id?: string | null;
+    no_score: boolean;
+    response_ms?: number;
+  }>;
+  duration_ms: number;
+}
+
+export interface PlayerDisconnectData {
+  user_id: string;
+  grace_expires_at_ms: number;
+}
+
+// REST helpers — all go through Next API proxies under /api/play/pvp.
+
+async function call<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`/api/play/pvp${path}`, {
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    const code = body?.error?.code ?? "request_failed";
+    const msg = body?.error?.message ?? `HTTP ${res.status}`;
+    throw Object.assign(new Error(msg), { code, status: res.status });
+  }
+  const body = await res.json();
+  return body.data as T;
+}
+
+export const pvpClient = {
+  createMatch: (format: MatchFormat, pool: { kind: PoolKind; group_id?: string }) =>
+    call<PvPMatchView>("/matches", {
+      method: "POST",
+      body: JSON.stringify({ format, pool }),
+    }),
+  getMatch: (code: string) =>
+    call<PvPMatchView>(`/matches/${encodeURIComponent(code)}`),
+  join: (code: string) =>
+    call<PvPMatchView>(`/matches/${encodeURIComponent(code)}/join`, { method: "POST" }),
+  ready: (code: string, ready: boolean) =>
+    call<PvPMatchView>(`/matches/${encodeURIComponent(code)}/ready`, {
+      method: "POST",
+      body: JSON.stringify({ ready }),
+    }),
+  leave: (code: string) =>
+    call<{ left: boolean }>(`/matches/${encodeURIComponent(code)}/leave`, { method: "POST" }),
+  cancel: (code: string) =>
+    call<{ cancelled: boolean }>(`/matches/${encodeURIComponent(code)}/cancel`, { method: "POST" }),
+  rematch: (code: string) =>
+    call<PvPMatchView>(`/matches/${encodeURIComponent(code)}/rematch`, { method: "POST" }),
+  mintWSToken: (room_code: string) =>
+    call<{ token: string; expires_at: string }>("/socket/token", {
+      method: "POST",
+      body: JSON.stringify({ room_code }),
+    }),
+};
+
+// PvPSocket wraps the browser WebSocket with reconnect semantics and
+// a tiny event emitter. The match page wires its state machine to
+// `onFrame` and treats the socket as a black box otherwise.
+export class PvPSocket {
+  private ws: WebSocket | null = null;
+  private closed = false;
+  private listeners = new Set<(f: Frame) => void>();
+  private statusListeners = new Set<(s: "open" | "closed" | "error") => void>();
+
+  constructor(private code: string) {}
+
+  async connect(): Promise<void> {
+    const { token } = await pvpClient.mintWSToken(this.code);
+    const url = new URL("/api/v1/play/pvp/socket", window.location.origin);
+    url.protocol = url.protocol.replace("http", "ws");
+    url.searchParams.set("token", token);
+    url.searchParams.set("room", this.code);
+    const ws = new WebSocket(url.toString());
+    this.ws = ws;
+    ws.onopen = () => this.fireStatus("open");
+    ws.onclose = () => {
+      this.fireStatus("closed");
+      this.ws = null;
+    };
+    ws.onerror = () => this.fireStatus("error");
+    ws.onmessage = (e) => {
+      try {
+        const frame = JSON.parse(e.data) as Frame;
+        for (const l of this.listeners) l(frame);
+      } catch {
+        /* ignore */
+      }
+    };
+  }
+
+  send(type: string, data?: unknown): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify({ type, data }));
+  }
+
+  submitAnswer(round_id: string, opening_id: string, client_submit_ms: number) {
+    this.send("answer.submit", { round_id, opening_id, client_submit_ms });
+  }
+  sendTyping() {
+    this.send("input.typing");
+  }
+  sendPing() {
+    this.send("client.ping", { client_sent_ms: Date.now() });
+  }
+
+  onFrame(fn: (f: Frame) => void): () => void {
+    this.listeners.add(fn);
+    return () => this.listeners.delete(fn);
+  }
+  onStatus(fn: (s: "open" | "closed" | "error") => void): () => void {
+    this.statusListeners.add(fn);
+    return () => this.statusListeners.delete(fn);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  private fireStatus(s: "open" | "closed" | "error") {
+    for (const l of this.statusListeners) l(s);
+  }
+}
+
+// Wire→view helper: returns the formatted "first to N" target for the
+// match HUD.
+export function targetFromFormat(format: MatchFormat): number {
+  return format === "ft5" ? 5 : format === "ft15" ? 15 : 10;
+}

--- a/pages/api/play/pvp/matches/[code].ts
+++ b/pages/api/play/pvp/matches/[code].ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders } from "@/lib/api-proxy";
+
+// GET /api/play/pvp/matches/{code} — read the lobby view.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  const code = String(req.query.code ?? "");
+  const upstream = await fetch(backendUrl(`/play/pvp/matches/${encodeURIComponent(code)}`), {
+    headers: buildCsrfHeaders(req.headers.cookie),
+  });
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(text);
+}

--- a/pages/api/play/pvp/matches/[code]/[action].ts
+++ b/pages/api/play/pvp/matches/[code]/[action].ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+// POST /api/play/pvp/matches/{code}/{action} — proxies all the
+// verb-style mutations on a match: join, ready, leave, cancel, edit,
+// rematch. Allowlist keeps the upstream URL injection-safe.
+const ALLOWED = new Set(["join", "ready", "leave", "cancel", "edit", "rematch"]);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const code = String(req.query.code ?? "");
+  const action = String(req.query.action ?? "");
+  if (!ALLOWED.has(action)) return res.status(404).json({ error: "unknown action" });
+  const upstream = await fetch(
+    backendUrl(`/play/pvp/matches/${encodeURIComponent(code)}/${action}`),
+    {
+      method: "POST",
+      headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+      body: req.body ? JSON.stringify(req.body) : undefined,
+    },
+  );
+  copyBackendCookies(res, upstream);
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(text);
+}

--- a/pages/api/play/pvp/matches/index.ts
+++ b/pages/api/play/pvp/matches/index.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
+
+// POST /api/play/pvp/matches — create a new PvP lobby.
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const upstream = await fetch(backendUrl("/play/pvp/matches"), {
+    method: "POST",
+    headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+    body: JSON.stringify(req.body ?? {}),
+  });
+  copyBackendCookies(res, upstream);
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(text);
+}

--- a/pages/api/play/pvp/socket/token.ts
+++ b/pages/api/play/pvp/socket/token.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl, buildCsrfHeaders } from "@/lib/api-proxy";
+
+// POST /api/play/pvp/socket/token — mint a one-shot WS upgrade
+// token. The WS itself opens against the absolute backend URL with
+// the token on the query string — no Next proxy involved (the
+// backend hits ingress directly).
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const upstream = await fetch(backendUrl("/play/pvp/socket/token"), {
+    method: "POST",
+    headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
+    body: JSON.stringify(req.body ?? {}),
+  });
+  const text = await upstream.text();
+  res.status(upstream.status);
+  res.setHeader("content-type", upstream.headers.get("content-type") ?? "application/json");
+  res.send(text);
+}

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -1,0 +1,819 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import Layout from "@/components/Layout";
+import { SOLO, Eyebrow } from "@/components/solo/atoms";
+import { loadSession } from "@/lib/session";
+import {
+  pvpClient,
+  PvPSocket,
+  type Frame,
+  type PvPMatchView,
+  type RoundStartData,
+  type RoundEndData,
+  type MatchEndData,
+  type PlayerDisconnectData,
+} from "@/lib/pvp";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User;
+  modQueueCount: number;
+  code: string;
+  initial: PvPMatchView | null;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user) {
+    const code = encodeURIComponent(String(ctx.params?.code ?? ""));
+    return { redirect: { destination: `/login?next=/play/b/${code}`, permanent: false } };
+  }
+  // The SSR fetch is intentionally lenient — if the match isn't
+  // found we still render the page with `initial: null` and let the
+  // client show a "Match not found" error. That matches the design
+  // (rooms expire, the link still resolves so the visitor sees what
+  // happened rather than a generic 404).
+  const code = String(ctx.params?.code ?? "");
+  let initial: PvPMatchView | null = null;
+  try {
+    const res = await fetch(
+      `${process.env.API_BASE_URL || "http://localhost:8080"}/api/v1/play/pvp/matches/${encodeURIComponent(code)}`,
+      { headers: session.cookie ? { cookie: session.cookie } : undefined, cache: "no-store" as RequestCache },
+    );
+    if (res.ok) {
+      const body = await res.json();
+      initial = body.data;
+    }
+  } catch {
+    // fall through to null
+  }
+  return {
+    props: { user: session.user, modQueueCount: session.modQueueCount, code, initial },
+  };
+};
+
+// ── Phase model ──────────────────────────────────────────────────────
+// One screen at a time. The WS drives transitions; REST mutations
+// (ready/leave/cancel) round-trip through pvpClient and the server
+// emits the resulting lobby.state which advances the phase.
+
+type Phase =
+  | { kind: "lobby" }
+  | { kind: "countdown"; startsAtMs: number }
+  | { kind: "reveal"; round: RoundStartData; countdownMs: number }
+  | { kind: "playing"; round: RoundStartData; playedMs: number }
+  | { kind: "round-end"; result: RoundEndData; round: RoundStartData; nextAt: number }
+  | { kind: "ended"; result: MatchEndData; winner: string | null }
+  | { kind: "error"; message: string }
+  | { kind: "disconnected"; userID: string; graceExpiresAtMs: number };
+
+const MODE_REVEAL_MS = 2000;
+const ROUND_END_HOLD_MS = 3500;
+
+export default function MatchPage({ user, modQueueCount, code, initial }: Props) {
+  const router = useRouter();
+  const [view, setView] = useState<PvPMatchView | null>(initial);
+  const [phase, setPhase] = useState<Phase>(initial?.match?.status === "ended"
+    ? { kind: "error", message: "This match has already ended." }
+    : { kind: "lobby" });
+  const [socketStatus, setSocketStatus] = useState<"connecting" | "open" | "closed">("connecting");
+  const sockRef = useRef<PvPSocket | null>(null);
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  // Refresh view from REST on mount + any time the phase resets to
+  // lobby. Cheap; saves a manual sync after REST mutations.
+  const refreshView = useCallback(async () => {
+    try {
+      const v = await pvpClient.getMatch(code);
+      setView(v);
+    } catch {
+      /* ignore */
+    }
+  }, [code]);
+
+  useEffect(() => {
+    const s = new PvPSocket(code);
+    sockRef.current = s;
+    const offFrame = s.onFrame((f) => handleFrame(f));
+    const offStatus = s.onStatus((st) => setSocketStatus(st === "open" ? "open" : st === "closed" ? "closed" : "closed"));
+    s.connect().catch((err) => {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to open match socket" });
+    });
+    const ping = setInterval(() => s.sendPing(), 15_000);
+    return () => {
+      clearInterval(ping);
+      offFrame();
+      offStatus();
+      s.close();
+      sockRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [code]);
+
+  function handleFrame(f: Frame) {
+    switch (f.type) {
+      case "lobby.state": {
+        // The server-sent lobby snapshot is authoritative.
+        const d = f.data as any;
+        setView((prev) => prev ? { ...prev, match: { ...prev.match, status: d.status, format: d.format, target_score: d.target_score }, players: d.players.map((p: any) => ({
+          user_id: p.user_id,
+          display_name: p.display_name,
+          avatar_url: null,
+          seat: p.seat,
+          ready: p.ready,
+          joined_at: prev.players.find((q) => q.user_id === p.user_id)?.joined_at ?? new Date().toISOString(),
+        })) } : prev);
+        break;
+      }
+      case "match.countdown": {
+        const d = f.data as { starts_at_ms: number };
+        setPhase({ kind: "countdown", startsAtMs: d.starts_at_ms });
+        break;
+      }
+      case "round.start": {
+        const d = f.data as RoundStartData;
+        setPhase({ kind: "reveal", round: d, countdownMs: MODE_REVEAL_MS });
+        break;
+      }
+      case "round.end": {
+        const d = f.data as RoundEndData;
+        setPhase((p) => p.kind === "playing" || p.kind === "reveal"
+          ? { kind: "round-end", result: d, round: p.kind === "playing" ? p.round : (p as any).round, nextAt: Date.now() + ROUND_END_HOLD_MS }
+          : p);
+        if (audioRef.current) {
+          try { audioRef.current.pause(); } catch { /* */ }
+        }
+        break;
+      }
+      case "match.end": {
+        const d = f.data as MatchEndData;
+        setPhase({ kind: "ended", result: d, winner: d.winner_user_id ?? null });
+        break;
+      }
+      case "player.disconnected": {
+        const d = f.data as PlayerDisconnectData;
+        if (d.user_id !== user.id) {
+          setPhase((p) =>
+            p.kind === "playing" || p.kind === "reveal" || p.kind === "round-end" || p.kind === "lobby"
+              ? { kind: "disconnected", userID: d.user_id, graceExpiresAtMs: d.grace_expires_at_ms }
+              : p,
+          );
+        }
+        break;
+      }
+      case "player.reconnected": {
+        setPhase((p) => p.kind === "disconnected" ? { kind: "lobby" } : p);
+        // Force a REST refresh — the opponent rejoined, we want the
+        // lobby state in sync.
+        refreshView();
+        break;
+      }
+    }
+  }
+
+  // Drive the 2-second mode-reveal countdown locally so the UI
+  // updates every frame; the actual clip play_at_ms is anchored by
+  // the server.
+  useEffect(() => {
+    if (phase.kind !== "reveal") return;
+    if (phase.countdownMs <= 0) {
+      // Start the in-match phase. Audio playback begins now.
+      const r = phase.round;
+      if (audioRef.current) {
+        try {
+          audioRef.current.src = r.clip_url;
+          audioRef.current.currentTime = 0;
+          audioRef.current.play().catch(() => {});
+        } catch { /* */ }
+      }
+      setPhase({ kind: "playing", round: r, playedMs: 0 });
+      return;
+    }
+    const t = setTimeout(() => {
+      setPhase((p) => p.kind === "reveal" ? { ...p, countdownMs: Math.max(0, p.countdownMs - 100) } : p);
+    }, 100);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  // Tick the clip timer.
+  const playingStartRef = useRef<number>(0);
+  useEffect(() => {
+    if (phase.kind !== "playing") return;
+    playingStartRef.current = Date.now();
+    const id = setInterval(() => {
+      setPhase((p) => p.kind === "playing"
+        ? { ...p, playedMs: Date.now() - playingStartRef.current }
+        : p);
+    }, 100);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [phase.kind === "playing" ? (phase as any).round.round_id : null]);
+
+  // Round-end → wait then either rely on next round.start, or fall
+  // through to ended/error.
+  useEffect(() => {
+    if (phase.kind !== "round-end") return;
+    const remaining = Math.max(0, phase.nextAt - Date.now());
+    const t = setTimeout(() => {
+      // The server will send round.start (or match.end) before this
+      // fires in steady state. If not, we stay on the reveal card
+      // and the next frame eventually moves us along.
+    }, remaining);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  // The lobby phase needs Ready / Leave / Cancel buttons.
+  const meReady = useMemo(
+    () => view?.players?.find((p) => p.user_id === user.id)?.ready ?? false,
+    [view, user.id],
+  );
+  const opponent = useMemo(
+    () => view?.players?.find((p) => p.user_id !== user.id) ?? null,
+    [view, user.id],
+  );
+
+  const handleReady = async () => {
+    try {
+      const next = await pvpClient.ready(code, !meReady);
+      setView(next);
+    } catch (err: any) {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to toggle ready" });
+    }
+  };
+  const handleLeave = async () => {
+    try {
+      await pvpClient.leave(code);
+      router.push("/play");
+    } catch (err: any) {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to leave" });
+    }
+  };
+  const handleCancel = async () => {
+    try {
+      await pvpClient.cancel(code);
+      router.push("/play");
+    } catch (err: any) {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to cancel" });
+    }
+  };
+  const handleRematch = async () => {
+    try {
+      const next = await pvpClient.rematch(code);
+      router.push(`/play/b/${next.match.room_code}`);
+    } catch (err: any) {
+      setPhase({ kind: "error", message: err?.message ?? "Failed to rematch" });
+    }
+  };
+
+  if (!view) {
+    return (
+      <Layout user={user} modQueueCount={modQueueCount} title="Match — Opening Wiki">
+        <CenterMessage text="Match not found. Has the link expired?" />
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout user={user} modQueueCount={modQueueCount} title={`Battle ${view.match.room_code}`}>
+      <Head><meta name="description" content="PvP battle." /></Head>
+      <audio ref={audioRef} preload="auto" />
+      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        {phase.kind === "lobby" && (
+          <LobbyView
+            view={view}
+            meReady={meReady}
+            opponent={opponent}
+            socketStatus={socketStatus}
+            onReady={handleReady}
+            onLeave={handleLeave}
+            onCancel={handleCancel}
+            isHost={view.you_are === "host"}
+            inviteUrl={`${typeof window !== "undefined" ? window.location.origin : ""}/play/b/${view.match.room_code}`}
+          />
+        )}
+        {phase.kind === "countdown" && (
+          <CountdownView startsAtMs={phase.startsAtMs} />
+        )}
+        {phase.kind === "reveal" && (
+          <RevealView mode={phase.round.mode} countdownMs={phase.countdownMs} view={view} />
+        )}
+        {phase.kind === "playing" && (
+          <PlayingView
+            view={view}
+            round={phase.round}
+            playedMs={phase.playedMs}
+            meID={user.id}
+            onSubmit={(opening_id) => {
+              sockRef.current?.submitAnswer(phase.round.round_id, opening_id, Date.now());
+            }}
+            onTyping={() => sockRef.current?.sendTyping()}
+          />
+        )}
+        {phase.kind === "round-end" && (
+          <RoundEndView result={phase.result} view={view} meID={user.id} />
+        )}
+        {phase.kind === "ended" && (
+          <MatchEndView
+            result={phase.result}
+            view={view}
+            meID={user.id}
+            onRematch={handleRematch}
+          />
+        )}
+        {phase.kind === "disconnected" && (
+          <DisconnectOverlay graceExpiresAtMs={phase.graceExpiresAtMs} userID={phase.userID} view={view} />
+        )}
+        {phase.kind === "error" && (
+          <CenterMessage text={phase.message} extra={<Link href="/play" style={{ color: SOLO.accent, fontFamily: SOLO.mono, fontSize: 13, textDecoration: "none" }}>back to play →</Link>} />
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+// ── Subviews ────────────────────────────────────────────────────────
+
+function CenterMessage({ text, extra }: { text: string; extra?: React.ReactNode }) {
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 16 }}>
+      <div style={{ color: SOLO.fg, fontSize: 18 }}>{text}</div>
+      {extra}
+    </div>
+  );
+}
+
+function LobbyView({
+  view, meReady, opponent, socketStatus, onReady, onLeave, onCancel, isHost, inviteUrl,
+}: {
+  view: PvPMatchView; meReady: boolean; opponent: any; socketStatus: string;
+  onReady: () => void; onLeave: () => void; onCancel: () => void;
+  isHost: boolean; inviteUrl: string;
+}) {
+  const me = view.players.find((p) => p.user_id === view.players.find((q) => q.seat === 1)?.user_id);
+  const filled = view.players.length === 2 && opponent;
+  const allReady = filled && view.players.every((p) => p.ready);
+  const copyInvite = async () => {
+    try { await navigator.clipboard.writeText(inviteUrl); } catch { /* */ }
+  };
+  return (
+    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "32px 40px 48px" }}>
+      <nav style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginBottom: 14, display: "flex", gap: 6 }}>
+        <Link href="/play" style={{ color: SOLO.fg2, textDecoration: "none" }}>Play</Link>
+        <span style={{ color: SOLO.fg4 }}>/</span>
+        <span style={{ color: SOLO.fg2 }}>Lobby</span>
+      </nav>
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 32, paddingBottom: 24, borderBottom: `1px solid ${SOLO.line}` }}>
+        <div>
+          <Eyebrow color={filled ? SOLO.ok : SOLO.fg3} dotColor={filled ? SOLO.ok : SOLO.accent}>
+            {filled ? "Lobby · 2 / 2" : "Lobby · open"}
+          </Eyebrow>
+          <h1 style={{ margin: "8px 0 0", fontWeight: 800, fontSize: 32, letterSpacing: "-0.025em", lineHeight: 1.05 }}>
+            {filled ? <>Ready when you <span style={{ color: SOLO.accent }}>are.</span></> : <>Waiting for an <span style={{ color: SOLO.accent }}>opponent.</span></>}
+          </h1>
+          <p style={{ margin: "8px 0 0", color: SOLO.fg3, fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.04em", maxWidth: 520, lineHeight: 1.6 }}>
+            {filled
+              ? "Both players need to press ready. The match starts 3 seconds after the second ready."
+              : "Share the link below — the match starts once they join and both of you press ready. The room stays open for 30 minutes."}
+          </p>
+        </div>
+        <div style={{ textAlign: "right", fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.06em" }}>
+          Room
+          <span style={{ display: "block", fontSize: 18, color: SOLO.fg, fontWeight: 500, letterSpacing: "0.08em", marginTop: 4 }}>
+            {view.match.room_code}
+          </span>
+        </div>
+      </div>
+
+      {/* VS panel */}
+      <div style={{ marginTop: 32, display: "grid", gridTemplateColumns: "1fr 80px 1fr", gap: 0, alignItems: "stretch" }}>
+        <PlayerCard
+          player={view.players.find((p) => p.user_id !== opponent?.user_id) ?? view.players[0]}
+          variant={isHost ? "you" : "opponent"}
+          label={isHost ? "You · host" : "Host"}
+          ready={view.players.find((p) => p.seat === 1)?.ready ?? false}
+        />
+        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", fontFamily: SOLO.mono, fontWeight: 600, fontSize: 20, color: SOLO.fg3, letterSpacing: "0.14em", gap: 14 }}>
+          <div style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
+          <div style={{ padding: "8px 0" }}>VS</div>
+          <div style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
+        </div>
+        {opponent ? (
+          <PlayerCard
+            player={opponent}
+            variant={isHost ? "opponent" : "you"}
+            label={isHost ? "Opponent" : "You"}
+            ready={opponent.ready}
+          />
+        ) : (
+          <EmptySlot />
+        )}
+      </div>
+
+      {/* Invite */}
+      {!filled && (
+        <div style={{
+          marginTop: 32, background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12,
+          padding: 28, display: "flex", flexDirection: "column", gap: 14, alignItems: "center", textAlign: "center",
+        }}>
+          <h3 style={{ margin: 0, fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, fontWeight: 500, display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", background: SOLO.warn, boxShadow: `0 0 10px ${SOLO.warn}` }} />
+            Share the invite
+          </h3>
+          <div style={{ fontWeight: 700, fontSize: 20, letterSpacing: "-0.02em", color: SOLO.fg }}>
+            Anyone with this link can join
+          </div>
+          <div style={{ width: "100%", maxWidth: 560 }}>
+            <div style={{ display: "flex", alignItems: "stretch", border: `1px solid ${SOLO.line2}`, borderRadius: 7, background: SOLO.bg, overflow: "hidden" }}>
+              <span style={{ flex: 1, padding: "11px 14px", fontFamily: SOLO.mono, fontSize: 12, color: SOLO.fg2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {inviteUrl}
+              </span>
+              <button onClick={copyInvite} style={{
+                padding: "0 16px", background: SOLO.bg3, color: SOLO.fg, fontFamily: SOLO.mono, fontSize: 11,
+                letterSpacing: "0.08em", textTransform: "uppercase", border: 0, borderLeft: `1px solid ${SOLO.line2}`, cursor: "pointer",
+              }}>Copy link</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {filled && (
+        <div style={{
+          marginTop: 28, background: `linear-gradient(90deg, rgba(125,211,143,.06) 0%, rgba(167,139,250,.06) 100%)`,
+          border: `1px solid rgba(125,211,143,.4)`, borderRadius: 12, padding: "22px 28px",
+          display: "flex", alignItems: "center", justifyContent: "space-between", gap: 20,
+        }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <Eyebrow color={SOLO.ok} dotColor={SOLO.ok}>
+              {meReady && opponent?.ready ? "Both ready · starting soon" : meReady ? "Waiting on opponent" : "Press ready when you are"}
+            </Eyebrow>
+            <h4 style={{ margin: 0, fontWeight: 700, fontSize: 18, letterSpacing: "-0.02em" }}>
+              Match starts 3s after the second ready.
+            </h4>
+            <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+              First to {view.match.target_score} · audio · top 1,000 pool
+            </div>
+          </div>
+          <div style={{ display: "flex", gap: 10 }}>
+            <button onClick={onLeave} style={lobbyBtn(SOLO.fg2, "transparent")}>Leave</button>
+            <button onClick={onReady} style={lobbyBtn(meReady ? SOLO.fg : SOLO.bg, meReady ? SOLO.bg3 : SOLO.accent, !meReady)}>
+              {meReady ? "Unready" : "✓ Ready"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div style={{ marginTop: 28, display: "flex", alignItems: "center", justifyContent: "space-between", paddingTop: 24, borderTop: `1px solid ${SOLO.line}` }}>
+        <span style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+          Socket · <span style={{ color: socketStatus === "open" ? SOLO.ok : SOLO.warn }}>● {socketStatus}</span>
+        </span>
+        {isHost && !filled && (
+          <button onClick={onCancel} style={lobbyBtn(SOLO.danger, "transparent")}>Cancel lobby</button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function lobbyBtn(color: string, bg: string, prim?: boolean): React.CSSProperties {
+  return {
+    background: bg, color, border: `1px solid ${prim ? SOLO.accent : SOLO.line2}`,
+    padding: "10px 16px", borderRadius: 7, fontSize: 13, cursor: "pointer", fontFamily: SOLO.sans,
+    fontWeight: prim ? 600 : 400, boxShadow: prim ? `0 0 30px ${SOLO.accent}55` : "none",
+  };
+}
+
+function PlayerCard({ player, variant, label, ready }: { player: any; variant: "you" | "opponent"; label: string; ready: boolean }) {
+  const color = variant === "you" ? SOLO.accent : SOLO.line2;
+  return (
+    <div style={{
+      background: SOLO.bg2, border: `1px solid ${ready ? "rgba(125,211,143,.5)" : color}`, borderRadius: 14, padding: 28,
+      display: "flex", flexDirection: "column", alignItems: "center", gap: 16, textAlign: "center", minHeight: 340,
+    }}>
+      <Eyebrow color={ready ? SOLO.ok : variant === "you" ? SOLO.accent : SOLO.fg3} dotColor={ready ? SOLO.ok : variant === "you" ? SOLO.accent : SOLO.fg3}>
+        {label}{ready ? " · ready" : ""}
+      </Eyebrow>
+      <div style={{
+        width: 84, height: 84, borderRadius: "50%", background: SOLO.bg3,
+        border: `2px solid ${ready ? SOLO.ok : color}`, display: "grid", placeItems: "center",
+        fontWeight: 700, fontSize: 32, color: variant === "you" ? SOLO.accent : SOLO.fg,
+      }}>
+        {(player?.display_name?.[0] ?? "?").toUpperCase()}
+      </div>
+      <div>
+        <div style={{ fontWeight: 700, fontSize: 20, letterSpacing: "-0.02em", color: SOLO.fg }}>{player?.display_name ?? "—"}</div>
+      </div>
+      <div style={{ marginTop: "auto", fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", padding: "5px 10px", borderRadius: 4, border: `1px solid ${SOLO.line2}`, color: ready ? SOLO.ok : SOLO.fg3 }}>
+        {ready ? "✓ Ready" : "In lobby"}
+      </div>
+    </div>
+  );
+}
+
+function EmptySlot() {
+  return (
+    <div style={{
+      background: SOLO.bg2, border: `1px dashed ${SOLO.line2}`, borderRadius: 14, padding: 28,
+      display: "flex", flexDirection: "column", alignItems: "center", gap: 16, textAlign: "center", minHeight: 340,
+    }}>
+      <Eyebrow color={SOLO.fg3} dotColor={SOLO.fg3}>Opponent · empty</Eyebrow>
+      <div style={{
+        width: 84, height: 84, borderRadius: "50%", background: "transparent",
+        border: `2px dashed ${SOLO.line2}`, display: "grid", placeItems: "center",
+        fontWeight: 700, fontSize: 32, color: SOLO.fg4,
+      }}>?</div>
+      <div>
+        <div style={{ fontWeight: 700, fontSize: 20, color: SOLO.fg3 }}>Waiting…</div>
+        <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>
+          Share the invite link to fill this slot
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CountdownView({ startsAtMs }: { startsAtMs: number }) {
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(id);
+  }, []);
+  const seconds = Math.max(0, Math.ceil((startsAtMs - now) / 1000));
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", alignItems: "center", justifyContent: "center", flexDirection: "column", gap: 24 }}>
+      <Eyebrow>Starting in</Eyebrow>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 200, fontWeight: 500, color: SOLO.accent, lineHeight: 0.9, textShadow: `0 0 60px ${SOLO.accent}55` }}>{seconds}</div>
+    </div>
+  );
+}
+
+function RevealView({ mode, countdownMs, view }: { mode: string; countdownMs: number; view: PvPMatchView }) {
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column" }}>
+      <MatchHud view={view} />
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", textAlign: "center", padding: "80px 40px" }}>
+        <Eyebrow>Next round · listen carefully</Eyebrow>
+        <h1 style={{ margin: "20px 0 0", fontWeight: 900, fontSize: 160, letterSpacing: "-0.06em", lineHeight: 0.9, color: SOLO.accent, textShadow: `0 0 60px ${SOLO.accent}55` }}>
+          {mode.toUpperCase()}
+        </h1>
+        <p style={{ marginTop: 24, color: SOLO.fg2, fontSize: 18, maxWidth: 520, lineHeight: 1.45 }}>
+          No video, no lyrics. Just the song. Guess the anime as fast as you can — first correct wins the round.
+        </p>
+        <div style={{ marginTop: 60, fontFamily: SOLO.mono, fontWeight: 500, fontSize: 120, color: SOLO.fg, letterSpacing: "-0.04em" }}>
+          {Math.ceil(countdownMs / 1000)}
+        </div>
+        <div style={{ marginTop: 8, fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: SOLO.fg4 }}>
+          Seconds until clip
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MatchHud({ view, scoreOverride }: { view: PvPMatchView; scoreOverride?: Record<string, number> }) {
+  const players = view.players;
+  const host = players.find((p) => p.seat === 1);
+  const opp = players.find((p) => p.seat === 2);
+  const hostScore = scoreOverride?.[host?.user_id ?? ""] ?? 0;
+  const oppScore = scoreOverride?.[opp?.user_id ?? ""] ?? 0;
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 24, padding: "16px 28px", background: "rgba(12,10,20,.92)", borderBottom: `1px solid ${SOLO.line}` }}>
+      <div style={{ display: "flex", alignItems: "center", gap: 14, flex: 1 }}>
+        <div style={{ width: 42, height: 42, borderRadius: "50%", background: SOLO.bg3, border: `2px solid ${SOLO.accent}`, color: SOLO.accent, display: "grid", placeItems: "center", fontWeight: 700, fontSize: 16 }}>
+          {(host?.display_name?.[0] ?? "?").toUpperCase()}
+        </div>
+        <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg }}>{host?.display_name ?? "—"}</div>
+      </div>
+      <div style={{ width: 1, height: 36, background: SOLO.line2 }} />
+      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 34, color: SOLO.accent, letterSpacing: "-0.04em" }}>{hostScore}</div>
+      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, padding: "0 24px" }}>
+        <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, letterSpacing: "0.14em", textTransform: "uppercase" }}>Race</div>
+        <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg2, letterSpacing: "0.06em" }}>first to <span style={{ color: SOLO.fg }}>{view.match.target_score}</span></div>
+      </div>
+      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 34, color: SOLO.line2, letterSpacing: "-0.04em" }}>{oppScore}</div>
+      <div style={{ width: 1, height: 36, background: SOLO.line2 }} />
+      <div style={{ display: "flex", alignItems: "center", gap: 14, flex: 1, justifyContent: "flex-end" }}>
+        <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, textAlign: "right" }}>{opp?.display_name ?? "—"}</div>
+        <div style={{ width: 42, height: 42, borderRadius: "50%", background: SOLO.bg3, border: `2px solid #6aa9ff`, color: "#6aa9ff", display: "grid", placeItems: "center", fontWeight: 700, fontSize: 16 }}>
+          {(opp?.display_name?.[0] ?? "?").toUpperCase()}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PlayingView({ view, round, playedMs, meID, onSubmit, onTyping }: {
+  view: PvPMatchView; round: RoundStartData; playedMs: number; meID: string;
+  onSubmit: (opening_id: string) => void; onTyping: () => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; anime: string }>>([]);
+  const [activeIdx, setActiveIdx] = useState(0);
+  const queryRef = useRef(query);
+  queryRef.current = query;
+
+  useEffect(() => {
+    if (query.trim().length < 2) { setSuggestions([]); return; }
+    onTyping();
+    const handle = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}&types=opening&limit=8`, { credentials: "include" });
+        if (!res.ok) return;
+        const body = await res.json();
+        if (queryRef.current !== query) return;
+        const items = (body?.data?.openings ?? []).slice(0, 8).map((o: any) => ({
+          id: o.id, title: o.title, anime: o.anime_name ?? o.anime?.name ?? "—",
+        }));
+        setSuggestions(items);
+        setActiveIdx(0);
+      } catch { /* */ }
+    }, 120);
+    return () => clearTimeout(handle);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query]);
+
+  const onKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") { e.preventDefault(); setActiveIdx((i) => Math.min(suggestions.length - 1, i + 1)); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); setActiveIdx((i) => Math.max(0, i - 1)); }
+    else if (e.key === "Enter") { e.preventDefault(); const pick = suggestions[activeIdx]; if (pick) onSubmit(pick.id); }
+    else if (e.key === "Escape") { setQuery(""); setSuggestions([]); }
+  };
+
+  const pct = Math.min(1, playedMs / round.clip_duration_ms);
+  const secsLeft = Math.max(0, (round.clip_duration_ms - playedMs) / 1000);
+
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column" }}>
+      <MatchHud view={view} />
+      <div style={{ height: 3, background: SOLO.line, position: "relative", overflow: "hidden" }}>
+        <div style={{ position: "absolute", inset: 0, right: `${(1 - pct) * 100}%`, background: secsLeft < 5 ? SOLO.danger : SOLO.accent, boxShadow: `0 0 14px ${secsLeft < 5 ? SOLO.danger : SOLO.accent}`, transition: "right .15s linear" }} />
+      </div>
+      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", padding: "40px 40px 30px", gap: 24 }}>
+        <div style={{ width: "100%", maxWidth: 720, aspectRatio: "16 / 9", background: `radial-gradient(ellipse at center, #1d1929 0%, #0c0a14 80%)`, borderRadius: 10, border: `1px solid ${SOLO.line2}`, display: "flex", alignItems: "center", justifyContent: "center", position: "relative", overflow: "hidden" }}>
+          <div style={{ position: "absolute", top: 14, left: 14, fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, background: "rgba(0,0,0,.4)", padding: "5px 9px", borderRadius: 4 }}>
+            ● Audio only · {secsLeft.toFixed(1)}s left
+          </div>
+        </div>
+        <div style={{ position: "relative", width: "100%", maxWidth: 720 }}>
+          {suggestions.length > 0 && (
+            <div style={{ position: "absolute", bottom: "100%", left: 0, right: 0, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 10, marginBottom: 8, overflow: "hidden", boxShadow: "0 -20px 50px -10px rgba(0,0,0,0.5)" }}>
+              {suggestions.map((s, i) => (
+                <div key={s.id} onMouseEnter={() => setActiveIdx(i)} onClick={() => onSubmit(s.id)} style={{
+                  display: "flex", alignItems: "center", gap: 12, padding: "12px 16px",
+                  background: i === activeIdx ? SOLO.bg3 : "transparent",
+                  borderLeft: i === activeIdx ? `2px solid ${SOLO.accent}` : "2px solid transparent",
+                  cursor: "pointer",
+                }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>{s.anime}</div>
+                  </div>
+                  {i === activeIdx && <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "2px 6px", borderRadius: 3 }}>↵</span>}
+                </div>
+              ))}
+            </div>
+          )}
+          <div style={{ display: "flex", alignItems: "center", gap: 14, background: SOLO.bg2, border: `1.5px solid ${SOLO.accent}`, borderRadius: 10, padding: "16px 20px", boxShadow: `0 0 0 4px ${SOLO.accent}11` }}>
+            <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.accent, letterSpacing: "0.16em", textTransform: "uppercase" }}>Title</span>
+            <input
+              autoFocus value={query} onChange={(e) => setQuery(e.target.value)} onKeyDown={onKey}
+              placeholder="Type the anime title…"
+              style={{ flex: 1, background: "transparent", border: 0, outline: 0, color: SOLO.fg, fontSize: 18, fontWeight: 500, fontFamily: SOLO.sans }}
+            />
+            <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ Enter</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPMatchView; meID: string }) {
+  const winner = result.winner_user_id;
+  const youWon = winner === meID;
+  const noScore = result.no_score;
+  const accent = noScore ? SOLO.warn : youWon ? SOLO.ok : SOLO.danger;
+  const headline = noScore ? "Tough one." : youWon ? "+1 round." : "−1 round.";
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column" }}>
+      <MatchHud view={view} scoreOverride={result.score} />
+      <div style={{ flex: 1, padding: "36px 40px 28px", display: "flex", flexDirection: "column", gap: 22, justifyContent: "center" }}>
+        <div>
+          <Eyebrow color={accent} dotColor={accent}>
+            {noScore ? "No score · redraw" : youWon ? "You got it" : "Opponent got it"}
+          </Eyebrow>
+          <h2 style={{ margin: "10px 0 4px", fontWeight: 800, fontSize: 54, letterSpacing: "-0.04em", color: accent }}>{headline}</h2>
+          <div style={{ fontFamily: SOLO.mono, fontSize: 13, color: SOLO.fg3 }}>
+            Score · <span style={{ color: SOLO.fg }}>{result.score[Object.keys(result.score)[0]]} – {result.score[Object.keys(result.score)[1]]}</span>
+          </div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 24, padding: "22px 24px", background: SOLO.bg2, border: `1px solid ${accent}33`, borderRadius: 12 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.accent, letterSpacing: "0.14em", textTransform: "uppercase", marginBottom: 6 }}>
+              Round · the answer
+            </div>
+            <h3 style={{ margin: "0 0 4px", fontWeight: 700, fontSize: 24, letterSpacing: "-0.025em" }}>{result.correct_opening.anime_name}</h3>
+            <div style={{ fontFamily: SOLO.mono, fontSize: 12, color: SOLO.fg3 }}>
+              {result.correct_opening.title}{result.correct_opening.singer_name ? ` · ${result.correct_opening.singer_name}` : ""}{result.correct_opening.year ? ` · ${result.correct_opening.year}` : ""}
+            </div>
+            {result.correct_opening.avg_rating ? (
+              <div style={{ marginTop: 8, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg2 }}>
+                <span style={{ color: SOLO.warn, fontWeight: 500 }}>★ {result.correct_opening.avg_rating.toFixed(1)}</span> · {result.correct_opening.rating_count ?? 0} ratings
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MatchEndView({ result, view, meID, onRematch }: { result: MatchEndData; view: PvPMatchView; meID: string; onRematch: () => void }) {
+  const youWon = result.winner_user_id === meID;
+  const me = view.players.find((p) => p.user_id === meID);
+  const opp = view.players.find((p) => p.user_id !== meID);
+  const myScore = result.final_score[meID] ?? 0;
+  const oppScore = opp ? (result.final_score[opp.user_id] ?? 0) : 0;
+  return (
+    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
+      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 28, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+        <div>
+          <Eyebrow color={youWon ? SOLO.ok : SOLO.danger} dotColor={youWon ? SOLO.ok : SOLO.danger}>
+            {youWon ? "Match · won" : "Match · lost"}{result.by_forfeit ? " · forfeit" : ""}
+          </Eyebrow>
+          <h1 style={{ margin: "14px 0 0", fontWeight: 900, fontSize: 80, letterSpacing: "-0.05em", lineHeight: 0.95 }}>
+            {youWon ? <>You took the <span style={{ color: SOLO.accent }}>match.</span></> : <>Good run.</>}
+          </h1>
+          {opp && (
+            <p style={{ marginTop: 14, color: SOLO.fg2, fontSize: 15, maxWidth: 520 }}>
+              {myScore}–{oppScore} {youWon ? "over" : "against"} <span style={{ color: SOLO.accent, fontWeight: 600 }}>{opp.display_name}</span> · {result.rounds.length} rounds.
+            </p>
+          )}
+        </div>
+        <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 80, letterSpacing: "-0.04em", display: "flex", alignItems: "center", gap: 18 }}>
+          <span style={{ color: SOLO.accent }}>{myScore}</span>
+          <span style={{ color: SOLO.fg4, fontSize: 50 }}>–</span>
+          <span style={{ color: SOLO.fg3 }}>{oppScore}</span>
+        </div>
+      </div>
+
+      {/* Round timeline */}
+      <div style={{ marginTop: 32, padding: "22px 24px", background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 14, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.14em", textTransform: "uppercase" }}>
+          <span>Round-by-round</span>
+        </div>
+        <div style={{ display: "flex", gap: 6 }}>
+          {result.rounds.map((r) => {
+            const youW = r.winner_user_id === meID;
+            const ns = r.no_score;
+            return (
+              <div key={r.round_no} style={{
+                flex: 1, height: 38, borderRadius: 5, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center",
+                fontFamily: SOLO.mono, fontSize: 11, fontWeight: 600,
+                background: ns ? SOLO.bg3 : youW ? `${SOLO.accent}26` : "rgba(106,169,255,.2)",
+                color: ns ? SOLO.fg4 : youW ? SOLO.accent : "#6aa9ff",
+                border: `1px solid ${ns ? SOLO.line2 : youW ? `${SOLO.accent}66` : "rgba(106,169,255,.4)"}`,
+              }}>
+                {r.round_no}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div style={{ marginTop: 32, paddingTop: 18, borderTop: `1px solid ${SOLO.line}`, display: "flex", justifyContent: "flex-end", gap: 10 }}>
+        <Link href="/play" style={{ ...lobbyBtn(SOLO.fg2, "transparent"), textDecoration: "none" }}>Back to play</Link>
+        <button onClick={onRematch} style={lobbyBtn(SOLO.bg, SOLO.accent, true)}>Rematch · same rules ↻</button>
+      </div>
+    </div>
+  );
+}
+
+function DisconnectOverlay({ graceExpiresAtMs, userID, view }: { graceExpiresAtMs: number; userID: string; view: PvPMatchView }) {
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 200);
+    return () => clearInterval(id);
+  }, []);
+  const remaining = Math.max(0, Math.floor((graceExpiresAtMs - now) / 1000));
+  const opp = view.players.find((p) => p.user_id === userID);
+  return (
+    <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", alignItems: "center", justifyContent: "center", padding: 40 }}>
+      <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.warn}`, borderRadius: 14, padding: 32, display: "flex", flexDirection: "column", alignItems: "center", gap: 14, textAlign: "center", maxWidth: 440, boxShadow: `0 0 60px ${SOLO.warn}26` }}>
+        <Eyebrow color={SOLO.warn} dotColor={SOLO.warn}>Connection lost · opponent</Eyebrow>
+        <h3 style={{ margin: 0, fontWeight: 700, fontSize: 22 }}>
+          {opp?.display_name ?? "Opponent"} is reconnecting.
+        </h3>
+        <p style={{ margin: 0, color: SOLO.fg2, fontSize: 14 }}>
+          The match is paused. If they don&apos;t return in time, the match is awarded to you by forfeit.
+        </p>
+        <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 48, color: SOLO.warn, lineHeight: 1, textShadow: `0 0 20px ${SOLO.warn}55` }}>
+          0:{String(remaining).padStart(2, "0")}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/pages/play/index.tsx
+++ b/pages/play/index.tsx
@@ -137,6 +137,55 @@ export default function SoloHub({ user, modQueueCount, stats, leaderboard, apiOn
             </div>
           </section>
 
+          {/* PvP card */}
+          <section style={{
+            background: `linear-gradient(135deg, #1a1530 0%, #221831 60%, #2a1d3c 100%)`,
+            border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
+            position: "relative", overflow: "hidden", minHeight: 240, marginTop: 20,
+            display: "flex", flexDirection: "column",
+          }}>
+            <div style={{
+              position: "absolute", top: -80, right: -80, width: 380, height: 380, borderRadius: "50%",
+              background: `radial-gradient(circle, ${SOLO.accent}33 0%, transparent 70%)`, pointerEvents: "none",
+            }} />
+            <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>1v1 · race</Eyebrow>
+            <h2 style={{ margin: "14px 0 10px", fontWeight: 800, fontSize: 38, letterSpacing: "-0.035em", lineHeight: 1, maxWidth: 480 }}>
+              Challenge a <span style={{ color: SOLO.accent }}>friend.</span>
+            </h2>
+            <p style={{ margin: 0, color: SOLO.fg2, fontSize: 14, maxWidth: 480, lineHeight: 1.55 }}>
+              Two players, same clip, simultaneous. First to ten correct wins the match.
+            </p>
+            <div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginTop: 20, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em" }}>
+              <span><span style={{ color: SOLO.fg }}>FT10</span> · first to ten</span>
+              <span><span style={{ color: SOLO.fg }}>Audio</span> · song only</span>
+              <span><span style={{ color: SOLO.fg }}>Top 1000</span> · clip pool</span>
+            </div>
+            <div style={{ flex: 1, minHeight: 24 }} />
+            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8 }}>
+              {user ? (
+                <Link href="/play/pvp/new" style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
+                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
+                  textDecoration: "none", boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  + Create battle
+                </Link>
+              ) : (
+                <Link href={`/login?next=${encodeURIComponent("/play/pvp/new")}`} style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, textDecoration: "none",
+                  boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  Log in to play
+                </Link>
+              )}
+              <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, lineHeight: 1.4 }}>
+                Invite by link<br />once the lobby is open
+              </div>
+            </div>
+          </section>
+
           <section style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
             {stats && (
               <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>

--- a/pages/play/pvp/new.tsx
+++ b/pages/play/pvp/new.tsx
@@ -1,0 +1,191 @@
+import Head from "next/head";
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+import { useRouter } from "next/router";
+import { useState } from "react";
+import Layout from "@/components/Layout";
+import { loadSession } from "@/lib/session";
+import { SOLO, Eyebrow } from "@/components/solo/atoms";
+import { pvpClient, type MatchFormat } from "@/lib/pvp";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user) {
+    return { redirect: { destination: "/login?next=/play/pvp/new", permanent: false } };
+  }
+  return { props: { user: session.user, modQueueCount: session.modQueueCount } };
+};
+
+// Format options match the backend's CHECK constraint exactly. Adding
+// a fourth format means a migration; the segment buttons here are
+// the user-facing copy of that contract.
+const FORMATS: { value: MatchFormat; label: string; sub: string }[] = [
+  { value: "ft10", label: "First to 10", sub: "Standard race" },
+  { value: "ft5", label: "First to 5", sub: "Short race" },
+  { value: "ft15", label: "First to 15", sub: "Long race" },
+];
+
+export default function NewBattle({ user, modQueueCount }: Props) {
+  const router = useRouter();
+  const [format, setFormat] = useState<MatchFormat>("ft10");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const open = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const view = await pvpClient.createMatch(format, { kind: "top_default" });
+      router.push(`/play/b/${view.match.room_code}`);
+    } catch (err: any) {
+      setSubmitting(false);
+      setError(err?.message ?? "Failed to open lobby");
+    }
+  };
+
+  const target = format === "ft5" ? 5 : format === "ft15" ? 15 : 10;
+
+  return (
+    <Layout user={user} modQueueCount={modQueueCount} title="New battle — Opening Wiki">
+      <Head><meta name="description" content="Open a 1v1 PvP lobby." /></Head>
+      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "36px 40px 48px" }}>
+          <nav style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em", marginBottom: 14, display: "flex", gap: 6, alignItems: "center" }}>
+            <Link href="/play" style={{ color: SOLO.fg2, textDecoration: "none" }}>Play</Link>
+            <span style={{ color: SOLO.fg4 }}>/</span>
+            <span style={{ color: SOLO.fg2 }}>New battle</span>
+          </nav>
+          <h1 style={{ margin: "0 0 6px", fontWeight: 800, fontSize: 36, letterSpacing: "-0.03em", lineHeight: 1 }}>
+            New <span style={{ color: SOLO.accent }}>battle.</span>
+          </h1>
+          <p style={{ margin: "0 0 28px", color: SOLO.fg3, fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.04em" }}>
+            1v1 race · configure → invite → play
+          </p>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 28 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <label style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: SOLO.fg3 }}>
+                  Format <span style={{ color: SOLO.accent }}>*</span>
+                </label>
+                <div style={{ display: "flex", border: `1px solid ${SOLO.line2}`, borderRadius: 8, background: SOLO.bg2, padding: 4, gap: 2 }}>
+                  {FORMATS.map((f) => {
+                    const on = f.value === format;
+                    return (
+                      <button
+                        key={f.value}
+                        type="button"
+                        onClick={() => setFormat(f.value)}
+                        style={{
+                          flex: 1, padding: "10px 14px", borderRadius: 5,
+                          color: on ? SOLO.accent : SOLO.fg3,
+                          background: on ? "rgba(167,139,250,.08)" : "transparent",
+                          border: 0,
+                          boxShadow: on ? `inset 0 0 0 1px ${SOLO.accent}` : "none",
+                          fontSize: 13, fontFamily: SOLO.sans, lineHeight: 1.3,
+                          display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2,
+                          cursor: "pointer", textAlign: "left",
+                        }}
+                      >
+                        {f.label}
+                        <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: on ? SOLO.accent : SOLO.fg4, letterSpacing: "0.04em" }}>{f.sub}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                <label style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: SOLO.fg3 }}>
+                  Clip pool
+                </label>
+                <div style={{
+                  background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 8, padding: 14,
+                  display: "flex", alignItems: "center", gap: 14,
+                }}>
+                  <div style={{
+                    width: 44, height: 44, borderRadius: 8, background: SOLO.bg3,
+                    border: `1px solid ${SOLO.line}`, display: "grid", placeItems: "center",
+                    color: SOLO.accent, fontFamily: SOLO.mono, fontSize: 18, flexShrink: 0,
+                  }}>★</div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, marginBottom: 2 }}>
+                      Default · Top 1,000 most-rated OPs
+                    </div>
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+                      Auto-refreshed nightly
+                    </div>
+                  </div>
+                </div>
+                <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.04em", lineHeight: 1.4 }}>
+                  Custom group pools coming later — MVP plays from the top-1000 default.
+                </span>
+              </div>
+
+              {error && (
+                <div style={{
+                  background: "rgba(255,107,122,.06)", border: `1px solid rgba(255,107,122,.3)`,
+                  borderRadius: 8, padding: "12px 14px", color: SOLO.fg, fontSize: 13,
+                }}>{error}</div>
+              )}
+            </div>
+
+            <aside style={{
+              position: "sticky", top: 80, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`,
+              borderRadius: 10, padding: 22, alignSelf: "start",
+            }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 18, paddingBottom: 14, borderBottom: `1px solid ${SOLO.line}` }}>
+                <h4 style={{ margin: 0, fontWeight: 700, fontSize: 18, letterSpacing: "-0.02em", color: SOLO.fg }}>
+                  Battle summary
+                  <span style={{ display: "block", fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, letterSpacing: "0.06em", textTransform: "uppercase", fontWeight: 500, marginTop: 3 }}>
+                    draft · not saved
+                  </span>
+                </h4>
+              </div>
+              <SumRow k="Format" v={`First to ${target}`} />
+              <SumRow k="Mode" v="Audio" />
+              <SumRow k="Pool" v="Top 1,000 OPs" />
+              <SumRow k="Players" v="1 / 2" mono />
+              <div style={{ marginTop: 20, display: "flex", flexDirection: "column", gap: 8 }}>
+                <button
+                  onClick={open}
+                  disabled={submitting}
+                  style={{
+                    background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                    padding: "14px 22px", fontWeight: 600, fontSize: 14, cursor: submitting ? "wait" : "pointer",
+                    boxShadow: `0 0 30px ${SOLO.accent}55`,
+                  }}
+                >
+                  {submitting ? "Opening…" : "Open lobby →"}
+                </button>
+                <Link href="/play" style={{
+                  background: "transparent", border: "none", color: SOLO.fg2,
+                  padding: "10px 16px", borderRadius: 7, fontSize: 13, fontFamily: SOLO.sans,
+                  textAlign: "center", textDecoration: "none",
+                }}>Cancel</Link>
+              </div>
+              <div style={{ marginTop: 14, fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.04em", textAlign: "center" }}>
+                Invite a friend once the lobby is open
+              </div>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+function SumRow({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", padding: "9px 0", borderBottom: `1px dashed ${SOLO.line}`, fontSize: 13 }}>
+      <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, letterSpacing: "0.08em", textTransform: "uppercase" }}>{k}</span>
+      <span style={{ color: SOLO.fg, fontWeight: mono ? 400 : 500, fontFamily: mono ? SOLO.mono : SOLO.sans, fontSize: mono ? 12 : 13 }}>{v}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Frontend half of the PvP MVP. Pairs with [openingwiki/backend#36](https://github.com/openingwiki/backend/pull/36) (\`feat/pvp-mvp\` over there).

Built directly against the design HTML files (\`PvP Battle.html\` + \`PvP Match.html\`) with the scope cuts from the design-tool chat (audio-only, no Elo, no rated/casual, no friend list, no round-timer config, single H2H card on match-end). Visual fidelity is close but inline-style first — pixel polish can ride along in a follow-up if needed.

## Files
- **\`lib/pvp.ts\`** — types + \`pvpClient\` (REST) + \`PvPSocket\` (WebSocket wrapper). Sockets handle reconnect / ping / send-typing / send-answer; consumers register \`onFrame\` and treat it as a black box.
- **\`pages/api/play/pvp/*\`** — Next API proxies. \`/matches\` + \`/matches/[code]\` (GET) + \`/matches/[code]/[action]\` (POST) for the verb mutations + \`/socket/token\` for the WS upgrade token. Standard CSRF + cookie passthrough via existing \`lib/api-proxy\`.
- **\`pages/play/pvp/new.tsx\`** — battle creation page. FT5/FT10/FT15 segment + pool card (top-1000 default in MVP).
- **\`pages/play/b/[code].tsx\`** — single route running both lobby and match. WS-driven state machine with phases: \`lobby\` → \`countdown\` → \`reveal\` → \`playing\` → \`round-end\` → \`ended\` plus \`disconnected\` overlay and \`error\` fallback. Audio playback + autocomplete reuse the Solo conventions.
- **\`pages/play/index.tsx\`** — adds a PvP card alongside the existing Solo card on the hub.

## Test plan
- [x] \`tsc --noEmit\` clean.
- [ ] Open \`/play\` → see both Solo and PvP cards.
- [ ] Click "Create battle" → land on \`/play/pvp/new\` → "Open lobby" → land on \`/play/b/<code>\` lobby view.
- [ ] Copy invite link, open in a second browser/incognito as another user → joins as opponent.
- [ ] Both press Ready → 3-2-1 countdown → mode reveal → audio plays → autocomplete + Enter submits.
- [ ] First to 10 ends the match → end screen with rematch CTA → click → fresh lobby with new room code.
- [ ] Close opponent's tab during a round → disconnect overlay shows grace timer → after 15 s, you win by forfeit.

## Out of scope (explicit per decision-pvp-mvp)
- Custom Group pool picker (server-side exists; UI keeps top-1000 only).
- Visual / lyrics modes.
- Tournaments / brackets / spectators.
- Anti-cheat — schema captures client+server timestamps for the future detector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)