### PR TITLE
feat(home): top contributors sidebar widget

### DIFF
--- a/components/ContributorsPanel.tsx
+++ b/components/ContributorsPanel.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ContributorLeaderboard, ContributorRange } from "@/lib/api";
+
+interface Props {
+  initial: ContributorLeaderboard | null;
+  meUserId?: string | null;
+}
+
+// Top contributors widget. Mirrors the design from Home.html:
+// - Two tabs (This week / All-time) switching the time window.
+// - Top-3 rows get accent / lighter foreground rank colors.
+// - The viewer's own row is appended at the bottom when present
+//   (only shown for logged-in users who have at least one submission
+//   in the window; otherwise the backend omits the `you` field).
+//
+// SSR seeds the first tab; switching tabs hits the proxy and updates
+// the local state. Fail-quietly: if a switch fetch fails the existing
+// list stays put.
+export default function ContributorsPanel({ initial, meUserId }: Props) {
+  const [range, setRange] = useState<ContributorRange>(initial?.range ?? "week");
+  const [board, setBoard] = useState<ContributorLeaderboard | null>(initial);
+  const [pending, setPending] = useState(false);
+
+  const fetchRange = useCallback(async (next: ContributorRange) => {
+    setPending(true);
+    try {
+      const res = await fetch(`/api/submissions/leaderboard?range=${next}`, { credentials: "include" });
+      if (!res.ok) return;
+      const payload = await res.json();
+      setBoard(payload?.data ?? null);
+    } catch {
+      /* keep the existing board */
+    } finally {
+      setPending(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (initial && initial.range === range) return;
+    fetchRange(range);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [range]);
+
+  const entries = board?.entries ?? [];
+  const you = board?.you;
+  // Don't duplicate the viewer's row if they're already in the top
+  // list — the standalone "you" stripe only adds value when the
+  // viewer is below the cutoff.
+  const showYouRow = !!you && !entries.some((e) => e.user_id === meUserId);
+
+  return (
+    <div className="panel">
+      <div className="panel-head">
+        <span>Top contributors</span>
+        <span style={{ color: "var(--fg-4)", letterSpacing: 0, textTransform: "none" }}>submissions</span>
+      </div>
+      <div className="lb-tabs">
+        <button
+          type="button"
+          className={`lb-tab${range === "week" ? " on" : ""}`}
+          onClick={() => setRange("week")}
+        >
+          This week
+        </button>
+        <button
+          type="button"
+          className={`lb-tab${range === "all" ? " on" : ""}`}
+          onClick={() => setRange("all")}
+        >
+          All-time
+        </button>
+      </div>
+      <div className="lb-list" aria-busy={pending}>
+        {entries.length === 0 && (
+          <div style={{ padding: "16px 14px", fontFamily: "var(--mono)", fontSize: 11, color: "var(--fg-4)" }}>
+            No submissions yet this window.
+          </div>
+        )}
+        {entries.map((e) => {
+          const rankClass = e.rank <= 3 ? ` top-${e.rank}` : "";
+          const isYou = !!meUserId && e.user_id === meUserId;
+          return (
+            <div key={e.user_id} className={`lb-item${rankClass}${isYou ? " is-you" : ""}`}>
+              <span className="lb-rank">{e.rank}</span>
+              <div className="lb-user">
+                <div className="lb-name">
+                  @{e.display_name}
+                  {isYou && <span className="lb-you-tag">YOU</span>}
+                </div>
+              </div>
+              <div className="lb-count">{e.count.toLocaleString()}</div>
+            </div>
+          );
+        })}
+      </div>
+      {showYouRow && you && (
+        <div className="lb-you-row">
+          <span className="lb-rank">#{you.rank}</span>
+          <div className="lb-user">
+            <div className="lb-name">
+              @{you.display_name}
+              <span className="lb-you-tag">YOU</span>
+            </div>
+          </div>
+          <div className="lb-count">{you.count.toLocaleString()}</div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -403,6 +403,25 @@ export function getKindCounts(cookie?: string): Promise<KindCounts> {
   }));
 }
 
+export type ContributorRange = "week" | "all";
+
+export interface ContributorEntry {
+  rank: number;
+  user_id: string;
+  display_name: string;
+  count: number;
+}
+
+export interface ContributorLeaderboard {
+  range: ContributorRange;
+  entries: ContributorEntry[];
+  you?: ContributorEntry;
+}
+
+export function getSubmissionLeaderboard(range: ContributorRange, cookie?: string): Promise<ContributorLeaderboard> {
+  return apiFetchData<ContributorLeaderboard>(`/submissions/leaderboard?range=${range}`, { cookie });
+}
+
 export function getModerationQueueCount(cookie?: string): Promise<{ count: number }> {
   return Promise.all(
     ["opening", "anime", "singer"].map((type) =>

--- a/pages/api/submissions/leaderboard.ts
+++ b/pages/api/submissions/leaderboard.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).end();
+  const range = req.query.range === "all" ? "all" : "week";
+  const upstream = await fetch(backendUrl(`/submissions/leaderboard?range=${range}`), {
+    headers: req.headers.cookie ? { cookie: req.headers.cookie } : undefined,
+  });
+  const data = await upstream.json();
+  return res.status(upstream.status).json(data);
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,9 +8,10 @@ import Pagination from "@/components/Pagination";
 import GroupsPanel from "@/components/GroupsPanel";
 import AuthCard from "@/components/AuthCard";
 import SubmitCard from "@/components/SubmitCard";
+import ContributorsPanel from "@/components/ContributorsPanel";
 
-import { getKindCounts, listMyGroups, listOpenings } from "@/lib/api";
-import type { KindCounts } from "@/lib/api";
+import { getKindCounts, getSubmissionLeaderboard, listMyGroups, listOpenings } from "@/lib/api";
+import type { ContributorLeaderboard, KindCounts } from "@/lib/api";
 import { loadSession } from "@/lib/session";
 import { mockGroups, mockOpenings } from "@/lib/mock";
 import type {
@@ -27,6 +28,7 @@ interface Props {
   page: OpeningPage;
   groups: Group[];
   kindCounts: KindCounts;
+  contributors: ContributorLeaderboard | null;
   q: string;
   sort: SortKey;
   kind: TrackKind;
@@ -61,6 +63,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   let openingsPage: OpeningPage;
   let kindCounts: KindCounts = { opening: 0, ending: 0, ost: 0 };
   let groups: Group[] = [];
+  let contributors: ContributorLeaderboard | null = null;
   let apiOnline = true;
 
   try {
@@ -71,6 +74,9 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
     if (session.user) {
       groups = session.mockGroups ?? await listMyGroups(session.cookie).catch(() => []);
     }
+    // Contributors widget is a soft dependency — the page still renders
+    // if the leaderboard endpoint fails for any reason.
+    contributors = await getSubmissionLeaderboard("week", session.cookie).catch(() => null);
   } catch {
     apiOnline = false;
     openingsPage = mockOpenings();
@@ -85,6 +91,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
       page: openingsPage,
       groups,
       kindCounts,
+      contributors,
       q,
       sort,
       kind,
@@ -105,6 +112,7 @@ export default function HomePage({
   page,
   groups,
   kindCounts,
+  contributors,
   q,
   sort,
   kind,
@@ -162,6 +170,7 @@ export default function HomePage({
 
           <aside className="side">
             {user ? <GroupsPanel groups={groups} /> : <AuthCard />}
+            <ContributorsPanel initial={contributors} meUserId={user?.id ?? null} />
             <SubmitCard authed={!!user} />
           </aside>
         </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -407,6 +407,58 @@ input, select { font: inherit; color: inherit; }
 }
 .panel-foot a { color: var(--accent); }
 
+/* Contributors leaderboard — mirrors Home.html design tokens. */
+.lb-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase;
+}
+.lb-tab {
+  flex: 1; padding: 8px 0;
+  color: var(--fg-3); background: transparent;
+  border: 0; border-bottom: 1px solid transparent;
+  margin-bottom: -1px; cursor: pointer;
+  text-align: center; transition: color .15s, border-color .15s;
+}
+.lb-tab:hover { color: var(--fg-2); }
+.lb-tab.on { color: var(--fg); border-bottom-color: var(--accent); }
+
+.lb-list { display: flex; flex-direction: column; }
+.lb-item {
+  display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center;
+  padding: 9px 14px; border-bottom: 1px solid var(--line);
+  transition: background .1s;
+}
+.lb-item:last-child { border-bottom: 0; }
+.lb-item:hover { background: var(--bg-3); }
+.lb-rank {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-4);
+  text-align: center; font-weight: 500;
+}
+.lb-item.top-1 .lb-rank { color: var(--accent); font-weight: 700; }
+.lb-item.top-2 .lb-rank,
+.lb-item.top-3 .lb-rank { color: var(--fg-2); font-weight: 600; }
+.lb-user { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.lb-name {
+  font-size: 13px; color: var(--fg); line-height: 1.2; letter-spacing: -0.005em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.lb-you-tag {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.1em;
+  color: var(--accent); margin-left: 6px;
+}
+.lb-count {
+  font-family: var(--sans); font-weight: 600; font-size: 14px; color: var(--fg);
+  letter-spacing: -0.01em; text-align: right; line-height: 1.1;
+}
+.lb-you-row {
+  display: grid; grid-template-columns: 22px minmax(0, 1fr) auto; gap: 10px; align-items: center;
+  padding: 9px 14px;
+  background: color-mix(in oklab, var(--accent) 8%, var(--bg-2));
+  border-top: 1px dashed var(--line-2);
+}
+.lb-you-row .lb-rank { color: var(--accent); font-weight: 600; }
+
 /* Submit callout */
 .submit-card { padding: 18px; }
 .submit-card h4 { margin: 0 0 6px; font-family: var(--sans); font-size: 16px; letter-spacing: -0.02em; font-weight: 700; }


### PR DESCRIPTION
Adds the "Top contributors" panel from the \`Home.html\` design to the home page right rail.

## What
- Two tabs: **This week** (default) and **All-time**.
- Top-3 rows get rank-color treatment (accent for #1, lighter foreground for #2–3).
- Each row shows \`@display_name\` and the submission count.
- When the viewer is authenticated and ranks outside the top list, a separate accent-tinted "you" stripe appears at the bottom. If they're already in the top list, no duplicate row is shown (just a \`YOU\` tag inline).
- Soft-fail: if the leaderboard endpoint errors during SSR, the page renders without the widget.

## Wiring
- New proxy: \`/pages/api/submissions/leaderboard.ts\` → backend \`/api/v1/submissions/leaderboard?range={week,all}\`.
- New \`ContributorsPanel\` component (client-side tab switching, SSR seeds "this week").
- \`.lb-tabs\` / \`.lb-list\` / \`.lb-item\` / \`.lb-you-row\` styles in \`globals.css\`, lifted directly from the design.

Backend in [openingwiki/backend#44](https://github.com/openingwiki/backend/pull/44).

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Home page right rail shows "Top contributors" between groups + submit cards
- [ ] Click "All-time" → list refreshes
- [ ] Logged-in user outside top 10 sees the accent-tinted "you" stripe