### PR TITLE
feat(me): My Submissions page + nav entry next to Home/Play

### DIFF
--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -6,14 +6,26 @@ interface Props {
   user: User | null;
 }
 
-const NAV = [
+type NavItem = { href: string; label: string; match: (p: string) => boolean };
+
+const BASE_NAV: NavItem[] = [
   { href: "/",       label: "Home",   match: (p: string) => p === "/" },
   { href: "/play",   label: "Play",   match: (p: string) => p.startsWith("/play") },
   { href: "/groups", label: "Groups", match: (p: string) => p.startsWith("/groups") || p.startsWith("/g/") },
 ];
 
+const ME_SUBMISSIONS_ITEM: NavItem = {
+  href: "/my-submissions",
+  label: "My submissions",
+  match: (p: string) => p.startsWith("/my-submissions"),
+};
+
 export default function Topbar({ user }: Props) {
   const { pathname } = useRouter();
+  // Slot "My submissions" between Play and Groups for authenticated
+  // users so it sits next to the other gameplay-adjacent entries
+  // rather than buried inside the avatar menu.
+  const nav = user ? [...BASE_NAV.slice(0, 2), ME_SUBMISSIONS_ITEM, ...BASE_NAV.slice(2)] : BASE_NAV;
 
   return (
     <header className="topbar">
@@ -24,7 +36,7 @@ export default function Topbar({ user }: Props) {
         </Link>
 
         <nav className="nav">
-          {NAV.map((item) => (
+          {nav.map((item) => (
             <Link
               key={item.href}
               href={item.href}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -403,6 +403,10 @@ export function getKindCounts(cookie?: string): Promise<KindCounts> {
   }));
 }
 
+export function getMySubmissions(cookie?: string): Promise<import("./types").MySubmissionsResponse> {
+  return apiFetchData<import("./types").MySubmissionsResponse>("/me/submissions", { cookie });
+}
+
 export type ContributorRange = "week" | "all";
 
 export interface ContributorEntry {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -308,6 +308,20 @@ export interface ModerationItem {
   bio?: string | null;
 }
 
+// MySubmissionItem extends ModerationItem with the review trail. The
+// /api/v1/me/submissions endpoint returns these so the user-facing
+// "My submissions" page can render rejection feedback inline.
+export interface MySubmissionItem extends ModerationItem {
+  reviewed_at?: string;
+  rejection_reason?: string;
+}
+
+export interface MySubmissionsResponse {
+  items: MySubmissionItem[];
+  counts: Record<"all" | SubmissionStatus, number>;
+  type_counts: Record<"all" | ModerationItemType, number>;
+}
+
 export interface ModerationQueuePage {
   items: ModerationItem[];
   total: number;

--- a/pages/api/me/submissions.ts
+++ b/pages/api/me/submissions.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { backendUrl } from "@/lib/api-proxy";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).end();
+  const upstream = await fetch(backendUrl(`/me/submissions`), {
+    headers: req.headers.cookie ? { cookie: req.headers.cookie } : undefined,
+  });
+  const data = await upstream.json();
+  return res.status(upstream.status).json(data);
+}

--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -1,0 +1,287 @@
+import type { GetServerSideProps } from "next";
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+import Layout from "@/components/Layout";
+import { getMySubmissions } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import type { MySubmissionItem, MySubmissionsResponse, SubmissionStatus, User } from "@/lib/types";
+
+interface Props {
+  user: User;
+  modQueueCount: number;
+  initial: MySubmissionsResponse;
+}
+
+type StatusFilter = "all" | SubmissionStatus;
+type TypeFilter = "all" | "opening" | "anime" | "singer";
+type SortMode = "recent" | "oldest" | "status";
+
+const STATUS_LABEL: Record<SubmissionStatus, string> = {
+  pending: "In queue",
+  approved: "Approved",
+  rejected: "Rejected",
+};
+
+const STATUS_ORDER: Record<SubmissionStatus, number> = {
+  pending: 0,
+  rejected: 1,
+  approved: 2,
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+  if (!session.user) {
+    return { redirect: { destination: "/login?next=/my-submissions", permanent: false } };
+  }
+  // Graceful fallback so a transient API error doesn't 500 the page.
+  // Empty counts/items render the empty state.
+  let initial: MySubmissionsResponse = {
+    items: [],
+    counts: { all: 0, pending: 0, approved: 0, rejected: 0 },
+    type_counts: { all: 0, opening: 0, anime: 0, singer: 0 },
+  };
+  try {
+    initial = await getMySubmissions(session.cookie);
+  } catch {
+    /* keep empty */
+  }
+  return {
+    props: { user: session.user, modQueueCount: session.modQueueCount, initial },
+  };
+};
+
+export default function MySubmissionsPage({ user, modQueueCount, initial }: Props) {
+  const [status, setStatus] = useState<StatusFilter>("all");
+  const [type, setType] = useState<TypeFilter>("all");
+  const [sort, setSort] = useState<SortMode>("recent");
+
+  const filtered = useMemo(() => {
+    const base = initial.items.filter((it) => {
+      if (status !== "all" && it.status !== status) return false;
+      if (type !== "all" && it.type !== type) return false;
+      return true;
+    });
+    if (sort === "recent") return base;
+    if (sort === "oldest") return [...base].reverse();
+    // by status: pending → rejected → approved (matches design)
+    return [...base].sort((a, b) => (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9));
+  }, [initial.items, status, type, sort]);
+
+  const c = initial.counts;
+  const tc = initial.type_counts;
+
+  return (
+    <Layout
+      user={user}
+      modQueueCount={modQueueCount}
+      title={`Your submissions — Opening Wiki`}
+      description="Your submissions and their review state."
+    >
+      <div className="wrap">
+        <div className="ms-crumb">
+          <Link href="/">← Back to catalogue</Link>
+          <span className="sep">/</span>
+          <span>@{user.display_name}</span>
+          <span className="sep">/</span>
+          <span>submissions</span>
+        </div>
+
+        <div className="ms-head">
+          <div>
+            <h1 className="ms-h1">Your <em>submissions</em>.</h1>
+            <p className="ms-sub">
+              {c.all} total · recently submitted entries and their review state
+            </p>
+          </div>
+          <div className="ms-head-right">
+            <Link href="/submit" className="btn primary">+ New submission</Link>
+          </div>
+        </div>
+
+        <div className="ms-filter-bar">
+          <div className="ms-sort">
+            <span className="ms-fb-label">Status</span>
+            <select value={status} onChange={(e) => setStatus(e.target.value as StatusFilter)}>
+              <option value="all">All ({c.all})</option>
+              <option value="pending">In queue ({c.pending})</option>
+              <option value="rejected">Rejected ({c.rejected})</option>
+              <option value="approved">Approved ({c.approved})</option>
+            </select>
+          </div>
+          <div className="ms-sort">
+            <span className="ms-fb-label">Type</span>
+            <select value={type} onChange={(e) => setType(e.target.value as TypeFilter)}>
+              <option value="all">All ({tc.all})</option>
+              <option value="opening">OP / ED / OST ({tc.opening})</option>
+              <option value="anime">Anime ({tc.anime})</option>
+              <option value="singer">Singers ({tc.singer})</option>
+            </select>
+          </div>
+          <span className="ms-spacer" />
+          <div className="ms-sort">
+            <span className="ms-fb-label">Sort</span>
+            <select value={sort} onChange={(e) => setSort(e.target.value as SortMode)}>
+              <option value="recent">Most recent</option>
+              <option value="oldest">Oldest first</option>
+              <option value="status">By status</option>
+            </select>
+          </div>
+        </div>
+
+        {filtered.length === 0 ? (
+          <div className="ms-empty">
+            <h3>Nothing here.</h3>
+            <p>No submissions match this filter combination.</p>
+            <Link href="/submit" className="btn primary">+ Submit something</Link>
+          </div>
+        ) : (
+          <div className="ms-list">
+            {filtered.map((it) => (
+              <SubmissionRow key={`${it.type}:${it.id}`} item={it} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}
+
+function SubmissionRow({ item }: { item: MySubmissionItem }) {
+  const submittedLabel = formatRelativeDate(item.submitted_at, "Sent");
+  const reviewedLabel = item.reviewed_at ? formatRelativeDate(item.reviewed_at) : null;
+
+  return (
+    <article className={`ms-sub ms-${item.status}`}>
+      <div className="ms-sub-head">
+        <div className="ms-thumb-wrap">
+          <Thumb item={item} />
+        </div>
+        <div className="ms-meta-block">
+          <div className="ms-meta-tags">{renderTypeTag(item)}</div>
+          <h3 className="ms-sub-title">{primaryTitle(item)}</h3>
+          <div className="ms-sub-sub">{renderSubMeta(item, submittedLabel)}</div>
+        </div>
+        <div>
+          <StatusBadge status={item.status} />
+        </div>
+      </div>
+      {item.status === "rejected" && (item.rejection_reason || reviewedLabel) && (
+        <div className="ms-review-block">
+          <div className="ms-review-head">
+            <span className="ms-verdict">Needs fixes</span>
+            {reviewedLabel && <><span className="sep">·</span><span className="when">{reviewedLabel}</span></>}
+          </div>
+          {item.rejection_reason && (
+            <div className="ms-review-msg">{item.rejection_reason}</div>
+          )}
+          <div className="ms-review-actions">
+            <Link href="/submit" className="btn primary sm">Edit &amp; resubmit</Link>
+          </div>
+        </div>
+      )}
+      {item.status === "pending" && (
+        <div className="ms-pending-note">
+          <span className="bar" />
+          <em>In moderator queue.</em> Reviewed within 24h typical.
+        </div>
+      )}
+    </article>
+  );
+}
+
+function renderTypeTag(item: MySubmissionItem) {
+  if (item.type === "opening") {
+    const k = (item.kind ?? "opening").toString();
+    const label = k === "opening" ? "OP" : k === "ending" ? "ED" : "OST";
+    const klass = k === "opening" ? "op" : k === "ending" ? "ed" : "ost";
+    return <span className={`ms-tag ${klass}`}>{label}</span>;
+  }
+  if (item.type === "anime") return <span className="ms-tag anime">Anime</span>;
+  return <span className="ms-tag singer">Singer</span>;
+}
+
+function primaryTitle(item: MySubmissionItem): string {
+  if (item.type === "opening") return item.title ?? "—";
+  return item.name ?? "—";
+}
+
+function renderSubMeta(item: MySubmissionItem, when: string) {
+  if (item.type === "opening") {
+    return (
+      <>
+        <span className="attr">{item.anime?.name ?? item.anime_name ?? "—"}</span>
+        <span className="sep">·</span>
+        <span>{item.singer?.name ?? item.singer_name ?? "—"}</span>
+        <span className="sep">·</span>
+        <span>{when}</span>
+      </>
+    );
+  }
+  if (item.type === "anime") {
+    const bits = [item.year, item.format, item.studio].filter(Boolean).join(" · ");
+    return (
+      <>
+        {bits && <><span>{bits}</span><span className="sep">·</span></>}
+        <span>{when}</span>
+      </>
+    );
+  }
+  return (
+    <>
+      <span>{item.singer_type ?? "—"}</span>
+      <span className="sep">·</span>
+      <span>{when}</span>
+    </>
+  );
+}
+
+function Thumb({ item }: { item: MySubmissionItem }) {
+  if (item.type === "opening") {
+    return <div className="ms-thumb"><div className="ms-yt" /></div>;
+  }
+  if (item.type === "anime") {
+    return (
+      <div className="ms-thumb ms-thumb-poster">
+        {item.cover_image_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={item.cover_image_url} alt="" />
+        ) : <span className="ms-ph">2:3</span>}
+      </div>
+    );
+  }
+  return (
+    <div className="ms-thumb ms-thumb-round">
+      {item.cover_image_url ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={item.cover_image_url} alt="" />
+      ) : <span className="ms-ph">1:1</span>}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: SubmissionStatus }) {
+  return (
+    <span className={`ms-status ms-status-${status}`}>
+      <span className="ms-sdot" />
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}
+
+function formatRelativeDate(iso: string, prefix?: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const days = Math.floor((Date.now() - d.getTime()) / 86_400_000);
+  let rel: string;
+  if (days <= 0) {
+    const hours = Math.max(1, Math.floor((Date.now() - d.getTime()) / 3_600_000));
+    rel = `${hours}h ago`;
+  } else if (days === 1) {
+    rel = "1 day ago";
+  } else {
+    rel = `${days} days ago`;
+  }
+  const stamp = d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return prefix ? `${prefix} ${stamp} · ${rel}` : `${stamp} · ${rel}`;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2707,3 +2707,200 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   flex-shrink: 0;
 }
 .rail-rating em { font-style: normal; font-size: 10px; color: var(--fg-4); margin-left: 1px; }
+
+/* ============================================================== */
+/* MY SUBMISSIONS page — design lifted from My Submissions.html    */
+/* ============================================================== */
+.ms-crumb {
+  padding: 28px 0 14px;
+  font-family: var(--mono); font-size: 12px; color: var(--fg-3);
+  display: flex; align-items: center; gap: 8px;
+}
+.ms-crumb a { color: var(--fg-3); transition: color .15s; }
+.ms-crumb a:hover { color: var(--fg); }
+.ms-crumb .sep { color: var(--fg-4); }
+
+.ms-head {
+  padding: 4px 0 28px;
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 30px;
+}
+.ms-h1 {
+  font-weight: 800; font-size: 44px; line-height: 1; letter-spacing: -0.035em;
+  margin: 0 0 10px;
+}
+.ms-h1 em { font-style: normal; color: var(--accent); }
+.ms-sub { color: var(--fg-3); font-family: var(--mono); font-size: 12px; margin: 0; letter-spacing: 0.04em; }
+.ms-head-right { display: flex; gap: 8px; }
+
+.ms-filter-bar {
+  display: flex; align-items: center; gap: 18px;
+  padding: 4px 0 26px;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  flex-wrap: wrap;
+}
+.ms-fb-label {
+  text-transform: uppercase; letter-spacing: 0.12em;
+  color: var(--fg-4); font-size: 10px;
+}
+.ms-spacer { flex: 1; }
+.ms-sort { display: inline-flex; align-items: center; gap: 8px; }
+.ms-sort select {
+  background: var(--bg-2); color: var(--fg);
+  border: 1px solid var(--line); border-radius: 5px;
+  padding: 5px 26px 5px 10px;
+  font-family: var(--mono); font-size: 11px;
+  outline: none; cursor: pointer;
+  appearance: none; -webkit-appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--fg-3) 50%),
+    linear-gradient(135deg, var(--fg-3) 50%, transparent 50%);
+  background-position: calc(100% - 12px) 50%, calc(100% - 8px) 50%;
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+}
+.ms-sort select:hover, .ms-sort select:focus { border-color: var(--line-2); color: var(--fg); }
+
+.ms-list { display: flex; flex-direction: column; gap: 14px; padding-bottom: 80px; }
+.ms-sub {
+  border: 1px solid var(--line); border-radius: 10px;
+  background: var(--bg-2); overflow: hidden;
+  transition: border-color .15s;
+}
+.ms-sub:hover { border-color: var(--line-2); }
+.ms-sub-head {
+  display: grid; grid-template-columns: 160px 1fr auto; gap: 20px;
+  align-items: center; padding: 18px 20px;
+}
+.ms-thumb-wrap { display: grid; place-items: center; width: 160px; }
+.ms-thumb {
+  width: 160px; aspect-ratio: 16/9; border-radius: 6px;
+  background-image: repeating-linear-gradient(45deg, #1a1628 0 8px, #241e36 8px 9px);
+  border: 1px solid var(--line-2);
+  position: relative; overflow: hidden;
+  display: grid; place-items: center;
+}
+.ms-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.ms-thumb.ms-thumb-poster {
+  aspect-ratio: 2/3; width: 80px;
+}
+.ms-thumb.ms-thumb-round {
+  aspect-ratio: 1/1; width: 80px; border-radius: 50%;
+  background-image: repeating-linear-gradient(60deg, #1a1628 0 8px, #2a2240 8px 9px);
+}
+.ms-yt {
+  width: 38px; height: 27px;
+  background: color-mix(in oklab, var(--danger) 90%, #000);
+  border-radius: 5px; display: grid; place-items: center; position: relative;
+}
+.ms-yt::after {
+  content: ""; width: 0; height: 0;
+  border-left: 9px solid #fff; border-top: 5px solid transparent; border-bottom: 5px solid transparent;
+  margin-left: 1px;
+}
+.ms-ph {
+  color: var(--fg-3); font-family: var(--mono); font-size: 9px;
+  letter-spacing: 0.12em; text-transform: uppercase;
+}
+
+.ms-meta-block { min-width: 0; }
+.ms-meta-tags { display: flex; align-items: center; gap: 6px; margin-bottom: 7px; flex-wrap: wrap; }
+.ms-tag {
+  font-family: var(--mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.14em; text-transform: uppercase;
+  padding: 3px 7px; border-radius: 3px;
+  border: 1px solid var(--line-2); color: var(--fg-3);
+}
+.ms-tag.op    { color: var(--accent); border-color: color-mix(in oklab, var(--accent) 50%, transparent); background: color-mix(in oklab, var(--accent) 10%, transparent); }
+.ms-tag.ed    { color: var(--ok);     border-color: color-mix(in oklab, var(--ok) 50%,     transparent); background: color-mix(in oklab, var(--ok) 10%,     transparent); }
+.ms-tag.ost   { color: var(--warn);   border-color: color-mix(in oklab, var(--warn) 50%,   transparent); background: color-mix(in oklab, var(--warn) 10%,   transparent); }
+.ms-tag.anime, .ms-tag.singer { color: var(--fg-2); }
+
+.ms-sub-title {
+  font-size: 18px; line-height: 1.15; letter-spacing: -0.02em; font-weight: 700;
+  margin: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.ms-sub-sub {
+  margin-top: 4px; font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+.ms-sub-sub .sep { color: var(--fg-4); }
+.ms-sub-sub .attr { color: var(--fg-2); }
+
+/* Status badge — pending in accent, approved in green,
+   rejected in RED (user request: highlight rejections clearly). */
+.ms-status {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 11px; border-radius: 5px;
+  font-family: var(--mono); font-size: 11px; font-weight: 600;
+  letter-spacing: 0.1em; text-transform: uppercase;
+  border: 1px solid var(--line-2); white-space: nowrap;
+  color: var(--fg-2); background: var(--bg-3);
+}
+.ms-status .ms-sdot { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-3); }
+.ms-status-pending {
+  color: var(--accent);
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  border-color: color-mix(in oklab, var(--accent) 40%, transparent);
+}
+.ms-status-pending .ms-sdot { background: var(--accent); animation: ms-pulse 1.8s ease-in-out infinite; }
+.ms-status-approved {
+  color: var(--ok);
+  background: color-mix(in oklab, var(--ok) 10%, transparent);
+  border-color: color-mix(in oklab, var(--ok) 40%, transparent);
+}
+.ms-status-approved .ms-sdot { background: var(--ok); }
+.ms-status-rejected {
+  color: var(--danger);
+  background: color-mix(in oklab, var(--danger) 10%, transparent);
+  border-color: color-mix(in oklab, var(--danger) 45%, transparent);
+}
+.ms-status-rejected .ms-sdot { background: var(--danger); }
+@keyframes ms-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+.ms-review-block {
+  border-top: 1px solid var(--line);
+  padding: 16px 20px 18px;
+  background: var(--bg);
+}
+.ms-review-head {
+  display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  margin-bottom: 8px;
+}
+.ms-verdict {
+  font-family: var(--sans); font-weight: 700; font-size: 13px; letter-spacing: -0.01em;
+  color: var(--danger); margin-right: 6px;
+}
+.ms-review-head .sep { color: var(--fg-4); }
+.ms-review-head .when { color: var(--fg-4); }
+.ms-review-msg { color: var(--fg-2); font-size: 14px; line-height: 1.55; white-space: pre-wrap; }
+.ms-review-actions { margin-top: 14px; display: flex; gap: 8px; flex-wrap: wrap; }
+
+.ms-pending-note {
+  border-top: 1px solid var(--line);
+  padding: 12px 20px;
+  background: var(--bg);
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+  display: flex; align-items: center; gap: 12px;
+}
+.ms-pending-note .bar {
+  flex: 1; max-width: 260px; height: 3px; border-radius: 2px;
+  background: var(--bg-3); overflow: hidden; position: relative;
+}
+.ms-pending-note .bar::after {
+  content: ""; position: absolute; inset: 0;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  background-size: 50% 100%; background-repeat: no-repeat;
+  animation: ms-slide 2.4s infinite linear;
+}
+@keyframes ms-slide { 0%{background-position: -50% 0} 100%{background-position: 150% 0} }
+.ms-pending-note em { font-style: normal; color: var(--fg-2); }
+
+.ms-empty {
+  margin: 30px 0 80px;
+  padding: 56px 40px; text-align: center;
+  border: 1px dashed var(--line-2); border-radius: 10px;
+  background: var(--bg-2);
+}
+.ms-empty h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -0.02em; }
+.ms-empty p { margin: 0 0 18px; color: var(--fg-3); font-family: var(--mono); font-size: 11px; }


### PR DESCRIPTION
Adds the "My Submissions" view from the design (\`My Submissions.html\`).

## What
- New route \`/my-submissions\` — SSR-fetched from \`/api/v1/me/submissions\`. Logged-in users only (otherwise redirected to \`/login\`).
- **Topbar** now shows **My submissions** between Play and Groups for logged-in users — slotted into the nav array per the user request "place the button near to home and play".
- Filter dropdowns drive the list client-side: status (All / In queue / Rejected / Approved), type (All / OP·ED·OST / Anime / Singers), sort (Most recent / Oldest / By status).
- Each submission row: type tag (OP/ED/OST/Anime/Singer in accent / green / amber / neutral), title, attribution line, sent-at + relative timestamp, status badge.
- **Rejected rows** expand inline showing a "Needs fixes" verdict, the moderator's \`rejection_reason\`, and an "Edit & resubmit" CTA.
- Pending rows show a subtle animated progress sliver and "In moderator queue. Reviewed within 24h typical."
- Empty state with copy + "+ Submit something" CTA.

## Red rejected badge
Per request, the rejected status badge is colored red (\`var(--danger)\`) instead of the design's neutral gray so rejections are unmissable. Approved stays green, pending stays accent.

Backend: [openingwiki/backend#46](https://github.com/openingwiki/backend/pull/46).

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Topbar shows the new entry only when authenticated; active state on /my-submissions
- [ ] Rejected row shows the moderator's reason inline, badge is red
- [ ] Filter combos hide/show rows correctly; empty state appears when nothing matches