### PR TITLE
feat(play): /play mode chooser + /play/endless Solo hub

### DIFF
--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -662,7 +662,7 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
   const [query, setQuery] = useState("");
   // Anime autocomplete — scoring is anime-based now, so the user
   // picks an anime and any of its openings counts as correct.
-  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null }>>([]);
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null; cover: string | null }>>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const queryRef = useRef(query);
   queryRef.current = query;
@@ -680,6 +680,7 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
           id: a.id,
           title: a.name || a.title_romaji,
           year: a.year ?? null,
+          cover: a.cover_image_url ?? null,
         }));
         setSuggestions(items);
         setActiveIdx(0);
@@ -719,11 +720,22 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
             <div style={{ position: "absolute", bottom: "100%", left: 0, right: 0, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 10, marginBottom: 8, overflow: "hidden", boxShadow: "0 -20px 50px -10px rgba(0,0,0,0.5)" }}>
               {suggestions.map((s, i) => (
                 <div key={s.id} onMouseEnter={() => setActiveIdx(i)} onClick={() => onSubmit(s.id)} style={{
-                  display: "flex", alignItems: "center", gap: 12, padding: "12px 16px",
+                  display: "flex", alignItems: "center", gap: 14, padding: "12px 16px",
                   background: i === activeIdx ? SOLO.bg3 : "transparent",
                   borderLeft: i === activeIdx ? `2px solid ${SOLO.accent}` : "2px solid transparent",
                   cursor: "pointer",
                 }}>
+                  <div style={{
+                    width: 38, height: 52, borderRadius: 4,
+                    border: `1px solid ${SOLO.line}`, flexShrink: 0, overflow: "hidden",
+                    background: s.cover ? "transparent" : SOLO.bg2,
+                    backgroundImage: s.cover ? "none" : `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 6px, ${SOLO.bg2} 6px 7px)`,
+                  }}>
+                    {s.cover && (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img src={s.cover} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} />
+                    )}
+                  </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
                     <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>{s.year ?? "—"}</div>

--- a/pages/play/endless.tsx
+++ b/pages/play/endless.tsx
@@ -1,0 +1,231 @@
+import Link from "next/link";
+import type { GetServerSideProps } from "next";
+
+import Layout from "@/components/Layout";
+import { getSoloLeaderboard, getSoloMyStats } from "@/lib/api";
+import { loadSession } from "@/lib/session";
+import { SOLO, Eyebrow } from "@/components/solo/atoms";
+import { formatResetCountdown, formatResponseMs } from "@/lib/play";
+import type { SoloLeaderboard, SoloMyStats } from "@/lib/play";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount: number;
+  stats: SoloMyStats | null;
+  leaderboard: SoloLeaderboard;
+  apiOnline: boolean;
+}
+
+const FALLBACK_LEADERBOARD: SoloLeaderboard = {
+  entries: [],
+  resets_in_sec: 6 * 3600,
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
+  const session = await loadSession(ctx);
+
+  let stats: SoloMyStats | null = null;
+  let leaderboard: SoloLeaderboard = FALLBACK_LEADERBOARD;
+  let apiOnline = true;
+  try {
+    leaderboard = await getSoloLeaderboard(undefined, session.cookie);
+    if (session.user) {
+      stats = await getSoloMyStats(session.cookie).catch(() => null);
+    }
+  } catch {
+    apiOnline = false;
+  }
+  return {
+    props: {
+      user: session.user,
+      modQueueCount: session.modQueueCount,
+      stats,
+      leaderboard,
+      apiOnline,
+    },
+  };
+};
+
+export default function EndlessHub({ user, modQueueCount, stats, leaderboard, apiOnline }: Props) {
+  return (
+    <Layout user={user} modQueueCount={modQueueCount} title="Endless · solo — Opening Wiki">
+      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 40px 60px" }}>
+
+          {/* Breadcrumb back to Play hub */}
+          <div style={{
+            fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em",
+            marginBottom: 18, display: "flex", alignItems: "center", gap: 8,
+          }}>
+            <Link href="/play" style={{ color: SOLO.fg2, textDecoration: "none" }}>Play</Link>
+            <span style={{ color: SOLO.fg4 }}>/</span>
+            <span>Endless</span>
+          </div>
+
+          <header style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 32, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+            <div>
+              <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>Endless · solo</Eyebrow>
+              <h1 style={{ margin: "12px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.98 }}>
+                Guess the anime. <span style={{ color: SOLO.accent }}>Alone.</span>
+              </h1>
+              <p style={{ margin: "12px 0 0", color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55 }}>
+                One run, three lives, a streak that keeps regenerating them. Daily leaderboard resets at midnight UTC.
+              </p>
+            </div>
+            {stats && stats.runs_played > 0 && (
+              <div style={{ display: "flex", gap: 24, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.06em" }}>
+                <div>
+                  <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>{stats.runs_played} runs</div>
+                  all time
+                </div>
+                {stats.todays_rank > 0 && (
+                  <div>
+                    <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>#{stats.todays_rank}</div>
+                    today
+                  </div>
+                )}
+              </div>
+            )}
+          </header>
+
+          {!apiOnline && (
+            <div style={{ marginTop: 24, padding: 16, borderRadius: 8, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, color: SOLO.fg2 }}>
+              The play backend is unreachable. The leaderboard below is empty until the API comes back.
+            </div>
+          )}
+
+          {/* Endless start CTA */}
+          <section style={{
+            background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
+            border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
+            position: "relative", overflow: "hidden", minHeight: 280, marginTop: 28,
+            display: "flex", flexDirection: "column",
+          }}>
+            <div style={{
+              position: "absolute", top: -60, right: -60, width: 420, height: 420, borderRadius: "50%",
+              background: `radial-gradient(circle, ${SOLO.accent}22 0%, transparent 70%)`,
+              pointerEvents: "none",
+            }} />
+            <h2 style={{ margin: "0 0 10px", fontWeight: 800, fontSize: 48, letterSpacing: "-0.04em", lineHeight: 1, maxWidth: 640, position: "relative" }}>
+              How far can you go before you slip?
+            </h2>
+            <p style={{ margin: 0, color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55, position: "relative" }}>
+              Three lives. Earn one back every five in a row. Difficulty climbs as you do. Run ends when you&apos;re out.
+            </p>
+            <div style={{ flex: 1, minHeight: 32 }} />
+            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8, position: "relative" }}>
+              {user ? (
+                <Link href="/play/run" style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
+                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
+                  textDecoration: "none",
+                  boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  Start run
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+                    <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </Link>
+              ) : (
+                <Link href={`/login?next=${encodeURIComponent("/play/endless")}`} style={{
+                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
+                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
+                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
+                  textDecoration: "none",
+                  boxShadow: `0 0 30px ${SOLO.accent}55`,
+                }}>
+                  Log in to play
+                </Link>
+              )}
+              <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, lineHeight: 1.4 }}>
+                ~ 8 min<br />top-1000 pool
+              </div>
+            </div>
+          </section>
+
+          <section style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
+            {stats && (
+              <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
+                <Eyebrow>Your records · all-time</Eyebrow>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px 36px", marginTop: 18 }}>
+                  {[
+                    [String(stats.best_score), "best run"],
+                    [String(stats.longest_streak), "longest streak"],
+                    [formatResponseMs(stats.avg_response_ms), "avg response"],
+                    [String(stats.runs_played), "runs played"],
+                  ].map(([v, l]) => (
+                    <div key={l}>
+                      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 32, letterSpacing: "-0.03em", color: SOLO.fg, lineHeight: 1 }}>{v}</div>
+                      <div style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, marginTop: 6 }}>{l}</div>
+                    </div>
+                  ))}
+                </div>
+                <div style={{ marginTop: 22, paddingTop: 18, borderTop: `1px dashed ${SOLO.line}`, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+                    Today&apos;s best · <span style={{ color: SOLO.accent }}>{stats.todays_best}</span>
+                  </div>
+                  {stats.todays_rank > 0 && (
+                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
+                      You&apos;re <span style={{ color: SOLO.fg }}>#{stats.todays_rank}</span> today
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
+                <Eyebrow>Daily leaderboard</Eyebrow>
+                <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.08em" }}>
+                  resets in {formatResetCountdown(leaderboard.resets_in_sec)}
+                </div>
+              </div>
+              {leaderboard.entries.length === 0 && (
+                <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, padding: 12 }}>
+                  No runs today yet. Be the first.
+                </div>
+              )}
+              {leaderboard.entries.slice(0, 10).map((e) => {
+                const you = e.user_id === user?.id;
+                return (
+                  <LeaderboardRow key={e.run_id} rank={e.rank} name={e.display_name} score={e.score} you={you} />
+                );
+              })}
+              {leaderboard.you && !leaderboard.entries.some((e) => e.user_id === user?.id) && (
+                <>
+                  <div style={{
+                    display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
+                    padding: "8px 12px", marginBottom: 2, fontFamily: SOLO.mono, fontSize: 13, color: SOLO.fg4,
+                  }}>
+                    <div>…</div><div /><div />
+                  </div>
+                  <LeaderboardRow rank={leaderboard.you.rank} name="you" score={leaderboard.you.score} you />
+                </>
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+function LeaderboardRow({ rank, name, score, you }: { rank: number | string; name: string; score: number; you?: boolean }) {
+  return (
+    <div style={{
+      display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
+      padding: "8px 12px", borderRadius: 6,
+      background: you ? `${SOLO.accent}14` : "transparent",
+      border: you ? `1px solid ${SOLO.accent}44` : "1px solid transparent",
+      marginBottom: 2,
+    }}>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 13, color: you ? SOLO.accent : SOLO.fg3, fontWeight: you ? 600 : 400 }}>{rank}</div>
+      <div style={{ fontFamily: SOLO.sans, fontSize: 13, color: you ? SOLO.fg : SOLO.fg2, fontWeight: you ? 600 : 400 }}>
+        {name}{you ? " (you)" : ""}
+      </div>
+      <div style={{ fontFamily: SOLO.mono, fontSize: 14, color: you ? SOLO.accent : SOLO.fg, fontWeight: 500 }}>{score}</div>
+    </div>
+  );
+}

--- a/pages/play/index.tsx
+++ b/pages/play/index.tsx
@@ -1,272 +1,152 @@
 import Link from "next/link";
 import type { GetServerSideProps } from "next";
-import Layout from "@/components/Layout";
+import type { ReactNode } from "react";
 
-import { getSoloLeaderboard, getSoloMyStats } from "@/lib/api";
+import Layout from "@/components/Layout";
 import { loadSession } from "@/lib/session";
 import { SOLO, Eyebrow } from "@/components/solo/atoms";
-import { formatResetCountdown, formatResponseMs } from "@/lib/play";
-import type { SoloLeaderboard, SoloMyStats } from "@/lib/play";
 import type { User } from "@/lib/types";
 
 interface Props {
   user: User | null;
   modQueueCount: number;
-  stats: SoloMyStats | null;
-  leaderboard: SoloLeaderboard;
-  apiOnline: boolean;
 }
 
-const FALLBACK_LEADERBOARD: SoloLeaderboard = {
-  entries: [],
-  resets_in_sec: 6 * 3600,
-};
-
+// /play is now a mode chooser: Endless (solo) and 1v1 (race).
+// The Endless-specific hub (stats, leaderboard, big start CTA) lives
+// at /play/endless. PvP creation is /play/pvp/new.
 export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const session = await loadSession(ctx);
-
-  // The hub renders whether or not the user is signed in — the
-  // leaderboard is public. Stats only make sense for a logged-in
-  // viewer, so the helper returns null on 401.
-  let stats: SoloMyStats | null = null;
-  let leaderboard: SoloLeaderboard = FALLBACK_LEADERBOARD;
-  let apiOnline = true;
-  try {
-    leaderboard = await getSoloLeaderboard(undefined, session.cookie);
-    if (session.user) {
-      stats = await getSoloMyStats(session.cookie).catch(() => null);
-    }
-  } catch {
-    apiOnline = false;
-  }
   return {
     props: {
       user: session.user,
       modQueueCount: session.modQueueCount,
-      stats,
-      leaderboard,
-      apiOnline,
     },
   };
 };
 
-export default function SoloHub({ user, modQueueCount, stats, leaderboard, apiOnline }: Props) {
+export default function PlayHub({ user, modQueueCount }: Props) {
+  // Login-gate happens on the actual mode page, not the chooser, so
+  // anon visitors can still see what's on offer.
+  const endlessHref = user ? "/play/endless" : `/login?next=${encodeURIComponent("/play/endless")}`;
+  const pvpHref = user ? "/play/pvp/new" : `/login?next=${encodeURIComponent("/play/pvp/new")}`;
   return (
-    <Layout user={user} modQueueCount={modQueueCount} title="Solo (Endless) — Opening Wiki">
+    <Layout user={user} modQueueCount={modQueueCount} title="Play — Opening Wiki">
       <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
-        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 40px 60px" }}>
-          <header style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 32, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
-            <div>
-              <Eyebrow>Play · solo</Eyebrow>
-              <h1 style={{ margin: "12px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.98 }}>
-                Guess the opening. <span style={{ color: SOLO.accent }}>Alone.</span>
-              </h1>
-              <p style={{ margin: "12px 0 0", color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55 }}>
-                One run, three lives, a streak that keeps regenerating them. Daily leaderboard resets at midnight UTC.
-              </p>
-            </div>
-            {stats && stats.runs_played > 0 && (
-              <div style={{ display: "flex", gap: 24, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.06em" }}>
-                <div>
-                  <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>{stats.runs_played} runs</div>
-                  all time
-                </div>
-                {stats.todays_rank > 0 && (
-                  <div>
-                    <div style={{ color: SOLO.fg, fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, marginBottom: 3 }}>#{stats.todays_rank}</div>
-                    today
-                  </div>
-                )}
-              </div>
-            )}
-          </header>
-
-          {!apiOnline && (
-            <div style={{ marginTop: 24, padding: 16, borderRadius: 8, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, color: SOLO.fg2 }}>
-              The play backend is unreachable. The leaderboard below is empty until the API comes back.
-            </div>
-          )}
-
-          {/* Endless — sole mode, full width */}
-          <section style={{
-            background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
-            border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
-            position: "relative", overflow: "hidden", minHeight: 280, marginTop: 32,
-            display: "flex", flexDirection: "column",
-          }}>
-            <div style={{
-              position: "absolute", top: -60, right: -60, width: 420, height: 420, borderRadius: "50%",
-              background: `radial-gradient(circle, ${SOLO.accent}22 0%, transparent 70%)`,
-            }} />
-            <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>Endless · live</Eyebrow>
-            <h2 style={{ margin: "14px 0 10px", fontWeight: 800, fontSize: 48, letterSpacing: "-0.04em", lineHeight: 1, maxWidth: 640 }}>
-              How far can you go before you slip?
-            </h2>
-            <p style={{ margin: 0, color: SOLO.fg2, fontSize: 15, maxWidth: 520, lineHeight: 1.55 }}>
-              Three lives. Earn one back every five in a row. Difficulty climbs as you do. Run ends when you&apos;re out.
+        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "64px 40px 60px" }}>
+          <div style={{ paddingBottom: 36, borderBottom: `1px solid ${SOLO.line}` }}>
+            <Eyebrow>Play</Eyebrow>
+            <h1 style={{ margin: "14px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 64, letterSpacing: "-0.045em", lineHeight: 0.96 }}>
+              Pick your <span style={{ color: SOLO.accent }}>mode.</span>
+            </h1>
+            <p style={{ margin: "14px 0 0", color: SOLO.fg2, fontSize: 15, maxWidth: 620, lineHeight: 1.55 }}>
+              Two ways to play. <strong style={{ color: SOLO.fg, fontWeight: 500 }}>Endless</strong> is a private solo run ranked on a daily leaderboard.
+              {" "}<strong style={{ color: SOLO.fg, fontWeight: 500 }}>1v1</strong> is a real-time race against a friend.
             </p>
-            <div style={{ flex: 1, minHeight: 32 }} />
-            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8 }}>
-              {user ? (
-                <Link href="/play/run" style={{
-                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
-                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
-                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
-                  textDecoration: "none",
-                  boxShadow: `0 0 30px ${SOLO.accent}55`,
-                }}>
-                  Start run
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
-                    <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                  </svg>
-                </Link>
-              ) : (
-                <Link href={`/login?next=${encodeURIComponent("/play")}`} style={{
-                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
-                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
-                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
-                  textDecoration: "none",
-                  boxShadow: `0 0 30px ${SOLO.accent}55`,
-                }}>
-                  Log in to play
-                </Link>
-              )}
-              <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, lineHeight: 1.4 }}>
-                ~ 8 min<br />top-1000 pool
-              </div>
-            </div>
-          </section>
+          </div>
 
-          {/* PvP card */}
-          <section style={{
-            background: `linear-gradient(135deg, #1a1530 0%, #221831 60%, #2a1d3c 100%)`,
-            border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
-            position: "relative", overflow: "hidden", minHeight: 240, marginTop: 20,
-            display: "flex", flexDirection: "column",
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20, marginTop: 32 }}>
+            <ModeCard
+              href={endlessHref}
+              eyebrow="Endless · solo"
+              title="Run it"
+              accentWord="alone."
+              desc="Three lives that regenerate every five in a row. Difficulty climbs with your streak. Daily leaderboard resets at midnight UTC."
+              cta="Open Endless"
+              meta={<>~ 8 min per run<br />daily ranked</>}
+            />
+            <ModeCard
+              href={pvpHref}
+              eyebrow="1v1 · race"
+              title="Challenge a"
+              accentWord="friend."
+              desc="Both players, same clip, simultaneous. First to ten correct wins. Configure format and pool in the next step."
+              cta="Open 1v1"
+              meta={<>casual lobby<br />invite by link</>}
+            />
+          </div>
+
+          {/* Tournaments teaser — phase-3 placeholder, no leaderboard. */}
+          <div style={{
+            marginTop: 22, padding: "18px 24px",
+            background: SOLO.bg2, border: `1px dashed ${SOLO.line2}`, borderRadius: 10,
+            display: "flex", alignItems: "center", justifyContent: "space-between", gap: 20,
           }}>
-            <div style={{
-              position: "absolute", top: -80, right: -80, width: 380, height: 380, borderRadius: "50%",
-              background: `radial-gradient(circle, ${SOLO.accent}33 0%, transparent 70%)`, pointerEvents: "none",
-            }} />
-            <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>1v1 · race</Eyebrow>
-            <h2 style={{ margin: "14px 0 10px", fontWeight: 800, fontSize: 38, letterSpacing: "-0.035em", lineHeight: 1, maxWidth: 480 }}>
-              Challenge a <span style={{ color: SOLO.accent }}>friend.</span>
-            </h2>
-            <p style={{ margin: 0, color: SOLO.fg2, fontSize: 14, maxWidth: 480, lineHeight: 1.55 }}>
-              Two players, same clip, simultaneous. First to ten correct wins the match.
-            </p>
-            <div style={{ display: "flex", gap: 18, flexWrap: "wrap", marginTop: 20, fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em" }}>
-              <span><span style={{ color: SOLO.fg }}>FT10</span> · first to ten</span>
-              <span><span style={{ color: SOLO.fg }}>Audio</span> · song only</span>
-              <span><span style={{ color: SOLO.fg }}>Top 1000</span> · clip pool</span>
-            </div>
-            <div style={{ flex: 1, minHeight: 24 }} />
-            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8 }}>
-              {user ? (
-                <Link href="/play/pvp/new" style={{
-                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
-                  padding: "14px 26px", fontWeight: 600, fontSize: 15, letterSpacing: "-0.01em",
-                  cursor: "pointer", display: "inline-flex", alignItems: "center", gap: 10,
-                  textDecoration: "none", boxShadow: `0 0 30px ${SOLO.accent}55`,
-                }}>
-                  + Create battle
-                </Link>
-              ) : (
-                <Link href={`/login?next=${encodeURIComponent("/play/pvp/new")}`} style={{
-                  background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
-                  padding: "14px 26px", fontWeight: 600, fontSize: 15, textDecoration: "none",
-                  boxShadow: `0 0 30px ${SOLO.accent}55`,
-                }}>
-                  Log in to play
-                </Link>
-              )}
-              <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, lineHeight: 1.4 }}>
-                Invite by link<br />once the lobby is open
+            <div style={{ display: "flex", alignItems: "center", gap: 16 }}>
+              <div style={{
+                fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.16em",
+                textTransform: "uppercase", color: SOLO.fg4,
+                border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4,
+              }}>Soon</div>
+              <div style={{ fontFamily: SOLO.sans, fontSize: 14, color: SOLO.fg2, lineHeight: 1.45 }}>
+                <strong style={{ color: SOLO.fg, fontWeight: 600 }}>Tournaments</strong> — bracketed multi-round 1v1, Elo, seasons.
               </div>
             </div>
-          </section>
-
-          <section style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
-            {stats && (
-              <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
-                <Eyebrow>Your endless · all-time</Eyebrow>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "24px 36px", marginTop: 18 }}>
-                  {[
-                    [String(stats.best_score), "best run"],
-                    [String(stats.longest_streak), "longest streak"],
-                    [formatResponseMs(stats.avg_response_ms), "avg response"],
-                    [String(stats.runs_played), "runs played"],
-                  ].map(([v, l]) => (
-                    <div key={l}>
-                      <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 32, letterSpacing: "-0.03em", color: SOLO.fg, lineHeight: 1 }}>{v}</div>
-                      <div style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.14em", textTransform: "uppercase", color: SOLO.fg3, marginTop: 6 }}>{l}</div>
-                    </div>
-                  ))}
-                </div>
-                <div style={{ marginTop: 22, paddingTop: 18, borderTop: `1px dashed ${SOLO.line}`, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                  <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
-                    Today&apos;s best · <span style={{ color: SOLO.accent }}>{stats.todays_best}</span>
-                  </div>
-                  {stats.todays_rank > 0 && (
-                    <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3 }}>
-                      You&apos;re <span style={{ color: SOLO.fg }}>#{stats.todays_rank}</span> today
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
-
-            <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 14 }}>
-                <Eyebrow>Daily leaderboard</Eyebrow>
-                <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.08em" }}>
-                  resets in {formatResetCountdown(leaderboard.resets_in_sec)}
-                </div>
-              </div>
-              {leaderboard.entries.length === 0 && (
-                <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, padding: 12 }}>
-                  No runs today yet. Be the first.
-                </div>
-              )}
-              {leaderboard.entries.slice(0, 10).map((e) => {
-                const you = e.user_id === user?.id;
-                return (
-                  <LeaderboardRow key={e.run_id} rank={e.rank} name={e.display_name} score={e.score} you={you} />
-                );
-              })}
-              {leaderboard.you && !leaderboard.entries.some((e) => e.user_id === user?.id) && (
-                <>
-                  <div style={{
-                    display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
-                    padding: "8px 12px", marginBottom: 2, fontFamily: SOLO.mono, fontSize: 13, color: SOLO.fg4,
-                  }}>
-                    <div>…</div><div /><div />
-                  </div>
-                  <LeaderboardRow rank={leaderboard.you.rank} name="you" score={leaderboard.you.score} you />
-                </>
-              )}
+            <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em" }}>
+              Phase 3 ↗
             </div>
-          </section>
+          </div>
         </div>
       </div>
     </Layout>
   );
 }
 
-function LeaderboardRow({ rank, name, score, you }: { rank: number | string; name: string; score: number; you?: boolean }) {
+interface ModeCardProps {
+  href: string;
+  eyebrow: string;
+  title: string;
+  accentWord: string;
+  desc: string;
+  cta: string;
+  meta: ReactNode;
+}
+
+// One mode card. Whole card is the link target — the visible button
+// is a secondary visual cue; clicking anywhere on the card routes.
+function ModeCard({ href, eyebrow, title, accentWord, desc, cta, meta }: ModeCardProps) {
   return (
-    <div style={{
-      display: "grid", gridTemplateColumns: "34px 1fr auto", gap: 14, alignItems: "center",
-      padding: "8px 12px", borderRadius: 6,
-      background: you ? `${SOLO.accent}14` : "transparent",
-      border: you ? `1px solid ${SOLO.accent}44` : "1px solid transparent",
-      marginBottom: 2,
+    <Link href={href} style={{
+      textDecoration: "none", color: "inherit",
+      background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
+      border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 32,
+      position: "relative", overflow: "hidden",
+      display: "flex", flexDirection: "column", minHeight: 340,
+      cursor: "pointer",
     }}>
-      <div style={{ fontFamily: SOLO.mono, fontSize: 13, color: you ? SOLO.accent : SOLO.fg3, fontWeight: you ? 600 : 400 }}>{rank}</div>
-      <div style={{ fontFamily: SOLO.sans, fontSize: 13, color: you ? SOLO.fg : SOLO.fg2, fontWeight: you ? 600 : 400 }}>
-        {name}{you ? " (you)" : ""}
+      <div style={{
+        position: "absolute", top: -80, right: -80, width: 360, height: 360, borderRadius: "50%",
+        background: `radial-gradient(circle, ${SOLO.accent}22 0%, transparent 70%)`,
+        pointerEvents: "none",
+      }} />
+      <Eyebrow color={SOLO.fg3} dotColor={SOLO.accent}>{eyebrow}</Eyebrow>
+      <h2 style={{
+        margin: "14px 0 12px", fontFamily: SOLO.sans, fontWeight: 800,
+        fontSize: 40, letterSpacing: "-0.035em", lineHeight: 1, maxWidth: 360,
+      }}>
+        {title} <span style={{ color: SOLO.accent }}>{accentWord}</span>
+      </h2>
+      <p style={{ margin: 0, color: SOLO.fg2, fontSize: 14, lineHeight: 1.55, maxWidth: 380 }}>
+        {desc}
+      </p>
+      <div style={{ flex: 1, minHeight: 28 }} />
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginTop: 18 }}>
+        <span style={{
+          background: SOLO.accent, color: SOLO.bg,
+          border: "none", borderRadius: 8, padding: "12px 22px",
+          fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, letterSpacing: "-0.01em",
+          display: "inline-flex", alignItems: "center", gap: 10,
+          boxShadow: `0 0 24px ${SOLO.accent}44`,
+        }}>
+          {cta}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
+            <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em", textAlign: "right", lineHeight: 1.4 }}>
+          {meta}
+        </div>
       </div>
-      <div style={{ fontFamily: SOLO.mono, fontSize: 14, color: you ? SOLO.accent : SOLO.fg, fontWeight: 500 }}>{score}</div>
-    </div>
+    </Link>
   );
 }

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -300,7 +300,7 @@ function ModeRevealScreen({ mode, countdownMs, run, round }: { mode: string; cou
 
 function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; run: SoloRun; playedMs: number; onSubmit: (animeId: string | null) => void }) {
   const [query, setQuery] = useState("");
-  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null }>>([]);
+  const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null; cover: string | null }>>([]);
   const [activeIdx, setActiveIdx] = useState(0);
   const queryRef = useRef(query);
   queryRef.current = query;
@@ -319,6 +319,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
           id: a.id,
           title: a.name || a.title_romaji,
           year: a.year ?? null,
+          cover: a.cover_image_url ?? null,
         }));
         setSuggestions(items);
         setActiveIdx(0);
@@ -395,10 +396,17 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
                 }}
               >
                 <div style={{
-                  width: 38, height: 52, background: SOLO.bg2, borderRadius: 4,
+                  width: 38, height: 52, borderRadius: 4,
                   border: `1px solid ${SOLO.line}`, flexShrink: 0,
-                  backgroundImage: `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 6px, ${SOLO.bg2} 6px 7px)`,
-                }} />
+                  overflow: "hidden",
+                  background: s.cover ? "transparent" : SOLO.bg2,
+                  backgroundImage: s.cover ? "none" : `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 6px, ${SOLO.bg2} 6px 7px)`,
+                }}>
+                  {s.cover && (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={s.cover} alt="" loading="lazy" style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }} />
+                  )}
+                </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, color: SOLO.fg, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.title}</div>
                   <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginTop: 2 }}>

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -222,7 +222,7 @@ function ErrorScreen({ message }: { message: string }) {
     <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 16 }}>
       <Eyebrow color={SOLO.danger} dotColor={SOLO.danger}>Something went wrong</Eyebrow>
       <div style={{ color: SOLO.fg, fontSize: 18 }}>{message}</div>
-      <Link href="/play" style={{ color: SOLO.accent, fontFamily: SOLO.mono, fontSize: 13, textDecoration: "none" }}>back to hub →</Link>
+      <Link href="/play/endless" style={{ color: SOLO.accent, fontFamily: SOLO.mono, fontSize: 13, textDecoration: "none" }}>back to hub →</Link>
     </div>
   );
 }
@@ -545,7 +545,7 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
                 <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
             </Link>
-            <Link href="/play" style={{
+            <Link href="/play/endless" style={{
               background: "transparent", border: `1px solid ${SOLO.line2}`, color: SOLO.fg2,
               borderRadius: 8, padding: "14px 22px", fontWeight: 500, fontSize: 14, textDecoration: "none",
             }}>Back to hub</Link>


### PR DESCRIPTION
New Play tab design from \`Solo Mode-2.html\`: \`/play\` is a mode chooser; the Endless solo hub gets its own page at \`/play/endless\`.

## Routes
- **\`/play\`** — Mode chooser. Two equal cards (Endless · solo and 1v1 · race) plus a "Soon · phase 3" Tournaments teaser. Each card is the link target — clicking anywhere routes.
- **\`/play/endless\`** — Everything that used to live at \`/play\`: breadcrumb back to Play, header with \`runs\` / \`#rank today\`, big "How far can you go before you slip?" CTA, your records grid, daily leaderboard.
- **\`/play/pvp/new\`** — Unchanged. Reached from the 1v1 card.

## Other touches
- Endless hub h1 now reads "Guess the anime" since scoring is anime-based ([backend#47](https://github.com/openingwiki/backend/pull/47)).
- Solo run page's contextual "back to hub" links re-target \`/play/endless\` (the brand-link in the floating topbar still points to \`/play\` — that's global nav, not contextual).
- Anonymous viewers see the chooser; per-mode entry points gate behind \`/login?next=…\` as before.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] \`/play\` shows two cards + Tournaments teaser; clicking Endless lands on \`/play/endless\`
- [ ] Anon → click Endless → /login?next=/play/endless
- [ ] Run completion → "Back to hub" returns to /play/endless