### PR TITLE
fix(mobile, run-end): rerun, drop regen, h-overflow, hide chrome

### DIFF
--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -91,7 +91,7 @@ export default function MySubmissionsPage({ user, modQueueCount, initial }: Prop
         <div className="ms-head">
           <div>
             <h1 className="ms-h1">Your <em>submissions</em>.</h1>
-            <p className="ms-sub">
+            <p className="ms-head-sub">
               {c.all} total · recently submitted entries and their review state
             </p>
           </div>

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -845,8 +845,8 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
       <MatchHud view={view} scoreOverride={result.score} />
       <div style={{ position: "absolute", top: 60, left: 0, right: 0, bottom: 0, background: noScore ? `${SOLO.warn}08` : youWon ? `${SOLO.ok}10` : `${SOLO.danger}0d`, pointerEvents: "none" }} />
       <TimerBar pct={0.4} danger={oppWon} />
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
-        <div style={{ position: "absolute", top: 30, left: 40 }}>
+      <div className="reveal-page" style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
+        <div className="reveal-eyebrow" style={{ position: "absolute", top: 30, left: 40 }}>
           <Eyebrow color={accent} dotColor={accent}>{eyebrow}</Eyebrow>
         </div>
         <div className="reveal-card" style={{

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -41,6 +41,11 @@ const REVEAL_HOLD_MS = 3500;
 
 export default function SoloRunPage({ user, modQueueCount }: Props) {
   const [phase, setPhase] = useState<Phase>({ kind: "starting" });
+  // Bumped when the user clicks "Run again" so the start-run effect
+  // re-fires and a fresh run is requested. A plain `<Link href="/play/run">`
+  // doesn't work — Next.js treats it as same-route and skips the
+  // re-mount, leaving the component stuck on the ended phase.
+  const [runGen, setRunGen] = useState(0);
   // The browser-decoded audio element. We keep one across rounds so the
   // user-gesture autoplay grant carries over the run.
   const audioRef = useRef<HTMLAudioElement | null>(null);
@@ -50,9 +55,11 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
   // The ref keeps the in-match UI on screen until the reveal arrives.
   const submittingRef = useRef(false);
 
-  // 1. start run on mount. CSRF + session cookies already in scope.
+  // 1. start run on mount, and again whenever runGen bumps.
   useEffect(() => {
     let abandoned = false;
+    setPhase({ kind: "starting" });
+    submittingRef.current = false;
     playClient.startRun()
       .then(({ run, round }) => {
         if (abandoned) return;
@@ -63,7 +70,7 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
         setPhase({ kind: "error", message: err.message ?? "Failed to start run" });
       });
     return () => { abandoned = true; };
-  }, []);
+  }, [runGen]);
 
   // 2. mode-reveal tick — counts down to 0, then drops us into in-match.
   useEffect(() => {
@@ -194,7 +201,12 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
           <RevealScreen result={phase.result} run={phase.result.run} />
         )}
         {phase.kind === "ended" && (
-          <RunEndScreen run={phase.run} summary={phase.summary} user={user} />
+          <RunEndScreen
+            run={phase.run}
+            summary={phase.summary}
+            user={user}
+            onRestart={() => setRunGen((g) => g + 1)}
+          />
         )}
       </div>
     </>
@@ -533,7 +545,7 @@ function StatCell({ value, label, color = SOLO.fg }: { value: string; label: str
   );
 }
 
-function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSummary; user: User | null }) {
+function RunEndScreen({ run, summary, user, onRestart }: { run: SoloRun; summary: SoloRunSummary; user: User | null; onRestart: () => void }) {
   const lengthMs = useMemo(() => {
     const ended = run.ended_at ? new Date(run.ended_at).getTime() : Date.now();
     return ended - new Date(run.started_at).getTime();
@@ -559,17 +571,17 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
             </p>
           </div>
           <div className="game-end-actions" style={{ display: "flex", gap: 12 }}>
-            <Link href="/play/run" style={{
+            <button onClick={onRestart} style={{
               background: SOLO.accent, color: SOLO.bg, border: "none", borderRadius: 8,
               padding: "14px 22px", fontWeight: 600, fontSize: 14, cursor: "pointer",
-              display: "inline-flex", alignItems: "center", gap: 8, textDecoration: "none",
+              display: "inline-flex", alignItems: "center", gap: 8, fontFamily: SOLO.sans,
               boxShadow: `0 0 30px ${SOLO.accent}55`,
             }}>
               Run again
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none">
                 <path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
               </svg>
-            </Link>
+            </button>
             <Link href="/play/endless" style={{
               background: "transparent", border: `1px solid ${SOLO.line2}`, color: SOLO.fg2,
               borderRadius: 8, padding: "14px 22px", fontWeight: 500, fontSize: 14, textDecoration: "none",
@@ -606,9 +618,8 @@ function RunEndScreen({ run, summary, user }: { run: SoloRun; summary: SoloRunSu
                 </div>
               );
             })}
-            <div style={{ marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line}`, display: "grid", gridTemplateColumns: "1fr 1fr 1fr 1fr", gap: 20 }}>
+            <div style={{ marginTop: 28, paddingTop: 22, borderTop: `1px dashed ${SOLO.line}`, display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 20 }}>
               <StatCell value={String(summary.longest_streak)} label="longest streak" />
-              <StatCell value={String(summary.lives_regen)} label="lives regen'd" />
               <StatCell value={lengthStr} label="run length" />
               <StatCell value={String(summary.score)} label="final score" color={SOLO.accent} />
             </div>

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -481,8 +481,8 @@ function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRu
       <div style={{ position: "absolute", top: 60, left: 0, right: 0, bottom: 0, background: correct ? `${SOLO.ok}10` : `${SOLO.danger}0d`, pointerEvents: "none" }} />
       <TimerBar pct={0.4} danger={!correct} />
       <Hud run={run} label={correct && result.round_result.life_regen ? "streak +1 · ♥+1" : correct ? "streak +1" : "streak reset"} />
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
-        <div style={{ position: "absolute", top: 30, left: 40 }}>
+      <div className="reveal-page" style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
+        <div className="reveal-eyebrow" style={{ position: "absolute", top: 30, left: 40 }}>
           <Eyebrow color={correct ? SOLO.ok : SOLO.danger} dotColor={correct ? SOLO.ok : SOLO.danger}>
             {correct ? `Correct · ${formatResponseMs(result.round_result.your_response_ms)}` : "Time's up · 20.0s"}
           </Eyebrow>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2729,7 +2729,10 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   margin: 0 0 10px;
 }
 .ms-h1 em { font-style: normal; color: var(--accent); }
-.ms-sub { color: var(--fg-3); font-family: var(--mono); font-size: 12px; margin: 0; letter-spacing: 0.04em; }
+/* Header lede under "Your submissions." — kept on its own class so the
+   submission-row `.ms-sub` card styling further down doesn't bleed onto
+   this paragraph (it used to inherit the bordered card look). */
+.ms-head-sub { color: var(--fg-3); font-family: var(--mono); font-size: 12px; margin: 0; letter-spacing: 0.04em; }
 .ms-head-right { display: flex; gap: 8px; }
 
 .ms-filter-bar {
@@ -3495,25 +3498,51 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
     overflow-y: auto !important;
     overscroll-behavior: contain;
   }
+  /* Reveal page outer container — desktop has inline `padding: 40` and
+     vertical centering, which on a 390px viewport eats 80px of horizontal
+     space and makes the card bounce vertically between in-match and
+     reveal. Pin to the top of the stage and tighten gutters. */
+  [data-mobile-game] .reveal-page {
+    padding: 12px 16px 16px !important;
+    align-items: flex-start !important;
+  }
+  [data-mobile-game] .reveal-eyebrow {
+    top: 12px !important;
+    left: 16px !important;
+  }
+
+  /* Compact reveal — matches the design's "song" card: 64px cover on the
+     left, info column on the right, stacked vertically beneath an
+     eyebrow. The previous mobile rule produced a 440px-tall card stacked
+     vertically; the in-match screen is only ~350px tall, so the swap
+     felt like the page was being shoved around. This compact form fits
+     in the stage area without forcing layout shifts. */
   [data-mobile-game] .reveal-card {
-    grid-template-columns: 1fr !important;
-    gap: 18px !important;
-    padding: 22px !important;
-    margin: 0 16px !important;
+    grid-template-columns: 64px minmax(0, 1fr) !important;
+    gap: 14px !important;
+    padding: 14px !important;
+    margin: 32px 0 0 !important;
+    align-items: start !important;
+    max-width: none !important;
   }
   [data-mobile-game] .reveal-cover {
-    width: 100% !important;
-    max-width: 180px;
-    height: auto !important;
-    aspect-ratio: 2 / 3;
-    justify-self: center;
+    width: 64px !important;
+    height: 90px !important;
+    max-width: none !important;
+    aspect-ratio: auto !important;
+    justify-self: auto !important;
   }
   [data-mobile-game] .reveal-headline {
-    font-size: 32px !important;
+    font-size: 22px !important;
+    line-height: 1.15 !important;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
   }
   [data-mobile-game] .reveal-stats {
     flex-wrap: wrap !important;
-    gap: 18px !important;
+    gap: 12px 18px !important;
+    margin-top: 12px !important;
+    padding-top: 12px !important;
   }
   /* Solo-run end & match-end screens */
   [data-mobile-game] .game-end-page {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2992,7 +2992,14 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
 .grp-strip-row {
   display: flex; gap: 10px;
   overflow-x: auto;
+  overflow-y: hidden;
   scrollbar-width: none;
+  /* Tell iOS Safari to keep the horizontal pan smooth, and reserve the
+     touch axis so the parent body's `overflow-x: hidden` doesn't swallow
+     the chips' own pan gesture. */
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-x;
+  overscroll-behavior-x: contain;
   /* Negative inline margin + matching padding lets chips touch the screen
      edge while still scrolling smoothly. */
   margin: 0 calc(-1 * var(--pad));
@@ -3184,11 +3191,41 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
     overflow-x: hidden;
     padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0));
   }
-  footer { padding-bottom: calc(var(--m-bottom) + env(safe-area-inset-bottom, 0)); }
+
+  /* Hide the global footer entirely on mobile — the "openings/endings/
+     OSTs/about/roadmap/moderation-policy/version" cluster is dead weight
+     above the bottom tab bar; the drawer covers everything you'd reach
+     from there. */
+  footer { display: none; }
+
+  /* The desktop search shows a "⌘K" key-cap hint — meaningless on a phone
+     and crowds the input. */
+  .search .kbd { display: none; }
 
   /* Groups: hide the desktop panel, reveal the chip strip. */
   .grp-panel-desktop { display: none; }
   .grp-strip { display: block; }
+
+  /* Without `minmax(0, 1fr)` the home grid's `auto` min-track lets any
+     non-shrinkable child push its column past the viewport — that's how
+     the sort trigger, submit button, contributors panel, and long singer
+     names "go off" the right edge. Force both the catalog column and the
+     side rail to be shrinkable. */
+  .page-grid, .page-grid-left { grid-template-columns: minmax(0, 1fr); }
+  .side, .side-left { min-width: 0; max-width: 100%; }
+  .panel, .auth-card, .submit-card { min-width: 0; max-width: 100%; }
+  .panel-head { min-width: 0; }
+  .panel-head > * { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  /* The sort popup defaults to `right: 0; min-width: 220px;` — that's
+     fine on desktop but on a narrow phone it can extend past the left
+     edge of the viewport, which with overflow-x: hidden simply gets
+     clipped (looking to the user like the dropdown is cut off). Anchor
+     it to viewport gutters instead so it always fits on screen. */
+  .sort-pop { left: var(--pad); right: var(--pad); min-width: 0; }
+  .sort-menu { min-width: 0; }
+  .sort-trigger { max-width: 100%; }
+  .sort-trigger-v { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 }
 
 /* Touch-friendly typography + spacing tweaks below 720. The Home page,


### PR DESCRIPTION
## Summary
- **Rerun button** on the endless run-end screen was a `<Link href="/play/run">` pointing back to the same route — Next.js treats that as a no-op navigation, the page never re-mounts, and the run never restarts. Lifted the start-run effect onto a `runGen` counter and pass an `onRestart` callback that bumps it; the button is now a real `<button>` that triggers a fresh run.
- **Drop "lives regen'd"** stat cell from the run-end summary. Lives don't regenerate anymore, so the value is always zero — the cell stays at 0 forever and confuses players. Stat row goes 4 → 3 columns (longest streak / run length / final score).
- **Mobile horizontal clipping** (sort trigger, submit button, contributors panel, long singer names): the home `.page-grid` was using `1fr` for its columns, which expands to `minmax(auto, 1fr)` — any non-shrinkable descendant pushes the column past the viewport, and with `overflow-x: hidden` on `<body>` the overflow is silently clipped, not scrolled. Switched the columns to `minmax(0, 1fr)`, added `min-width: 0` / `max-width: 100%` on `.side`, `.panel`, `.auth-card`, `.submit-card`, truncated `.panel-head` children with `nowrap + ellipsis`, and anchored `.sort-pop` to viewport gutters (`left: var(--pad); right: var(--pad)`).
- **Groups chip strip** now has `-webkit-overflow-scrolling: touch`, `touch-action: pan-x`, `overscroll-behavior-x: contain` — the horizontal pan was being swallowed by the parent body's `overflow-x: hidden` on iOS Safari.
- **Hide the `<footer>` on mobile** — the openings/endings/OSTs/about/roadmap/moderation-policy/version cluster is dead weight above the bottom tab bar and the drawer already exposes those routes.
- **Hide the desktop `⌘K` key-cap** in `.search` on mobile.

## Test plan
- [ ] End an Endless run, click "Run again" — a brand-new run starts (mode reveal → in-match) rather than staying stuck on the summary.
- [ ] The run-end stat row shows 3 cells: longest streak / run length / final score. No "lives regen'd".
- [ ] On `/` ≤ 720px, the sort trigger, submit card button, top-contributors rows, and long singer/anime names all fit inside the viewport — nothing is cut off on the right.
- [ ] Opening the sort dropdown on mobile shows the menu inside the viewport (not clipped on either side).
- [ ] The Groups chip strip can be swiped horizontally on iOS Safari and Chrome Android when there are enough groups to overflow.
- [ ] No `⌘K` key-cap visible inside the search input on mobile.
- [ ] No footer at the bottom of any page on mobile (drawer still has the same routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)