### PR TITLE
fix(pvp): auto-join non-host visitors before opening match socket

### DIFF
--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -96,15 +96,35 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
   }, [code]);
 
   useEffect(() => {
+    let cancelled = false;
     const s = new PvPSocket(code);
     sockRef.current = s;
     const offFrame = s.onFrame((f) => handleFrame(f));
     const offStatus = s.onStatus((st) => setSocketStatus(st === "open" ? "open" : st === "closed" ? "closed" : "closed"));
-    s.connect().catch((err) => {
-      setPhase({ kind: "error", message: err?.message ?? "Failed to open match socket" });
-    });
+
+    // Opponents arrive at /play/b/<code> via an invite link without
+    // being seated yet — only the host is auto-seated on create.
+    // Mint-WS-token rejects unseated callers with not_in_match, so
+    // join first if needed, then open the socket.
+    (async () => {
+      try {
+        if (initial && initial.you_are === "guest") {
+          const joined = await pvpClient.join(code);
+          if (cancelled) return;
+          setView(joined);
+        }
+        if (cancelled) return;
+        await s.connect();
+      } catch (err: any) {
+        if (!cancelled) {
+          setPhase({ kind: "error", message: err?.message ?? "Failed to open match socket" });
+        }
+      }
+    })();
+
     const ping = setInterval(() => s.sendPing(), 15_000);
     return () => {
+      cancelled = true;
       clearInterval(ping);
       offFrame();
       offStatus();


### PR DESCRIPTION
## Why
HAR from accessing \`/play/b/3KM2-TQGX\` as the opponent showed:

\`\`\`
POST /api/play/pvp/socket/token  →  403
{"error":{"code":"not_in_match","message":"You are not in this match"}}
\`\`\`

Only the host is auto-seated on \`CreateMatch\`. Opponents follow the invite link and land directly on the lobby page, which immediately opens the WS. \`MintWSToken\` rejects non-seated callers, so the page errored before the lobby could render.

## Fix
Before \`PvPSocket.connect()\`, look at SSR-returned \`you_are\`:
- \`"host"\` / \`"opponent"\`: already seated → straight to socket.
- \`"guest"\`: \`POST /matches/<code>/join\` first, update view from response, then open the socket.

Race-safe: the effect uses a \`cancelled\` flag so unmounting during the join doesn't try to setState afterward.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] As opponent, follow invite link → lobby renders with both seats, ready button works
- [ ] As host, lobby still works (no extra round-trip)