### PR TITLE
feat(play): guess the anime, not the specific opening

### DIFF
--- a/lib/play.ts
+++ b/lib/play.ts
@@ -136,7 +136,7 @@ async function call<T>(path: string, init?: RequestInit): Promise<T> {
 export const playClient = {
   startRun: () => call<SoloStartResponse>("/solo/runs", { method: "POST" }),
   getRun: (id: string) => call<{ run: SoloRun; current_round?: SoloRound }>(`/solo/runs/${encodeURIComponent(id)}`),
-  submitAnswer: (id: string, body: { round_token: string; opening_id: string | null; client_response_ms: number }) =>
+  submitAnswer: (id: string, body: { round_token: string; anime_id: string | null; client_response_ms: number }) =>
     call<SoloAnswerResponse>(`/solo/runs/${encodeURIComponent(id)}/answer`, {
       method: "POST",
       body: JSON.stringify(body),

--- a/lib/pvp.ts
+++ b/lib/pvp.ts
@@ -92,7 +92,7 @@ export interface RoundEndData {
     string,
     {
       status: "answered" | "locked" | "timeout";
-      picked_opening_id?: string | null;
+      picked_anime_id?: string | null;
       was_correct?: boolean;
       response_ms?: number;
     }
@@ -229,8 +229,8 @@ export class PvPSocket {
     this.ws.send(JSON.stringify({ type, data }));
   }
 
-  submitAnswer(round_id: string, opening_id: string, client_submit_ms: number) {
-    this.send("answer.submit", { round_id, opening_id, client_submit_ms });
+  submitAnswer(round_id: string, anime_id: string, client_submit_ms: number) {
+    this.send("answer.submit", { round_id, anime_id, client_submit_ms });
   }
   sendTyping() {
     this.send("input.typing");

--- a/pages/api/play/solo/runs/[id]/answer.ts
+++ b/pages/api/play/solo/runs/[id]/answer.ts
@@ -2,8 +2,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { backendUrl, buildCsrfHeaders, copyBackendCookies } from "@/lib/api-proxy";
 
 // POST /api/play/solo/runs/{id}/answer — submit the round answer.
-// opening_id may be null for "no guess / timeout"; round_token is
-// required and the backend rejects mismatches with 401.
+// anime_id may be null for "no guess / timeout"; round_token is
+// required and the backend rejects mismatches with 401. Scoring is
+// anime-based: any opening of the right anime counts.
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
   const id = String(req.query.id ?? "");
@@ -15,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     headers: buildCsrfHeaders(req.headers.cookie, { "Content-Type": "application/json" }),
     body: JSON.stringify({
       round_token: body.round_token ?? "",
-      opening_id: body.opening_id ?? null,
+      anime_id: body.anime_id ?? null,
       client_response_ms: Number(body.client_response_ms ?? 0) | 0,
     }),
   });

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -355,8 +355,8 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
             playedMs={phase.playedMs}
             meID={user.id}
             score={score}
-            onSubmit={(opening_id) => {
-              sockRef.current?.submitAnswer(phase.round.round_id, opening_id, Date.now());
+            onSubmit={(anime_id) => {
+              sockRef.current?.submitAnswer(phase.round.round_id, anime_id, Date.now());
             }}
             onTyping={() => sockRef.current?.sendTyping()}
           />
@@ -657,10 +657,12 @@ function MatchHud({ view, scoreOverride }: { view: PvPMatchView; scoreOverride?:
 function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }: {
   view: PvPMatchView; round: RoundStartData; playedMs: number; meID: string;
   score: Record<string, number>;
-  onSubmit: (opening_id: string) => void; onTyping: () => void;
+  onSubmit: (anime_id: string) => void; onTyping: () => void;
 }) {
   const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; anime: string }>>([]);
+  // Anime autocomplete — scoring is anime-based now, so the user
+  // picks an anime and any of its openings counts as correct.
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null }>>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const queryRef = useRef(query);
   queryRef.current = query;
@@ -670,12 +672,14 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
     onTyping();
     const handle = setTimeout(async () => {
       try {
-        const res = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}&types=opening&limit=8`, { credentials: "include" });
+        const res = await fetch(`/api/v1/anime/search?q=${encodeURIComponent(query)}&limit=8`, { credentials: "include" });
         if (!res.ok) return;
         const body = await res.json();
         if (queryRef.current !== query) return;
-        const items = (body?.data?.openings ?? []).slice(0, 8).map((o: any) => ({
-          id: o.id, title: o.title, anime: o.anime_name ?? o.anime?.name ?? "—",
+        const items = (body?.data ?? []).slice(0, 8).map((a: any) => ({
+          id: a.id,
+          title: a.name || a.title_romaji,
+          year: a.year ?? null,
         }));
         setSuggestions(items);
         setActiveIdx(0);
@@ -722,7 +726,7 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
                 }}>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
-                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>{s.anime}</div>
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>{s.year ?? "—"}</div>
                   </div>
                   {i === activeIdx && <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "2px 6px", borderRadius: 3 }}>↵</span>}
                 </div>
@@ -730,7 +734,7 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
             </div>
           )}
           <div style={{ display: "flex", alignItems: "center", gap: 14, background: SOLO.bg2, border: `1.5px solid ${SOLO.accent}`, borderRadius: 10, padding: "16px 20px", boxShadow: `0 0 0 4px ${SOLO.accent}11` }}>
-            <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.accent, letterSpacing: "0.16em", textTransform: "uppercase" }}>Title</span>
+            <span style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.accent, letterSpacing: "0.16em", textTransform: "uppercase" }}>Anime</span>
             <input
               autoFocus value={query} onChange={(e) => setQuery(e.target.value)} onKeyDown={onKey}
               placeholder="Type the anime title…"

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -137,12 +137,12 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const submitAnswer = useCallback(async (p: Phase & { kind: "in-match" }, openingId: string | null) => {
+  const submitAnswer = useCallback(async (p: Phase & { kind: "in-match" }, animeId: string | null) => {
     setPhase({ kind: "starting" });
     try {
       const response = await playClient.submitAnswer(p.run.id, {
         round_token: p.round.round_token,
-        opening_id: openingId,
+        anime_id: animeId,
         client_response_ms: Date.now() - inMatchStart.current,
       });
       if (audioRef.current) {
@@ -175,7 +175,7 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
             round={phase.round}
             run={phase.run}
             playedMs={phase.clipPlayedMs}
-            onSubmit={(openingId) => submitAnswer(phase, openingId)}
+            onSubmit={(animeId) => submitAnswer(phase, animeId)}
           />
         )}
         {phase.kind === "reveal" && (
@@ -298,28 +298,27 @@ function ModeRevealScreen({ mode, countdownMs, run, round }: { mode: string; cou
   );
 }
 
-function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; run: SoloRun; playedMs: number; onSubmit: (openingId: string | null) => void }) {
+function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; run: SoloRun; playedMs: number; onSubmit: (animeId: string | null) => void }) {
   const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; anime: string; year: number | null }>>([]);
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null }>>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const queryRef = useRef(query);
   queryRef.current = query;
 
-  // Debounced autocomplete fetch — backend /api/v1/search returns
-  // openings + anime + singer; we project openings only for the
-  // suggestion list.
+  // Debounced autocomplete fetch — scoring is anime-based now, so we
+  // hit /api/v1/anime/search instead of filtering openings.
   useEffect(() => {
     if (query.trim().length < 2) { setSuggestions([]); return; }
     const handle = setTimeout(async () => {
       try {
-        const res = await fetch(`/api/v1/search?q=${encodeURIComponent(query)}&types=opening&limit=8`, { credentials: "include" });
+        const res = await fetch(`/api/v1/anime/search?q=${encodeURIComponent(query)}&limit=8`, { credentials: "include" });
         if (!res.ok) return;
         const body = await res.json();
         if (queryRef.current !== query) return;
-        const items = (body?.data?.openings ?? []).slice(0, 8).map((o: any) => ({
-          id: o.id, title: o.title,
-          anime: o.anime?.name ?? "—",
-          year: o.anime?.year ?? null,
+        const items = (body?.data ?? []).slice(0, 8).map((a: any) => ({
+          id: a.id,
+          title: a.name || a.title_romaji,
+          year: a.year ?? null,
         }));
         setSuggestions(items);
         setActiveIdx(0);
@@ -369,7 +368,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
         </div>
         <Waveform played={pct} />
         <div style={{ textAlign: "center", marginTop: 22, fontFamily: SOLO.sans, fontSize: 14, color: SOLO.fg3 }}>
-          Type the opening you hear. ↵ to submit.
+          Name the anime. ↵ to submit.
         </div>
       </div>
       <div style={{ padding: "0 40px 32px", position: "relative" }}>
@@ -381,7 +380,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
             boxShadow: "0 -20px 50px -10px rgba(0,0,0,0.5)",
           }}>
             <div style={{ padding: "10px 16px", fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, borderBottom: `1px solid ${SOLO.line}` }}>
-              Matches by song · anime
+              Anime matches
             </div>
             {suggestions.map((s, i) => (
               <div
@@ -403,7 +402,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
                   <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>
-                    {s.anime}{s.year ? ` · ${s.year}` : ""}
+                    {s.year ? `${s.year}` : "—"}
                   </div>
                 </div>
                 {i === activeIdx && (
@@ -428,7 +427,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={onKey}
-            placeholder="Start typing the song or anime…"
+            placeholder="Type the anime…"
             style={{
               flex: 1, fontSize: 18, fontWeight: 500, color: SOLO.fg,
               letterSpacing: "-0.01em", fontFamily: SOLO.sans,


### PR DESCRIPTION
Frontend half of the scoring switch. Backend: [openingwiki/backend#47](https://github.com/openingwiki/backend/pull/47).

## Changes
- **Autocomplete** in both Solo (run.tsx) and PvP (PlayingView in [code].tsx) hits \`/api/v1/anime/search\` instead of filtering openings out of \`/search\`. Suggestion projects \`{id, name, year}\`.
- **Solo**: \`/api/play/solo/runs/[id]/answer\` proxy + \`playClient.submitAnswer\` payload field \`opening_id\` → \`anime_id\`.
- **PvP**: \`PvPSocket.submitAnswer(round_id, anime_id, …)\` — the WS \`answer.submit\` frame's \`data\` field renamed accordingly. Round-end response type also renamed (\`picked_opening_id\` → \`picked_anime_id\`).
- **Copy**: in-match prompt "Type the opening you hear" → "Name the anime"; PvP input header "Title" → "Anime"; placeholders updated.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Solo: name the right anime → correct. Try a different opening of the same anime → also correct.
- [ ] PvP: both players use the anime picker; round.end shows the actual opening that played in the reveal card.