### PR TITLE
feat(mobile): adapt catalog + play surfaces for phones

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -5,6 +5,7 @@ import Topbar from "./Topbar";
 import Rolebar from "./Rolebar";
 import Footer from "./Footer";
 import EmailVerificationBanner from "./EmailVerificationBanner";
+import MobileNav from "./MobileNav";
 
 interface Props {
   children: ReactNode;
@@ -26,14 +27,15 @@ export default function Layout({
       <Head>
         <title>{title}</title>
         <meta name="description" content={description} />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </Head>
       <Topbar user={user} />
       <EmailVerificationBanner user={user} />
       <Rolebar user={user} modQueueCount={modQueueCount} />
-      {children}
+      <div className="page-body">{children}</div>
       <Footer />
+      <MobileNav user={user} modQueueCount={modQueueCount} />
     </>
   );
 }

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -1,0 +1,234 @@
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import type { User } from "@/lib/types";
+
+interface Props {
+  user: User | null;
+  modQueueCount?: number;
+}
+
+const HOME_ICON = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 11l9-8 9 8" /><path d="M5 10v10h14V10" />
+  </svg>
+);
+const PLAY_ICON = (
+  <svg viewBox="0 0 24 24" fill="currentColor" stroke="none">
+    <path d="M8 5v14l11-7z" />
+  </svg>
+);
+const SUBS_ICON = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z" /><path d="M14 3v6h6" />
+    <path d="M9 14h6" /><path d="M9 17h4" />
+  </svg>
+);
+const GROUPS_ICON = (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <circle cx="9" cy="9" r="3.5" /><path d="M2 20c0-3.3 3.1-6 7-6s7 2.7 7 6" />
+    <circle cx="17" cy="8" r="2.5" /><path d="M16 14c3 0 6 2 6 5" />
+  </svg>
+);
+const STAR_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 16.8 5.8 21.3l2.4-7.4L2 9.4h7.6z" />
+  </svg>
+);
+const PLUS_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 5v14M5 12h14" />
+  </svg>
+);
+const SHIELD_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6z" />
+  </svg>
+);
+const LOGOUT_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><path d="m16 17 5-5-5-5" /><path d="M21 12H9" />
+  </svg>
+);
+const LOGIN_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" /><path d="m10 17 5-5-5-5" /><path d="M15 12H3" />
+  </svg>
+);
+const CLOSE_ICON = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <path d="M6 6l12 12M18 6L6 18" />
+  </svg>
+);
+
+interface Tab {
+  key: string;
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+  match: (p: string) => boolean;
+}
+
+const TABS: Tab[] = [
+  { key: "home",   href: "/",        label: "Home",        icon: HOME_ICON,   match: (p) => p === "/" },
+  { key: "play",   href: "/play",    label: "Play",        icon: PLAY_ICON,   match: (p) => p.startsWith("/play") },
+  { key: "subs",   href: "/my-submissions", label: "Submissions", icon: SUBS_ICON,   match: (p) => p.startsWith("/my-submissions") },
+  { key: "groups", href: "/groups",  label: "Groups",      icon: GROUPS_ICON, match: (p) => p.startsWith("/groups") || p.startsWith("/g/") },
+];
+
+// MobileNav renders the bottom tab bar plus a slide-in drawer triggered
+// from the Topbar hamburger. It's hidden via CSS on viewports > 720px;
+// the desktop Topbar nav takes over there.
+export default function MobileNav({ user, modQueueCount = 0 }: Props) {
+  const { pathname } = useRouter();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // Sync drawer state with a global event so Topbar's hamburger can toggle
+  // it without prop-drilling.
+  useEffect(() => {
+    const onOpen = () => setDrawerOpen(true);
+    const onClose = () => setDrawerOpen(false);
+    window.addEventListener("mobile-drawer-open", onOpen);
+    window.addEventListener("mobile-drawer-close", onClose);
+    return () => {
+      window.removeEventListener("mobile-drawer-open", onOpen);
+      window.removeEventListener("mobile-drawer-close", onClose);
+    };
+  }, []);
+
+  // Close the drawer whenever the route changes so it doesn't stay open
+  // while the user is reading the new page.
+  useEffect(() => {
+    setDrawerOpen(false);
+  }, [pathname]);
+
+  const close = () => setDrawerOpen(false);
+  const isMod = user?.role === "moderator" || user?.role === "admin";
+  const initials = user ? user.display_name.slice(0, 2).toUpperCase() : "";
+
+  return (
+    <>
+      {/* Bottom tab bar */}
+      <nav className="mtabbar" aria-label="Primary">
+        {TABS.map((t) => {
+          const on = t.match(pathname);
+          return (
+            <Link key={t.key} href={t.href} className={`mtab${on ? " on" : ""}`}>
+              <span className="mtab-ico">{t.icon}</span>
+              <span className="mtab-l">{t.label}</span>
+            </Link>
+          );
+        })}
+      </nav>
+
+      {/* Drawer + scrim */}
+      <div
+        className={`mscrim${drawerOpen ? " on" : ""}`}
+        onClick={close}
+        aria-hidden={!drawerOpen}
+      />
+      <aside className={`mdrawer${drawerOpen ? " on" : ""}`} aria-hidden={!drawerOpen}>
+        <div className="mdrawer-head">
+          {user ? (
+            <div className="mdrawer-me">
+              <div className="mdrawer-avatar" aria-hidden>
+                {user.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={user.avatar_url} alt="" />
+                ) : (
+                  initials
+                )}
+              </div>
+              <div className="mdrawer-me-text">
+                <div className="mdrawer-me-name">
+                  {user.display_name}
+                  {isMod && <span className={`pill${user.role === "admin" ? " admin" : ""}`}>{user.role}</span>}
+                </div>
+                <div className="mdrawer-me-sub">@{user.display_name.toLowerCase()}</div>
+              </div>
+            </div>
+          ) : (
+            <div className="mdrawer-me">
+              <div className="mdrawer-me-text">
+                <div className="mdrawer-me-name">Welcome</div>
+                <div className="mdrawer-me-sub">Sign in to play and rate</div>
+              </div>
+            </div>
+          )}
+          <button className="mdrawer-x" onClick={close} aria-label="Close menu">
+            {CLOSE_ICON}
+          </button>
+        </div>
+
+        <nav className="mdrawer-nav">
+          <div className="mdrawer-section">Browse</div>
+          <Link href="/" className={pathname === "/" ? "cur" : undefined}>
+            <span className="mdrawer-ico">{HOME_ICON}</span>
+            Home
+          </Link>
+          <Link href="/groups" className={pathname.startsWith("/groups") ? "cur" : undefined}>
+            <span className="mdrawer-ico">{GROUPS_ICON}</span>
+            Groups
+          </Link>
+          <Link href="/play" className={pathname.startsWith("/play") ? "cur" : undefined}>
+            <span className="mdrawer-ico">{PLAY_ICON}</span>
+            Play
+          </Link>
+
+          {user && (
+            <>
+              <div className="mdrawer-section">You</div>
+              <Link href="/my-submissions">
+                <span className="mdrawer-ico">{SUBS_ICON}</span>
+                My submissions
+              </Link>
+              <Link href="/me">
+                <span className="mdrawer-ico">{STAR_ICON}</span>
+                My ratings
+              </Link>
+              <Link href="/submit">
+                <span className="mdrawer-ico">{PLUS_ICON}</span>
+                Submit an entry
+              </Link>
+            </>
+          )}
+
+          {isMod && (
+            <>
+              <div className="mdrawer-section">Moderation</div>
+              <Link href="/mod/queue">
+                <span className="mdrawer-ico">{SHIELD_ICON}</span>
+                Moderation queue
+                {modQueueCount > 0 && <span className="mdrawer-badge">{modQueueCount}</span>}
+              </Link>
+            </>
+          )}
+
+          <div className="mdrawer-section">Account</div>
+          {user ? (
+            <Link href="/api/v1/auth/logout">
+              <span className="mdrawer-ico">{LOGOUT_ICON}</span>
+              Log out
+            </Link>
+          ) : (
+            <>
+              <Link href="/login">
+                <span className="mdrawer-ico">{LOGIN_ICON}</span>
+                Log in
+              </Link>
+              <Link href="/signup">
+                <span className="mdrawer-ico">{PLUS_ICON}</span>
+                Sign up
+              </Link>
+            </>
+          )}
+        </nav>
+
+        <div className="mdrawer-foot">
+          <span>Opening Wiki · v0.2</span>
+          <Link href="/about">About</Link>
+        </div>
+      </aside>
+    </>
+  );
+}

--- a/components/Topbar.tsx
+++ b/components/Topbar.tsx
@@ -20,12 +20,24 @@ const ME_SUBMISSIONS_ITEM: NavItem = {
   match: (p: string) => p.startsWith("/my-submissions"),
 };
 
+const MENU_ICON = (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <path d="M4 7h16" /><path d="M4 12h16" /><path d="M4 17h10" />
+  </svg>
+);
+
 export default function Topbar({ user }: Props) {
   const { pathname } = useRouter();
   // Slot "My submissions" between Play and Groups for authenticated
   // users so it sits next to the other gameplay-adjacent entries
   // rather than buried inside the avatar menu.
   const nav = user ? [...BASE_NAV.slice(0, 2), ME_SUBMISSIONS_ITEM, ...BASE_NAV.slice(2)] : BASE_NAV;
+
+  const openDrawer = () => {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event("mobile-drawer-open"));
+    }
+  };
 
   return (
     <header className="topbar">
@@ -70,6 +82,17 @@ export default function Topbar({ user }: Props) {
             </>
           )}
         </div>
+
+        {/* Mobile-only hamburger — opens the MobileNav drawer. Hidden via CSS
+            on viewports > 720px where the standard nav links + avatar suffice. */}
+        <button
+          type="button"
+          className="topbar-menu"
+          aria-label="Open menu"
+          onClick={openDrawer}
+        >
+          {MENU_ICON}
+        </button>
       </div>
     </header>
   );

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -320,7 +320,7 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
     <Layout user={user} modQueueCount={modQueueCount} title={`Battle ${view.match.room_code}`}>
       <Head><meta name="description" content="PvP battle." /></Head>
       <audio ref={audioRef} preload="auto" />
-      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+      <div data-mobile-pvp-lobby data-mobile-game style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
         {phase.kind === "lobby" && (
           <LobbyView
             view={view}
@@ -400,13 +400,13 @@ function LobbyView({
     try { await navigator.clipboard.writeText(inviteUrl); } catch { /* */ }
   };
   return (
-    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "32px 40px 48px" }}>
+    <div className="lobby-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "32px 40px 48px" }}>
       <nav style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, marginBottom: 14, display: "flex", gap: 6 }}>
         <Link href="/play" style={{ color: SOLO.fg2, textDecoration: "none" }}>Play</Link>
         <span style={{ color: SOLO.fg4 }}>/</span>
         <span style={{ color: SOLO.fg2 }}>Lobby</span>
       </nav>
-      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 32, paddingBottom: 24, borderBottom: `1px solid ${SOLO.line}` }}>
+      <div className="lobby-head" style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 32, paddingBottom: 24, borderBottom: `1px solid ${SOLO.line}` }}>
         <div>
           <Eyebrow color={filled ? SOLO.ok : SOLO.fg3} dotColor={filled ? SOLO.ok : SOLO.accent}>
             {filled ? "Lobby · 2 / 2" : "Lobby · open"}
@@ -429,17 +429,17 @@ function LobbyView({
       </div>
 
       {/* VS panel */}
-      <div style={{ marginTop: 32, display: "grid", gridTemplateColumns: "1fr 80px 1fr", gap: 0, alignItems: "stretch" }}>
+      <div className="vs-panel" style={{ marginTop: 32, display: "grid", gridTemplateColumns: "1fr 80px 1fr", gap: 0, alignItems: "stretch" }}>
         <PlayerCard
           player={view.players.find((p) => p.user_id !== opponent?.user_id) ?? view.players[0]}
           variant={isHost ? "you" : "opponent"}
           label={isHost ? "You · host" : "Host"}
           ready={view.players.find((p) => p.seat === 1)?.ready ?? false}
         />
-        <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", fontFamily: SOLO.mono, fontWeight: 600, fontSize: 20, color: SOLO.fg3, letterSpacing: "0.14em", gap: 14 }}>
-          <div style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
+        <div className="vs-divider" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", fontFamily: SOLO.mono, fontWeight: 600, fontSize: 20, color: SOLO.fg3, letterSpacing: "0.14em", gap: 14 }}>
+          <div className="vs-line" style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
           <div style={{ padding: "8px 0" }}>VS</div>
-          <div style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
+          <div className="vs-line" style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
         </div>
         {opponent ? (
           <PlayerCard
@@ -481,7 +481,7 @@ function LobbyView({
       )}
 
       {filled && (
-        <div style={{
+        <div className="lobby-cta" style={{
           marginTop: 28, background: `linear-gradient(90deg, rgba(125,211,143,.06) 0%, rgba(167,139,250,.06) 100%)`,
           border: `1px solid rgba(125,211,143,.4)`, borderRadius: 12, padding: "22px 28px",
           display: "flex", alignItems: "center", justifyContent: "space-between", gap: 20,
@@ -497,7 +497,7 @@ function LobbyView({
               First to {view.match.target_score} · audio · top 1,000 pool
             </div>
           </div>
-          <div style={{ display: "flex", gap: 10 }}>
+          <div className="lobby-cta-actions" style={{ display: "flex", gap: 10 }}>
             <button onClick={onLeave} style={lobbyBtn(SOLO.fg2, "transparent")}>Leave</button>
             <button onClick={onReady} style={lobbyBtn(meReady ? SOLO.fg : SOLO.bg, meReady ? SOLO.bg3 : SOLO.accent, !meReady)}>
               {meReady ? "Unready" : "✓ Ready"}
@@ -620,23 +620,23 @@ function MatchHud({ view, scoreOverride }: { view: PvPMatchView; scoreOverride?:
   const hostScore = scoreOverride?.[host?.user_id ?? ""] ?? 0;
   const oppScore = scoreOverride?.[opp?.user_id ?? ""] ?? 0;
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 24, padding: "16px 28px", background: "rgba(12,10,20,.92)", borderBottom: `1px solid ${SOLO.line}` }}>
+    <div className="pvp-hud" style={{ display: "flex", alignItems: "center", gap: 24, padding: "16px 28px", background: "rgba(12,10,20,.92)", borderBottom: `1px solid ${SOLO.line}` }}>
       <div style={{ display: "flex", alignItems: "center", gap: 14, flex: 1 }}>
         <div style={{ width: 42, height: 42, borderRadius: "50%", background: SOLO.bg3, border: `2px solid ${SOLO.accent}`, color: SOLO.accent, display: "grid", placeItems: "center", fontWeight: 700, fontSize: 16 }}>
           {(host?.display_name?.[0] ?? "?").toUpperCase()}
         </div>
-        <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg }}>{host?.display_name ?? "—"}</div>
+        <div className="pvp-hud-name" style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg }}>{host?.display_name ?? "—"}</div>
       </div>
       <div style={{ width: 1, height: 36, background: SOLO.line2 }} />
       <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 34, color: SOLO.accent, letterSpacing: "-0.04em" }}>{hostScore}</div>
-      <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, padding: "0 24px" }}>
+      <div className="pvp-hud-mid" style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6, padding: "0 24px" }}>
         <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg3, letterSpacing: "0.14em", textTransform: "uppercase" }}>Race</div>
         <div style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg2, letterSpacing: "0.06em" }}>first to <span style={{ color: SOLO.fg }}>{view.match.target_score}</span></div>
       </div>
       <div style={{ fontFamily: SOLO.mono, fontWeight: 500, fontSize: 34, color: SOLO.line2, letterSpacing: "-0.04em" }}>{oppScore}</div>
       <div style={{ width: 1, height: 36, background: SOLO.line2 }} />
       <div style={{ display: "flex", alignItems: "center", gap: 14, flex: 1, justifyContent: "flex-end" }}>
-        <div style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, textAlign: "right" }}>{opp?.display_name ?? "—"}</div>
+        <div className="pvp-hud-name" style={{ fontWeight: 600, fontSize: 14, color: SOLO.fg, textAlign: "right" }}>{opp?.display_name ?? "—"}</div>
         <div style={{ width: 42, height: 42, borderRadius: "50%", background: SOLO.bg3, border: `2px solid #6aa9ff`, color: "#6aa9ff", display: "grid", placeItems: "center", fontWeight: 700, fontSize: 16 }}>
           {(opp?.display_name?.[0] ?? "?").toUpperCase()}
         </div>
@@ -698,15 +698,15 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
     <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column" }}>
       <MatchHud view={view} scoreOverride={score} />
       <TimerBar pct={pct} danger={secsLeft < 5} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "40px 0 30px", position: "relative" }}>
-        <div style={{
+      <div className="game-stage" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "40px 0 30px", position: "relative" }}>
+        <div className="game-clip-time" style={{
           position: "absolute", top: 20, right: 40,
           fontFamily: SOLO.mono, fontSize: 56, fontWeight: 500,
           letterSpacing: "-0.04em", color: secsLeft < 5 ? SOLO.danger : SOLO.fg, lineHeight: 1,
         }}>
-          {secsLeft.toFixed(1)}<span style={{ color: SOLO.fg4, fontSize: 32 }}>s</span>
+          {secsLeft.toFixed(1)}<s style={{ color: SOLO.fg4, fontSize: 32 }}>s</s>
         </div>
-        <div style={{
+        <div className="game-clip-label" style={{
           position: "absolute", top: 28, left: 40,
           fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3,
           letterSpacing: "0.14em", textTransform: "uppercase",
@@ -718,9 +718,9 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
           Name the anime. ↵ to submit.
         </div>
       </div>
-      <div style={{ padding: "0 40px 32px", position: "relative" }}>
+      <div className="game-input" style={{ padding: "0 40px 32px", position: "relative" }}>
         {suggestions.length > 0 && (
-          <div style={{
+          <div className="game-suggs" style={{
             position: "absolute", bottom: "100%", left: 40, right: 40,
             background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 10,
             marginBottom: 8, overflow: "hidden",
@@ -849,7 +849,7 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
         <div style={{ position: "absolute", top: 30, left: 40 }}>
           <Eyebrow color={accent} dotColor={accent}>{eyebrow}</Eyebrow>
         </div>
-        <div style={{
+        <div className="reveal-card" style={{
           display: "grid", gridTemplateColumns: "auto 1fr", gap: 40, maxWidth: 880,
           background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 14,
           padding: 36, position: "relative", overflow: "hidden",
@@ -859,7 +859,7 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
             border: `1px solid ${accent}55`,
             boxShadow: `0 0 40px ${accent}33, inset 0 0 60px ${accent}0a`,
           }} />
-          <div style={{
+          <div className="reveal-cover" style={{
             width: 200, height: 280, borderRadius: 8,
             background: SOLO.bg3, border: `1px solid ${SOLO.line2}`,
             backgroundImage: coverURL ? "none" : `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 14px, #221c33 14px 15px)`,
@@ -875,7 +875,7 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
             <div style={{ fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", color: accent, marginBottom: 10 }}>
               {subLead}
             </div>
-            <h2 style={{ margin: 0, fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.95, color: SOLO.fg }}>
+            <h2 className="reveal-headline" style={{ margin: 0, fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.95, color: SOLO.fg }}>
               {op.anime_name || "—"}
             </h2>
             <div style={{ fontFamily: SOLO.sans, fontSize: 17, color: SOLO.fg2, marginTop: 8 }}>
@@ -887,7 +887,7 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
             {/* Per-player verdict cells — the "if you fail, show the
                 other one is guessed" requirement is satisfied by the
                 opp cell turning green with their response time. */}
-            <div style={{ display: "flex", gap: 36, marginTop: 24, paddingTop: 22, borderTop: `1px dashed ${SOLO.line2}` }}>
+            <div className="reveal-stats" style={{ display: "flex", gap: 36, marginTop: 24, paddingTop: 22, borderTop: `1px dashed ${SOLO.line2}` }}>
               <PlayerCell label="you" me name={me?.display_name ?? "you"} resp={myResp} />
               <PlayerCell label="opp" name={oppName} resp={oppResp} />
               {op.avg_rating ? (
@@ -952,8 +952,8 @@ function MatchEndView({ result, view, meID, roundResults }: { result: MatchEndDa
   // include a rounds list yet.
   const rounds = roundResults;
   return (
-    <div style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
-      <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 28, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+    <div className="game-end-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
+      <div className="game-end-head" style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 28, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
         <div>
           <Eyebrow color={youWon ? SOLO.ok : SOLO.danger} dotColor={youWon ? SOLO.ok : SOLO.danger}>
             {youWon ? "Match · won" : "Match · lost"}{result.by_forfeit ? " · forfeit" : ""}
@@ -1039,7 +1039,7 @@ function MatchEndView({ result, view, meID, roundResults }: { result: MatchEndDa
       </div>
       )}
 
-      <div style={{ marginTop: 32, paddingTop: 18, borderTop: `1px solid ${SOLO.line}`, display: "flex", justifyContent: "flex-end", gap: 10 }}>
+      <div className="game-end-actions" style={{ marginTop: 32, paddingTop: 18, borderTop: `1px solid ${SOLO.line}`, display: "flex", justifyContent: "flex-end", gap: 10 }}>
         <Link href="/play" style={{ ...lobbyBtn(SOLO.bg, SOLO.accent, true), textDecoration: "none" }}>Back to play</Link>
       </div>
     </div>

--- a/pages/play/endless.tsx
+++ b/pages/play/endless.tsx
@@ -50,8 +50,8 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 export default function EndlessHub({ user, modQueueCount, stats, leaderboard, apiOnline }: Props) {
   return (
     <Layout user={user} modQueueCount={modQueueCount} title="Endless · solo — Opening Wiki">
-      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
-        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 40px 60px" }}>
+      <div data-mobile-endless-hub style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div className="solo-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "40px 40px 60px" }}>
 
           {/* Breadcrumb back to Play hub */}
           <div style={{
@@ -63,7 +63,7 @@ export default function EndlessHub({ user, modQueueCount, stats, leaderboard, ap
             <span>Endless</span>
           </div>
 
-          <header style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 32, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+          <header className="endless-head" style={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 32, paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
             <div>
               <Eyebrow color={SOLO.accent} dotColor={SOLO.accent}>Endless · solo</Eyebrow>
               <h1 style={{ margin: "12px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 56, letterSpacing: "-0.04em", lineHeight: 0.98 }}>
@@ -96,7 +96,7 @@ export default function EndlessHub({ user, modQueueCount, stats, leaderboard, ap
           )}
 
           {/* Endless start CTA */}
-          <section style={{
+          <section className="endless-hero" style={{
             background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
             border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 40,
             position: "relative", overflow: "hidden", minHeight: 280, marginTop: 28,
@@ -114,7 +114,7 @@ export default function EndlessHub({ user, modQueueCount, stats, leaderboard, ap
               Three lives. Earn one back every five in a row. Difficulty climbs as you do. Run ends when you&apos;re out.
             </p>
             <div style={{ flex: 1, minHeight: 32 }} />
-            <div style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8, position: "relative" }}>
+            <div className="endless-hero-foot" style={{ display: "flex", alignItems: "center", gap: 18, marginTop: 8, position: "relative" }}>
               {user ? (
                 <Link href="/play/run" style={{
                   background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
@@ -145,7 +145,7 @@ export default function EndlessHub({ user, modQueueCount, stats, leaderboard, ap
             </div>
           </section>
 
-          <section style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
+          <section className="endless-stats-grid" style={{ display: "grid", gridTemplateColumns: stats ? "1fr 1.1fr" : "1fr", gap: 20, marginTop: 28 }}>
             {stats && (
               <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 24 }}>
                 <Eyebrow>Your records · all-time</Eyebrow>

--- a/pages/play/index.tsx
+++ b/pages/play/index.tsx
@@ -32,9 +32,9 @@ export default function PlayHub({ user, modQueueCount }: Props) {
   const pvpHref = user ? "/play/pvp/new" : `/login?next=${encodeURIComponent("/play/pvp/new")}`;
   return (
     <Layout user={user} modQueueCount={modQueueCount} title="Play — Opening Wiki">
-      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
-        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "64px 40px 60px" }}>
-          <div style={{ paddingBottom: 36, borderBottom: `1px solid ${SOLO.line}` }}>
+      <div data-mobile-play-hub style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div className="solo-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "64px 40px 60px" }}>
+          <div className="play-hub-head" style={{ paddingBottom: 36, borderBottom: `1px solid ${SOLO.line}` }}>
             <Eyebrow>Play</Eyebrow>
             <h1 style={{ margin: "14px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 64, letterSpacing: "-0.045em", lineHeight: 0.96 }}>
               Pick your <span style={{ color: SOLO.accent }}>mode.</span>
@@ -45,7 +45,7 @@ export default function PlayHub({ user, modQueueCount }: Props) {
             </p>
           </div>
 
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20, marginTop: 32 }}>
+          <div className="play-grid" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20, marginTop: 32 }}>
             <ModeCard
               href={endlessHref}
               eyebrow="Endless · solo"
@@ -67,7 +67,7 @@ export default function PlayHub({ user, modQueueCount }: Props) {
           </div>
 
           {/* Tournaments teaser — phase-3 placeholder, no leaderboard. */}
-          <div style={{
+          <div className="play-tournament-teaser" style={{
             marginTop: 22, padding: "18px 24px",
             background: SOLO.bg2, border: `1px dashed ${SOLO.line2}`, borderRadius: 10,
             display: "flex", alignItems: "center", justifyContent: "space-between", gap: 20,
@@ -106,7 +106,7 @@ interface ModeCardProps {
 // is a secondary visual cue; clicking anywhere on the card routes.
 function ModeCard({ href, eyebrow, title, accentWord, desc, cta, meta }: ModeCardProps) {
   return (
-    <Link href={href} style={{
+    <Link href={href} className="play-mode-card" style={{
       textDecoration: "none", color: "inherit",
       background: `linear-gradient(135deg, ${SOLO.bg2} 0%, ${SOLO.bg3} 100%)`,
       border: `1px solid ${SOLO.line2}`, borderRadius: 12, padding: 32,
@@ -130,8 +130,8 @@ function ModeCard({ href, eyebrow, title, accentWord, desc, cta, meta }: ModeCar
         {desc}
       </p>
       <div style={{ flex: 1, minHeight: 28 }} />
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginTop: 18 }}>
-        <span style={{
+      <div className="play-mode-foot" style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 16, marginTop: 18 }}>
+        <span className="play-mode-cta" style={{
           background: SOLO.accent, color: SOLO.bg,
           border: "none", borderRadius: 8, padding: "12px 22px",
           fontFamily: SOLO.sans, fontWeight: 600, fontSize: 14, letterSpacing: "-0.01em",

--- a/pages/play/pvp/new.tsx
+++ b/pages/play/pvp/new.tsx
@@ -54,8 +54,8 @@ export default function NewBattle({ user, modQueueCount }: Props) {
   return (
     <Layout user={user} modQueueCount={modQueueCount} title="New battle — Opening Wiki">
       <Head><meta name="description" content="Open a 1v1 PvP lobby." /></Head>
-      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
-        <div style={{ maxWidth: 1120, margin: "0 auto", padding: "36px 40px 48px" }}>
+      <div data-mobile-pvp-new style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        <div className="solo-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "36px 40px 48px" }}>
           <nav style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3, letterSpacing: "0.04em", marginBottom: 14, display: "flex", gap: 6, alignItems: "center" }}>
             <Link href="/play" style={{ color: SOLO.fg2, textDecoration: "none" }}>Play</Link>
             <span style={{ color: SOLO.fg4 }}>/</span>
@@ -68,13 +68,13 @@ export default function NewBattle({ user, modQueueCount }: Props) {
             1v1 race · configure → invite → play
           </p>
 
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 28 }}>
+          <div className="pvp-grid" style={{ display: "grid", gridTemplateColumns: "1fr 320px", gap: 28 }}>
             <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
                 <label style={{ fontFamily: SOLO.mono, fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: SOLO.fg3 }}>
                   Format <span style={{ color: SOLO.accent }}>*</span>
                 </label>
-                <div style={{ display: "flex", border: `1px solid ${SOLO.line2}`, borderRadius: 8, background: SOLO.bg2, padding: 4, gap: 2 }}>
+                <div className="pvp-format" style={{ display: "flex", border: `1px solid ${SOLO.line2}`, borderRadius: 8, background: SOLO.bg2, padding: 4, gap: 2 }}>
                   {FORMATS.map((f) => {
                     const on = f.value === format;
                     return (
@@ -136,7 +136,7 @@ export default function NewBattle({ user, modQueueCount }: Props) {
               )}
             </div>
 
-            <aside style={{
+            <aside className="pvp-sidebar" style={{
               position: "sticky", top: 80, background: SOLO.bg2, border: `1px solid ${SOLO.line2}`,
               borderRadius: 10, padding: 22, alignSelf: "start",
             }}>

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -158,7 +158,7 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
     <>
       <Head><title>Solo run · Opening Wiki</title></Head>
       <audio ref={audioRef} preload="auto" />
-      <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100vh", fontFamily: SOLO.sans, display: "flex", flexDirection: "column" }}>
+      <div data-mobile-game style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100vh", fontFamily: SOLO.sans, display: "flex", flexDirection: "column" }}>
         <TopbarSolo />
         {phase.kind === "starting" && <CenterMessage text="Loading run…" />}
         {phase.kind === "error" && <ErrorScreen message={phase.message} />}
@@ -229,7 +229,7 @@ function ErrorScreen({ message }: { message: string }) {
 
 function Hud({ run, mode, label }: { run: SoloRun; mode?: string; label?: string }) {
   return (
-    <div style={{
+    <div className="game-hud" style={{
       display: "flex", alignItems: "center", justifyContent: "space-between",
       padding: "18px 40px", borderBottom: `1px solid ${SOLO.line}`,
     }}>
@@ -262,14 +262,14 @@ function ModeRevealScreen({ mode, countdownMs, run, round }: { mode: string; cou
     <>
       <TimerBar pct={0} />
       <Hud run={run} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", position: "relative", overflow: "hidden" }}>
+      <div className="game-stage" style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", position: "relative", overflow: "hidden" }}>
         <div style={{
           position: "absolute", width: 800, height: 800, borderRadius: "50%",
           background: `radial-gradient(circle, ${SOLO.accent}26 0%, transparent 60%)`,
           filter: "blur(20px)", pointerEvents: "none",
         }} />
         <div style={{ fontFamily: SOLO.mono, fontSize: 13, letterSpacing: "0.4em", color: SOLO.fg3, marginBottom: 24 }}>— MODE —</div>
-        <div style={{
+        <div className="game-mode-big" style={{
           fontFamily: SOLO.sans, fontWeight: 900, fontSize: 200,
           letterSpacing: "-0.06em", lineHeight: 0.85, color: SOLO.fg,
           textShadow: `0 0 60px ${SOLO.accent}66`, position: "relative",
@@ -352,15 +352,15 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
     <>
       <TimerBar pct={pct} danger={secsLeft < 5} />
       <Hud run={run} mode={round.mode} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "40px 0 30px", position: "relative" }}>
-        <div style={{
+      <div className="game-stage" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "center", padding: "40px 0 30px", position: "relative" }}>
+        <div className="game-clip-time" style={{
           position: "absolute", top: 20, right: 40,
           fontFamily: SOLO.mono, fontSize: 56, fontWeight: 500,
           letterSpacing: "-0.04em", color: secsLeft < 5 ? SOLO.danger : SOLO.fg, lineHeight: 1,
         }}>
-          {secsLeft.toFixed(1)}<span style={{ color: SOLO.fg4, fontSize: 32 }}>s</span>
+          {secsLeft.toFixed(1)}<s style={{ color: SOLO.fg4, fontSize: 32 }}>s</s>
         </div>
-        <div style={{
+        <div className="game-clip-label" style={{
           position: "absolute", top: 28, left: 40,
           fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg3,
           letterSpacing: "0.14em", textTransform: "uppercase",
@@ -372,9 +372,9 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
           Name the anime. ↵ to submit.
         </div>
       </div>
-      <div style={{ padding: "0 40px 32px", position: "relative" }}>
+      <div className="game-input" style={{ padding: "0 40px 32px", position: "relative" }}>
         {suggestions.length > 0 && (
-          <div style={{
+          <div className="game-suggs" style={{
             position: "absolute", bottom: "100%", left: 40, right: 40,
             background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 10,
             marginBottom: 8, overflow: "hidden",
@@ -463,7 +463,7 @@ function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRu
             {correct ? `Correct · ${formatResponseMs(result.round_result.your_response_ms)}` : "Time's up · 20.0s"}
           </Eyebrow>
         </div>
-        <div style={{
+        <div className="reveal-card" style={{
           display: "grid", gridTemplateColumns: "auto 1fr", gap: 40, maxWidth: 880,
           background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 14,
           padding: 36, position: "relative", overflow: "hidden",
@@ -473,7 +473,7 @@ function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRu
             border: `1px solid ${correct ? SOLO.ok : SOLO.danger}55`,
             boxShadow: `0 0 40px ${correct ? SOLO.ok : SOLO.danger}33, inset 0 0 60px ${correct ? SOLO.ok : SOLO.danger}0a`,
           }} />
-          <div style={{
+          <div className="reveal-cover" style={{
             width: 200, height: 280, borderRadius: 8, background: SOLO.bg3,
             border: `1px solid ${SOLO.line2}`,
             backgroundImage: op?.anime?.cover_image_url ? "none" : `repeating-linear-gradient(135deg, ${SOLO.bg3} 0 14px, #221c33 14px 15px)`,
@@ -489,7 +489,7 @@ function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRu
             <div style={{ fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.16em", textTransform: "uppercase", color: correct ? SOLO.ok : SOLO.danger, marginBottom: 10 }}>
               {correct ? `✓ ${op?.title ?? "—"}` : "✕ The answer was"}
             </div>
-            <h2 style={{ margin: 0, fontFamily: SOLO.sans, fontWeight: 800, fontSize: correct ? 56 : 48, letterSpacing: "-0.04em", lineHeight: 0.95, color: SOLO.fg }}>
+            <h2 className="reveal-headline" style={{ margin: 0, fontFamily: SOLO.sans, fontWeight: 800, fontSize: correct ? 56 : 48, letterSpacing: "-0.04em", lineHeight: 0.95, color: SOLO.fg }}>
               {correct ? op?.anime?.name ?? "—" : op?.title ?? "—"}
             </h2>
             <div style={{ fontFamily: SOLO.sans, fontSize: 17, color: SOLO.fg2, marginTop: 6 }}>
@@ -497,7 +497,7 @@ function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRu
                 ? <>{op?.anime?.name ?? ""}</>
                 : <>from <em style={{ fontStyle: "normal", color: SOLO.accent }}>{op?.anime?.name ?? "—"}</em></>}
             </div>
-            <div style={{ display: "flex", gap: 36, marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line2}` }}>
+            <div className="reveal-stats" style={{ display: "flex", gap: 36, marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line2}` }}>
               <StatCell value={correct ? `+${result.round_result.score_delta}` : "+0"} label="score" color={correct ? SOLO.ok : SOLO.danger} />
               <StatCell value={formatResponseMs(result.round_result.your_response_ms)} label="your time" />
               <StatCell value={formatResponseMs(result.round_result.avg_player_response_ms)} label="avg player" />
@@ -535,8 +535,8 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
 
   return (
     <div style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100%", fontFamily: SOLO.sans }}>
-      <div style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
-        <header style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
+      <div className="game-end-page" style={{ maxWidth: 1120, margin: "0 auto", padding: "48px 40px 64px" }}>
+        <header className="game-end-head" style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", paddingBottom: 28, borderBottom: `1px solid ${SOLO.line}` }}>
           <div>
             <Eyebrow color={SOLO.danger} dotColor={SOLO.danger}>Run over · all lives spent</Eyebrow>
             <h1 style={{ margin: "14px 0 0", fontFamily: SOLO.sans, fontWeight: 800, fontSize: 88, letterSpacing: "-0.05em", lineHeight: 0.9 }}>
@@ -546,7 +546,7 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
               {user ? `Run as ${user.display_name}.` : "Anonymous run."} Longest streak this run: {summary.longest_streak}.
             </p>
           </div>
-          <div style={{ display: "flex", gap: 12 }}>
+          <div className="game-end-actions" style={{ display: "flex", gap: 12 }}>
             <Link href="/play/run" style={{
               background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
               padding: "14px 22px", fontWeight: 600, fontSize: 14, cursor: "pointer",
@@ -565,7 +565,7 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
           </div>
         </header>
 
-        <section style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 20, marginTop: 32 }}>
+        <section className="game-end-grid" style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 20, marginTop: 32 }}>
           <div style={{ background: SOLO.bg2, border: `1px solid ${SOLO.line}`, borderRadius: 12, padding: 28 }}>
             <Eyebrow>This run · by mode</Eyebrow>
             {summary.by_mode.length === 0 && (

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2960,3 +2960,478 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 
   .ms-crumb { padding: 20px 0 10px; flex-wrap: wrap; }
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+   MOBILE — bottom tab bar, hamburger drawer, and responsive overrides that
+   bring the Twilight-mobile design into the existing Next pages. Active
+   below 720px; desktop layout stays untouched above that.
+   ─────────────────────────────────────────────────────────────────────────── */
+
+:root {
+  --m-top: 56px;
+  --m-bottom: 78px;
+  --bg-4: #261f37;
+}
+
+/* The Topbar hamburger is hidden by default; only the desktop nav shows. */
+.topbar-menu {
+  display: none;
+  width: 38px; height: 38px; border-radius: 10px;
+  align-items: center; justify-content: center;
+  color: var(--fg-2);
+  background: transparent;
+  transition: background .15s, color .15s;
+  margin-left: 6px;
+}
+.topbar-menu:hover, .topbar-menu:active { background: var(--bg-3); color: var(--fg); }
+
+/* Bottom tab bar — hidden by default, shown on mobile. */
+.mtabbar {
+  display: none;
+  position: fixed;
+  bottom: 0; left: 0; right: 0;
+  height: var(--m-bottom);
+  padding: 6px 6px 18px;
+  padding-bottom: calc(18px + env(safe-area-inset-bottom, 0));
+  height: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0));
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: blur(18px);
+  border-top: 1px solid var(--line);
+  grid-template-columns: repeat(4, 1fr);
+  z-index: 40;
+}
+.mtab {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 3px;
+  color: var(--fg-3); text-decoration: none;
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.04em;
+  position: relative;
+}
+.mtab-ico { display: grid; place-items: center; }
+.mtab-ico svg { width: 22px; height: 22px; display: block; }
+.mtab.on { color: var(--fg); }
+.mtab.on::before {
+  content: ''; position: absolute; top: 0; width: 28px; height: 2px;
+  border-radius: 0 0 2px 2px; background: var(--accent);
+}
+
+/* Drawer + scrim — hidden by default. Slides in from the right on mobile. */
+.mscrim {
+  position: fixed; inset: 0; z-index: 60;
+  background: rgba(6, 4, 14, 0.62);
+  backdrop-filter: blur(2px);
+  opacity: 0; pointer-events: none;
+  transition: opacity .2s;
+  display: none;
+}
+.mscrim.on { opacity: 1; pointer-events: auto; }
+
+.mdrawer {
+  position: fixed; top: 0; right: 0; bottom: 0;
+  width: 84%; max-width: 340px;
+  background: var(--bg-2);
+  border-left: 1px solid var(--line);
+  z-index: 70;
+  transform: translateX(100%);
+  transition: transform .26s cubic-bezier(.2, .7, .3, 1);
+  display: none;
+  flex-direction: column;
+  box-shadow: -30px 0 60px rgba(0, 0, 0, 0.5);
+}
+.mdrawer.on { transform: translateX(0); }
+
+.mdrawer-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 22px 18px 16px;
+  border-bottom: 1px solid var(--line);
+  padding-top: calc(22px + env(safe-area-inset-top, 0));
+}
+.mdrawer-me {
+  display: flex; align-items: center; gap: 11px; min-width: 0;
+}
+.mdrawer-avatar {
+  width: 38px; height: 38px; border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), #6e57d8);
+  color: var(--accent-ink);
+  display: grid; place-items: center;
+  font-weight: 700; font-size: 14px; letter-spacing: -0.02em;
+  flex-shrink: 0; overflow: hidden;
+}
+.mdrawer-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.mdrawer-me-text { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.mdrawer-me-name {
+  display: flex; align-items: center; gap: 8px;
+  font-weight: 600; font-size: 15px; letter-spacing: -0.01em; line-height: 1.15;
+}
+.mdrawer-me-sub {
+  font-family: var(--mono); font-size: 10px; color: var(--fg-3); letter-spacing: 0.06em;
+}
+.mdrawer-x {
+  width: 36px; height: 36px; border-radius: 8px;
+  display: grid; place-items: center;
+  color: var(--fg-3);
+  background: transparent; border: 0; cursor: pointer;
+}
+.mdrawer-x:hover, .mdrawer-x:active { background: var(--bg-3); color: var(--fg); }
+
+.mdrawer-nav { padding: 10px 0; flex: 1; overflow-y: auto; }
+.mdrawer-section {
+  font-family: var(--mono); font-size: 9px; letter-spacing: 0.14em;
+  text-transform: uppercase; color: var(--fg-4);
+  padding: 16px 18px 8px;
+}
+.mdrawer-nav a {
+  display: flex; align-items: center; gap: 14px;
+  padding: 12px 18px; color: var(--fg);
+  font-size: 14.5px; letter-spacing: -0.005em;
+  text-decoration: none;
+  transition: background .12s;
+}
+.mdrawer-nav a:active { background: var(--bg-3); }
+.mdrawer-ico {
+  width: 22px; display: grid; place-items: center;
+  color: var(--fg-3);
+}
+.mdrawer-nav a.cur { color: var(--accent); }
+.mdrawer-nav a.cur .mdrawer-ico { color: var(--accent); }
+.mdrawer-badge {
+  margin-left: auto;
+  font-family: var(--mono); font-size: 10px;
+  background: var(--accent); color: var(--accent-ink);
+  padding: 2px 7px; border-radius: 3px; font-weight: 600;
+}
+.mdrawer-foot {
+  padding: 14px 18px 22px;
+  padding-bottom: calc(22px + env(safe-area-inset-bottom, 0));
+  border-top: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10px; color: var(--fg-4);
+  display: flex; justify-content: space-between; align-items: center;
+}
+.mdrawer-foot a { color: var(--fg-3); }
+
+/* Activate mobile chrome at ≤ 720px and tune the layout. */
+@media (max-width: 720px) {
+  .mtabbar { display: grid; }
+  .mscrim { display: block; }
+  .mdrawer { display: flex; }
+  .topbar-menu { display: inline-flex; }
+
+  /* Hide the desktop "Submit / Avatar / Log in / Sign up" cluster on
+     mobile — the hamburger drawer carries those actions. */
+  .top-right { display: none; }
+  .nav { display: none; }
+  .topbar-inner { justify-content: space-between; height: 56px; }
+
+  /* Push content above the bottom tab bar so the last item isn't hidden. */
+  .page-body {
+    padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0));
+  }
+  footer { padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0)); }
+}
+
+/* Touch-friendly typography + spacing tweaks below 720. The Home page,
+   Play hub, and most form-style screens benefit from these alone. */
+@media (max-width: 720px) {
+  :root { --pad: 16px; }
+
+  /* Home / catalogue head */
+  .head { padding: 22px 0 8px; }
+  .head h1 { font-size: 32px; letter-spacing: -0.035em; line-height: 1.02; margin: 0 0 8px; }
+  .head p { font-size: 11px; margin: 0 0 18px; }
+  .search { padding: 12px 14px; border-radius: 10px; gap: 10px; }
+  .search input { font-size: 15px; }
+
+  /* Catalog tabs become a tighter segmented control on mobile. */
+  .cat-tabs {
+    display: grid; grid-template-columns: repeat(3, 1fr); gap: 4px;
+    background: var(--bg-2); border: 1px solid var(--line);
+    padding: 4px; border-radius: 10px;
+    margin: 12px 0 0;
+  }
+  .cat-tab {
+    border-radius: 7px; padding: 9px 6px;
+    display: flex; flex-direction: column; align-items: center; gap: 2px;
+    border-bottom: 0 !important;
+    background: transparent !important;
+  }
+  .cat-tab.on { background: var(--bg-4) !important; }
+  .cat-tab-label { font-size: 13px; flex-direction: column; gap: 2px; align-items: center; }
+  .cat-tab-count { font-size: 10px; }
+  .cat-tab-sub { display: none; }
+
+  /* Sort bar gets tighter padding on small screens. */
+  .sort-bar { padding: 14px 0 10px; font-size: 11px; gap: 8px; }
+  .sort-pop { right: 0; left: auto; min-width: 200px; }
+
+  /* The page-grid collapses to a single column (already covered by the
+     960px rule), but we need to flip the order: side rail moves below
+     pagination on mobile. */
+  .page-grid, .page-grid-left { gap: 22px; padding-bottom: 32px; }
+  .side, .side-left { gap: 18px; }
+
+  /* Catalogue cards become a horizontal row: thumb · meta — like the
+     mobile design's 132px thumb + info column. */
+  .cat { grid-template-columns: 1fr; gap: 14px; padding: 4px 0 16px; }
+  .op-card { display: grid; grid-template-columns: 132px 1fr; gap: 12px; align-items: center; }
+  .op-thumb { border-radius: 8px; }
+  .op-info { flex-direction: column; gap: 4px; align-items: stretch; }
+  .op-main { flex: none; }
+  .op-title { font-size: 15px; line-height: 1.2; margin: 0; -webkit-line-clamp: 2; display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; }
+  .op-meta { font-size: 10.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .op-score { text-align: left; display: flex; align-items: baseline; gap: 8px; margin-top: 2px; }
+  .op-score .n { font-size: 15px; }
+  .op-score .n em { font-size: 10px; }
+  .op-score .ct { font-size: 11px; }
+  .op-play { display: none; }
+
+  /* Side panels become full-width cards stacked below the list. */
+  .panel { border-radius: 12px; }
+  .panel-head { padding: 12px 14px; font-size: 10px; }
+
+  /* Auth card / submit card */
+  .auth-card { padding: 18px; }
+  .submit-card { padding: 18px; }
+}
+
+/* Pagination on mobile — convert to "Prev / N of M / Next" trio. */
+@media (max-width: 720px) {
+  .pag { flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+  .pag button, .pag a { min-width: 38px; height: 34px; padding: 0 12px; }
+}
+
+/* ── PLAY hub mobile overrides ──────────────────────────────────────────── */
+@media (max-width: 720px) {
+  /* The hub uses inline styles (SOLO atoms). Wrap-tweak via attribute
+     selectors and globally-named inline styles isn't reachable, so we
+     rely on class hooks in the page React. Instead, scope these
+     overrides to a body-level page wrapper added below. */
+  [data-mobile-play-hub] .play-grid {
+    grid-template-columns: 1fr !important;
+    gap: 14px !important;
+  }
+  [data-mobile-play-hub] .play-mode-card {
+    min-height: auto !important;
+    padding: 22px !important;
+  }
+  [data-mobile-play-hub] .play-mode-card h2 {
+    font-size: 28px !important;
+  }
+  [data-mobile-play-hub] .play-mode-card .play-mode-cta {
+    width: 100%;
+    justify-content: center;
+  }
+  [data-mobile-play-hub] .play-mode-card .play-mode-foot {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 12px !important;
+  }
+  [data-mobile-play-hub] .play-hub-head h1 {
+    font-size: 38px !important;
+    line-height: 1.02 !important;
+  }
+  [data-mobile-play-hub] .play-hub-head p {
+    font-size: 13.5px !important;
+  }
+  [data-mobile-play-hub] .play-hub-head {
+    padding-bottom: 24px !important;
+  }
+  [data-mobile-play-hub] .play-tournament-teaser {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 12px !important;
+  }
+  [data-mobile-play-hub] .solo-page {
+    padding: 22px 16px 32px !important;
+  }
+}
+
+/* ── ENDLESS hub mobile overrides ───────────────────────────────────────── */
+@media (max-width: 720px) {
+  [data-mobile-endless-hub] .solo-page {
+    padding: 22px 16px 32px !important;
+  }
+  [data-mobile-endless-hub] .endless-head {
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    gap: 16px !important;
+  }
+  [data-mobile-endless-hub] .endless-head h1 {
+    font-size: 36px !important;
+    line-height: 1.02 !important;
+  }
+  [data-mobile-endless-hub] .endless-hero {
+    padding: 24px !important;
+    min-height: auto !important;
+  }
+  [data-mobile-endless-hub] .endless-hero h2 {
+    font-size: 28px !important;
+  }
+  [data-mobile-endless-hub] .endless-hero-foot {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 12px !important;
+  }
+  [data-mobile-endless-hub] .endless-hero-foot > a {
+    justify-content: center;
+    width: 100%;
+  }
+  [data-mobile-endless-hub] .endless-stats-grid {
+    grid-template-columns: 1fr !important;
+  }
+  [data-mobile-endless-hub] .endless-stats-grid > div {
+    padding: 18px !important;
+  }
+}
+
+/* ── PvP NEW (Battle setup) mobile overrides ────────────────────────────── */
+@media (max-width: 720px) {
+  [data-mobile-pvp-new] .solo-page {
+    padding: 22px 16px 32px !important;
+  }
+  [data-mobile-pvp-new] .pvp-grid {
+    grid-template-columns: 1fr !important;
+  }
+  [data-mobile-pvp-new] .pvp-format {
+    flex-direction: column !important;
+  }
+  [data-mobile-pvp-new] .pvp-sidebar {
+    position: static !important;
+  }
+  [data-mobile-pvp-new] h1 {
+    font-size: 30px !important;
+  }
+}
+
+/* ── PvP Lobby mobile overrides ─────────────────────────────────────────── */
+@media (max-width: 720px) {
+  [data-mobile-pvp-lobby] .lobby-page {
+    padding: 22px 16px 32px !important;
+  }
+  [data-mobile-pvp-lobby] .lobby-head {
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    gap: 16px !important;
+  }
+  [data-mobile-pvp-lobby] .lobby-head h1 {
+    font-size: 28px !important;
+  }
+  [data-mobile-pvp-lobby] .vs-panel {
+    grid-template-columns: 1fr !important;
+  }
+  [data-mobile-pvp-lobby] .vs-panel .vs-divider {
+    flex-direction: row !important;
+    width: 100%;
+    height: 40px;
+    padding: 0 !important;
+  }
+  [data-mobile-pvp-lobby] .vs-panel .vs-divider .vs-line {
+    width: auto !important; flex: 1; height: 1px !important;
+    background: linear-gradient(90deg, transparent 0%, var(--line-2) 50%, transparent 100%) !important;
+  }
+  [data-mobile-pvp-lobby] .player-card {
+    min-height: auto !important;
+    padding: 22px !important;
+  }
+  [data-mobile-pvp-lobby] .lobby-cta {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 14px !important;
+  }
+  [data-mobile-pvp-lobby] .lobby-cta-actions {
+    width: 100%;
+    flex-direction: column !important;
+    gap: 8px !important;
+  }
+  [data-mobile-pvp-lobby] .lobby-cta-actions button {
+    width: 100%;
+  }
+}
+
+/* ── GAME PAGES (Solo run, PvP match) — mobile ─────────────────────────── */
+@media (max-width: 720px) {
+  /* On the run pages the global Topbar/MobileNav are hidden — they have
+     their own arcade chrome that fills the viewport. The CSS we add
+     here makes the inline-styled phases readable on a phone. */
+  [data-mobile-game] .game-hud {
+    padding: 14px 16px !important;
+  }
+  [data-mobile-game] .game-stage {
+    padding: 20px 16px !important;
+  }
+  [data-mobile-game] .game-mode-big {
+    font-size: 96px !important;
+  }
+  [data-mobile-game] .game-clip-time {
+    font-size: 40px !important;
+    top: 12px !important; right: 16px !important;
+  }
+  [data-mobile-game] .game-clip-time s { font-size: 20px !important; }
+  [data-mobile-game] .game-clip-label {
+    top: 14px !important; left: 16px !important;
+    font-size: 10px !important;
+  }
+  [data-mobile-game] .game-input {
+    margin: 0 16px 22px !important;
+  }
+  [data-mobile-game] .game-input input {
+    font-size: 16px !important;
+  }
+  [data-mobile-game] .game-suggs {
+    left: 16px !important; right: 16px !important;
+  }
+  [data-mobile-game] .reveal-card {
+    grid-template-columns: 1fr !important;
+    gap: 18px !important;
+    padding: 22px !important;
+    margin: 0 16px !important;
+  }
+  [data-mobile-game] .reveal-cover {
+    width: 100% !important;
+    max-width: 180px;
+    height: auto !important;
+    aspect-ratio: 2 / 3;
+    justify-self: center;
+  }
+  [data-mobile-game] .reveal-headline {
+    font-size: 32px !important;
+  }
+  [data-mobile-game] .reveal-stats {
+    flex-wrap: wrap !important;
+    gap: 18px !important;
+  }
+  /* Solo-run end & match-end screens */
+  [data-mobile-game] .game-end-page {
+    padding: 24px 16px 32px !important;
+  }
+  [data-mobile-game] .game-end-head {
+    flex-direction: column !important;
+    align-items: flex-start !important;
+    gap: 16px !important;
+  }
+  [data-mobile-game] .game-end-head h1 {
+    font-size: 48px !important;
+  }
+  [data-mobile-game] .game-end-grid {
+    grid-template-columns: 1fr !important;
+  }
+  [data-mobile-game] .game-end-actions {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    gap: 8px !important;
+  }
+  [data-mobile-game] .game-end-actions > a {
+    width: 100%;
+    justify-content: center;
+  }
+  /* PvP HUD compresses a lot — names sit next to scores instead of
+     using 5 columns of space. */
+  [data-mobile-game] .pvp-hud {
+    gap: 8px !important;
+    padding: 12px !important;
+  }
+  [data-mobile-game] .pvp-hud .pvp-hud-name { display: none; }
+  [data-mobile-game] .pvp-hud .pvp-hud-mid {
+    padding: 0 8px !important;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Adds a bottom 4-tab bar (Home / Play / Submissions / Groups) and a hamburger-driven slide-in drawer for navigation on phones, layered into the existing `Layout` so every page benefits without page-level wiring.
- Restyles the Home catalog (mobile segmented type tabs, horizontal opening cards), Play hub, Endless hub, PvP setup/lobby, and the Solo/PvP in-match + end screens via responsive CSS (`@media (max-width: 720px)`).
- Inline-styled play pages get `data-mobile-*` attributes and element-level class hooks (`.play-mode-card`, `.endless-hero`, `.lobby-cta`, `.game-hud`, `.reveal-card`, etc.) so the overrides can reach into the SOLO-tokenised React without rewriting each page in CSS modules.
- Pulls in the design tokens from the seven mobile HTML mocks (Twilight palette, 56px top app bar, 78px bottom bar, drawer chrome).

No backend changes — anything the mock implied that the API doesn't already expose was skipped per request.

## Test plan
- [ ] On a phone-sized viewport (≤ 480px) and tablet-ish (≤ 720px), the bottom tab bar renders with the correct active tab on `/`, `/play`, `/my-submissions`, `/groups`.
- [ ] The hamburger in the Topbar opens the right-side drawer; tapping the scrim, X, or any nav link closes it; current-route link is highlighted.
- [ ] `/` — title block, segmented Openings/Endings/OSTs, sort dropdown, opening rows (132px thumb + meta), pagination, side panels stack below pagination.
- [ ] `/play` — mode cards stack to single column; CTAs full-width.
- [ ] `/play/endless` — head stacks, hero card resizes, stats grid collapses to 1 column.
- [ ] `/play/pvp/new` — config + Battle summary sidebar stack vertically; format buttons stack.
- [ ] `/play/b/<code>` lobby — VS panel stacks (host / VS / opponent vertically); Ready/Leave actions full-width.
- [ ] `/play/run` and `/play/b/<code>` in-match — HUD compact, clip timer + label at 16px gutters, reveal card stacks cover above metadata; end-screens are single-column.
- [ ] Desktop (> 720px) is untouched: nav links + avatar pill + "+ Submit" remain in the top right; no bottom bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)