### PR TITLE
feat(me): load YouTube previews for opening submissions

### DIFF
--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -6,6 +6,7 @@ import Layout from "@/components/Layout";
 import { getMySubmissions } from "@/lib/api";
 import { loadSession } from "@/lib/session";
 import type { MySubmissionItem, MySubmissionsResponse, SubmissionStatus, User } from "@/lib/types";
+import { youtubeThumbnail } from "@/lib/youtube";
 
 interface Props {
   user: User;
@@ -238,7 +239,20 @@ function renderSubMeta(item: MySubmissionItem, when: string) {
 
 function Thumb({ item }: { item: MySubmissionItem }) {
   if (item.type === "opening") {
-    return <div className="ms-thumb"><div className="ms-yt" /></div>;
+    // Pull the preview straight from YouTube's CDN — no API key needed,
+    // and the URL is already validated server-side, so a bad submission
+    // can't render a broken image (youtubeThumbnail returns null).
+    const preview = item.youtube_url ? youtubeThumbnail(item.youtube_url) : null;
+    return (
+      <div className="ms-thumb">
+        {preview ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={preview} alt="" loading="lazy" />
+        ) : (
+          <div className="ms-yt" />
+        )}
+      </div>
+    );
   }
   if (item.type === "anime") {
     return (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2779,7 +2779,7 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   position: relative; overflow: hidden;
   display: grid; place-items: center;
 }
-.ms-thumb img { width: 100%; height: 100%; object-fit: cover; }
+.ms-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
 .ms-thumb.ms-thumb-poster {
   aspect-ratio: 2/3; width: 80px;
 }


### PR DESCRIPTION
Was meant to ship with #43 but the merge raced the push.

Pipes each opening submission's \`youtube_url\` through the existing \`youtubeThumbnail\` helper (\`lib/youtube.ts\` → \`https://i.ytimg.com/vi/<id>/hqdefault.jpg\`) and renders it inside the 16:9 thumb box. \`object-fit: cover\` crops the hqdefault's 4:3 letterboxing so just the video frame fills the box. Falls back to the existing placeholder when the URL is missing or doesn't parse to a valid 11-char ID — no broken-image states.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Opening rows on /my-submissions show their YouTube thumbnail; non-opening rows + bad URLs keep the placeholder