### PR TITLE
fix(pvp): lobby REST poll + WS auto-reconnect

### DIFF
--- a/lib/pvp.ts
+++ b/lib/pvp.ts
@@ -167,11 +167,21 @@ export const pvpClient = {
 // PvPSocket wraps the browser WebSocket with reconnect semantics and
 // a tiny event emitter. The match page wires its state machine to
 // `onFrame` and treats the socket as a black box otherwise.
+//
+// Reconnect strategy: on close (not user-initiated), mint a fresh
+// token and retry with exponential backoff (1s, 2s, 4s, 8s, then
+// capped). Tokens are single-shot and short-lived (30s), so we always
+// mint a new one rather than reusing the original. Ingress proxies
+// quietly drop idle WS connections; without reconnect the user would
+// silently miss every lobby.state and match.* frame that arrived
+// after the drop.
 export class PvPSocket {
   private ws: WebSocket | null = null;
   private closed = false;
   private listeners = new Set<(f: Frame) => void>();
   private statusListeners = new Set<(s: "open" | "closed" | "error") => void>();
+  private reconnectDelay = 1000;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private code: string) {}
 
@@ -183,10 +193,14 @@ export class PvPSocket {
     url.searchParams.set("room", this.code);
     const ws = new WebSocket(url.toString());
     this.ws = ws;
-    ws.onopen = () => this.fireStatus("open");
+    ws.onopen = () => {
+      this.reconnectDelay = 1000;
+      this.fireStatus("open");
+    };
     ws.onclose = () => {
       this.fireStatus("closed");
       this.ws = null;
+      if (!this.closed) this.scheduleReconnect();
     };
     ws.onerror = () => this.fireStatus("error");
     ws.onmessage = (e) => {
@@ -197,6 +211,17 @@ export class PvPSocket {
         /* ignore */
       }
     };
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer || this.closed) return;
+    const delay = this.reconnectDelay;
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, 8000);
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.closed) return;
+      this.connect().catch(() => this.scheduleReconnect());
+    }, delay);
   }
 
   send(type: string, data?: unknown): void {
@@ -225,6 +250,10 @@ export class PvPSocket {
 
   close(): void {
     this.closed = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     this.ws?.close();
     this.ws = null;
   }

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -95,6 +95,17 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
     }
   }, [code]);
 
+  // Lobby-phase poll. WS lobby.state is authoritative when it arrives
+  // but ingress timeouts and brief network blips can drop frames
+  // silently — without a fallback, one player toggling ready never
+  // shows up on the other player's screen. Poll only while we're in
+  // the lobby (cheap; stops the moment the match transitions out).
+  useEffect(() => {
+    if (phase.kind !== "lobby") return;
+    const t = setInterval(refreshView, 2500);
+    return () => clearInterval(t);
+  }, [phase.kind, refreshView]);
+
   useEffect(() => {
     let cancelled = false;
     const s = new PvPSocket(code);


### PR DESCRIPTION
## Symptom
From HAR of an attempted lobby (room \`EV28-B62F\`):
- Opponent toggles ready 4×, each REST response is 200 and contains a fresh full view.
- The view shows the host's ready state flipping between true/false (the host is also toggling) — but those changes are only visible to the opponent in the REST responses of their *own* actions, never live.
- Final response has both \`ready: true\` but \`status: lobby\` — and the match never starts.

In short: WS \`lobby.state\` / \`match.countdown\` frames aren't reliably reaching the page.

## Fix
Two defensive changes — neither replaces the WS as the primary mechanism, both keep the UI usable when frames slip through.

### 1. PvPSocket actually reconnects now
The class's docstring claimed reconnect semantics but \`onclose\` just dropped the socket. Ingress timeouts and brief network blips silently kill long-lived WS connections; once that happens the page misses every subsequent frame.

\`\`\`ts
ws.onclose = () => {
  this.fireStatus("closed");
  this.ws = null;
  if (!this.closed) this.scheduleReconnect();
};
\`\`\`

Backoff 1/2/4/8s capped at 8s. A fresh single-shot token is minted on each retry (existing ones are 30s TTL and consumed on first use). User-initiated \`close()\` suppresses reconnects via the existing \`closed\` flag.

### 2. Lobby-phase REST poll
Match page polls \`/matches/<code>\` every 2.5s while \`phase === "lobby"\`. Other player's ready toggle propagates within ~3s even if the WS frame was dropped. Poll stops the moment the phase transitions out — no cost during gameplay.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Open lobby in two browsers, toggle ready from each — the other side updates within ~3s
- [ ] Break the WS (network throttling / kill tab and reopen on the same code) — the socket reconnects and frames resume