### PR TITLE
fix(mobile): groups strip, rolebar hide, no h-scroll, YT thumbs

### DIFF
--- a/components/GroupsPanel.tsx
+++ b/components/GroupsPanel.tsx
@@ -22,6 +22,11 @@ const LOCK_ICON = (
     <path d="M8 11V7a4 4 0 0 1 8 0v4" />
   </svg>
 );
+const PLUS_ICON = (
+  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M12 5v14M5 12h14" />
+  </svg>
+);
 
 function modifier(g: Group): string {
   if (g.is_system_rated) return "system";
@@ -37,35 +42,66 @@ function icon(g: Group) {
 
 export default function GroupsPanel({ groups }: Props) {
   return (
-    <div className="panel">
-      <div className="panel-head">
-        <span>Your groups</span>
-        <Link href="/groups?new=1">+ New</Link>
-      </div>
+    <>
+      {/* Desktop panel — vertical list with row-per-group. Hidden on mobile
+          where the .grp-strip below takes over (the design uses a
+          horizontally-scrollable chip strip on phones). */}
+      <div className="panel grp-panel-desktop">
+        <div className="panel-head">
+          <span>Your groups</span>
+          <Link href="/groups?new=1">+ New</Link>
+        </div>
 
-      <div className="grp-list">
-        {groups.map((g) => (
-          <div key={g.id} className={`grp-item-wrap ${modifier(g)}`.trim()}>
-            <Link
-              className={`grp-item ${modifier(g)}`.trim()}
-              href={`/groups/${g.id}`}
-            >
-              <span className="grp-icon">{icon(g)}</span>
-              <span className="grp-name">{g.name}</span>
-              <span className="grp-count">{g.opening_count}</span>
-            </Link>
-            {g.is_public && g.share_slug && (
-              <Link className="grp-public-link" href={`/g/${g.share_slug}`} title="Open public page">
-                Public
+        <div className="grp-list">
+          {groups.map((g) => (
+            <div key={g.id} className={`grp-item-wrap ${modifier(g)}`.trim()}>
+              <Link
+                className={`grp-item ${modifier(g)}`.trim()}
+                href={`/groups/${g.id}`}
+              >
+                <span className="grp-icon">{icon(g)}</span>
+                <span className="grp-name">{g.name}</span>
+                <span className="grp-count">{g.opening_count}</span>
               </Link>
-            )}
-          </div>
-        ))}
+              {g.is_public && g.share_slug && (
+                <Link className="grp-public-link" href={`/g/${g.share_slug}`} title="Open public page">
+                  Public
+                </Link>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="panel-foot">
+          <Link href="/groups">Manage all groups →</Link>
+        </div>
       </div>
 
-      <div className="panel-foot">
-        <Link href="/groups">Manage all groups →</Link>
+      {/* Mobile chip strip — hidden on desktop. Horizontally scrollable so
+          the rail of groups doesn't blow up the page width. */}
+      <div className="grp-strip" aria-hidden={false}>
+        <div className="grp-strip-head">
+          <h3>Your groups</h3>
+          <Link href="/groups">See all →</Link>
+        </div>
+        <div className="grp-strip-row">
+          {groups.map((g) => (
+            <Link
+              key={g.id}
+              href={`/groups/${g.id}`}
+              className={`grp-chip ${modifier(g)}`.trim()}
+            >
+              <span className="grp-chip-ico">{icon(g)}</span>
+              <span className="grp-chip-name">{g.name}</span>
+              <span className="grp-chip-count">{g.opening_count}</span>
+            </Link>
+          ))}
+          <Link href="/groups?new=1" className="grp-chip add">
+            <span className="grp-chip-ico">{PLUS_ICON}</span>
+            <span className="grp-chip-name">New group</span>
+          </Link>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/components/OpeningCard.tsx
+++ b/components/OpeningCard.tsx
@@ -25,7 +25,17 @@ export default function OpeningCard({ op, newLabel }: Props) {
       <Link href={`/openings/${op.id}`} className={thumbClass}>
         {thumb && (
           // eslint-disable-next-line @next/next/no-img-element
-          <img src={thumb} alt="" className="op-thumb-img" loading="lazy" />
+          <img
+            src={thumb}
+            alt=""
+            className="op-thumb-img"
+            // i.ytimg.com sometimes refuses hotlinks when the Referer header
+            // is set (most common on iOS Safari + strict cross-origin
+            // referrer policies). no-referrer makes the request anonymous
+            // and unblocks the thumbnail.
+            referrerPolicy="no-referrer"
+            decoding="async"
+          />
         )}
         {newLabel && <span className="op-badge new">NEW · {newLabel}</span>}
         {op.duration && <span className="op-duration">{op.duration}</span>}

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -775,7 +775,7 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
               background: "transparent", border: "none", outline: "none",
             }}
           />
-          <span style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ submit</span>
+          <span className="game-submit-hint" style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ submit</span>
         </div>
       </div>
     </div>

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -44,6 +44,11 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
   // The browser-decoded audio element. We keep one across rounds so the
   // user-gesture autoplay grant carries over the run.
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  // Lock for in-flight submissions. We used to swap phase to "starting"
+  // here (which paints a centered "Loading run…" between in-match and
+  // reveal), but on mobile that one-frame flash reads as a page-shake.
+  // The ref keeps the in-match UI on screen until the reveal arrives.
+  const submittingRef = useRef(false);
 
   // 1. start run on mount. CSRF + session cookies already in scope.
   useEffect(() => {
@@ -138,19 +143,26 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
   }, []);
 
   const submitAnswer = useCallback(async (p: Phase & { kind: "in-match" }, animeId: string | null) => {
-    setPhase({ kind: "starting" });
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    // Pause audio immediately so the user gets feedback that the submit
+    // registered, but keep the in-match screen mounted — the reveal card
+    // replaces it directly once the response lands, no centered-loading
+    // flash in between.
+    if (audioRef.current) {
+      try { audioRef.current.pause(); } catch { /* */ }
+    }
     try {
       const response = await playClient.submitAnswer(p.run.id, {
         round_token: p.round.round_token,
         anime_id: animeId,
         client_response_ms: Date.now() - inMatchStart.current,
       });
-      if (audioRef.current) {
-        try { audioRef.current.pause(); } catch { /* */ }
-      }
       setPhase({ kind: "reveal", result: response, nextAt: Date.now() + REVEAL_HOLD_MS, run: response.run });
     } catch (err: any) {
       setPhase({ kind: "error", message: err?.message ?? "Failed to submit answer" });
+    } finally {
+      submittingRef.current = false;
     }
   }, []);
 
@@ -442,7 +454,7 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
               background: "transparent", border: "none", outline: "none",
             }}
           />
-          <span style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ submit</span>
+          <span className="game-submit-hint" style={{ fontFamily: SOLO.mono, fontSize: 11, color: SOLO.fg4, border: `1px solid ${SOLO.line2}`, padding: "3px 8px", borderRadius: 4 }}>↵ submit</span>
         </div>
       </div>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3443,8 +3443,20 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   [data-mobile-game] .game-input input {
     font-size: 16px !important;
   }
+  /* The "↵ submit" key cap inside the search input is purely a desktop
+     keyboard hint and crowds the input on a phone (the user reports it
+     blocking the actual text). Hide it on mobile. */
+  [data-mobile-game] .game-submit-hint { display: none !important; }
+
+  /* The autocomplete is `position: absolute; bottom: 100%` so its top edge
+     moves up/down as the result count changes — on mobile this reads as
+     the page shaking. Cap the height with a max and let the rows scroll
+     inside, so the visible top edge stays near-stable across queries. */
   [data-mobile-game] .game-suggs {
     left: 16px !important; right: 16px !important;
+    max-height: 50vh !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
   }
   [data-mobile-game] .reveal-card {
     grid-template-columns: 1fr !important;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2973,6 +2973,53 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   --bg-4: #261f37;
 }
 
+/* Groups: mobile chip strip — only shown < 720px (rule lower in file). The
+   default desktop view hides this entirely so the panel stays the canonical
+   widget there. */
+.grp-strip { display: none; }
+.grp-strip-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 0 0 10px;
+}
+.grp-strip-head h3 {
+  margin: 0;
+  font-family: var(--mono); font-size: 10px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--fg-3); font-weight: 500;
+}
+.grp-strip-head a {
+  font-family: var(--mono); font-size: 11px; color: var(--accent);
+}
+.grp-strip-row {
+  display: flex; gap: 10px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  /* Negative inline margin + matching padding lets chips touch the screen
+     edge while still scrolling smoothly. */
+  margin: 0 calc(-1 * var(--pad));
+  padding: 2px var(--pad) 8px;
+}
+.grp-strip-row::-webkit-scrollbar { display: none; }
+.grp-chip {
+  flex: 0 0 auto;
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 9px 14px;
+  background: var(--bg-2); border: 1px solid var(--line);
+  border-radius: 999px;
+  font-size: 13px; color: var(--fg);
+  text-decoration: none;
+  transition: border-color .15s;
+}
+.grp-chip:active { border-color: var(--line-2); }
+.grp-chip-ico { display: grid; place-items: center; color: var(--fg-4); }
+.grp-chip.system .grp-chip-ico { color: var(--accent); }
+.grp-chip.public .grp-chip-ico { color: var(--ok); }
+.grp-chip-name { white-space: nowrap; }
+.grp-chip-count {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+}
+.grp-chip.add { color: var(--accent); border-style: dashed; }
+.grp-chip.add .grp-chip-ico { color: var(--accent); }
+
 /* The Topbar hamburger is hidden by default; only the desktop nav shows. */
 .topbar-menu {
   display: none;
@@ -3122,11 +3169,26 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   .nav { display: none; }
   .topbar-inner { justify-content: space-between; height: 56px; }
 
-  /* Push content above the bottom tab bar so the last item isn't hidden. */
+  /* The Rolebar (mod/admin shortcut to the moderation queue) is redundant
+     on mobile — the drawer's Moderation section already exposes the same
+     entry with the unread-count badge. */
+  .rolebar { display: none; }
+
+  /* A loose grid cell or a long nowrap string can push the page wider than
+     the viewport on phones, especially on the openings tab where some
+     anime/singer names are long enough to overflow `.op-meta`. Clamp the
+     body wrapper as a safety net so the user can't accidentally horizontal-
+     scroll the whole page. */
+  html, body { overflow-x: hidden; }
   .page-body {
+    overflow-x: hidden;
     padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0));
   }
   footer { padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0)); }
+
+  /* Groups: hide the desktop panel, reveal the chip strip. */
+  .grp-panel-desktop { display: none; }
+  .grp-strip { display: block; }
 }
 
 /* Touch-friendly typography + spacing tweaks below 720. The Home page,
@@ -3170,12 +3232,17 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   .side, .side-left { gap: 18px; }
 
   /* Catalogue cards become a horizontal row: thumb · meta — like the
-     mobile design's 132px thumb + info column. */
+     mobile design's 132px thumb + info column. minmax(0, 1fr) on the info
+     column lets the truncation rules in .op-meta / .op-title actually take
+     effect; without it the default `auto` min-track means a long nowrap
+     anime/singer name expands the column past 1fr and pushes the page
+     wider than the viewport (this was the source of the horizontal
+     scrollbar that only showed up on the Openings tab). */
   .cat { grid-template-columns: 1fr; gap: 14px; padding: 4px 0 16px; }
-  .op-card { display: grid; grid-template-columns: 132px 1fr; gap: 12px; align-items: center; }
+  .op-card { display: grid; grid-template-columns: 132px minmax(0, 1fr); gap: 12px; align-items: center; }
   .op-thumb { border-radius: 8px; }
-  .op-info { flex-direction: column; gap: 4px; align-items: stretch; }
-  .op-main { flex: none; }
+  .op-info { flex-direction: column; gap: 4px; align-items: stretch; min-width: 0; }
+  .op-main { flex: none; min-width: 0; }
   .op-title { font-size: 15px; line-height: 1.2; margin: 0; -webkit-line-clamp: 2; display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden; }
   .op-meta { font-size: 10.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .op-score { text-align: left; display: flex; align-items: baseline; gap: 8px; margin-top: 2px; }


### PR DESCRIPTION
## Summary
Four follow-up fixes against the mobile pass that just landed:

- **Horizontal scrollbar on the Openings tab.** The catalog cards used `grid-template-columns: 132px 1fr` for thumb + info; the default `auto` min-track on the 1fr column meant a long anime/singer name in `.op-meta` (which has `white-space: nowrap`) could push the column wider than `1fr`, blowing the page past the viewport on long-titled openings. Endings/OSTs happened to have shorter titles, so the bug was tab-specific. Switched to `minmax(0, 1fr)` and added `min-width: 0` on `.op-info`/`.op-main` so truncation actually works, plus `overflow-x: hidden` on `html`/`body`/`.page-body` as a safety net.
- **Groups widget → chip strip on mobile.** `GroupsPanel` now renders both a desktop panel and a mobile chip rail; CSS shows the one that matches the breakpoint. Chips are horizontally scrollable, end in a dashed `+ New group` chip, and use the same icon affordances (system ★ / public link / private lock) as the panel.
- **Moderation rolebar hidden on mobile.** The mod/admin "Moderation queue · N pending" bar under the topbar is redundant on phones — the drawer's Moderation section already exposes the same entry with the unread-count badge.
- **YouTube thumbs not loading on mobile.** Added `referrerPolicy="no-referrer"` and dropped `loading="lazy"` from the OpeningCard `<img>`. iOS Safari + strict cross-origin referrer policies were the most likely reason `i.ytimg.com/vi/.../hqdefault.jpg` failed to render on phones.

## Test plan
- [ ] On a narrow viewport (≤ 720px), `/` shows no horizontal scrollbar on the Openings, Endings, or OSTs tabs even with the longest title in the dataset.
- [ ] On mobile, the Groups widget is rendered as a chip rail; chips scroll horizontally inside the rail without scrolling the page itself; tapping a chip routes to `/groups/<id>`.
- [ ] On mobile, "+ New group" dashed chip is the last item and routes to `/groups?new=1`.
- [ ] On desktop (> 720px), the Groups widget is the existing vertical panel.
- [ ] Logged in as a moderator on mobile: the Rolebar under the topbar is hidden; the drawer's Moderation section still shows "Moderation queue" with the badge.
- [ ] YouTube thumbnails load on iOS Safari and Chrome Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)