### PR TITLE
fix(play, reveal): wrong-vs-timeout label, full-screen flash

### DIFF
--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -843,7 +843,7 @@ function RoundEndView({ result, view, meID }: { result: RoundEndData; view: PvPM
   return (
     <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column", position: "relative" }}>
       <MatchHud view={view} scoreOverride={result.score} />
-      <div style={{ position: "absolute", top: 60, left: 0, right: 0, bottom: 0, background: noScore ? `${SOLO.warn}08` : youWon ? `${SOLO.ok}10` : `${SOLO.danger}0d`, pointerEvents: "none" }} />
+      <div style={{ position: "fixed", inset: 0, background: noScore ? `${SOLO.warn}26` : youWon ? `${SOLO.ok}26` : `${SOLO.danger}26`, pointerEvents: "none", zIndex: 50 }} />
       <TimerBar pct={0.4} danger={oppWon} />
       <div className="reveal-page" style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
         <div className="reveal-eyebrow" style={{ position: "absolute", top: 30, left: 40 }}>

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -32,7 +32,7 @@ type Phase =
   | { kind: "starting" }
   | { kind: "mode-reveal"; countdownMs: number; round: SoloRound; run: SoloRun }
   | { kind: "in-match"; round: SoloRound; run: SoloRun; clipPlayedMs: number }
-  | { kind: "reveal"; result: SoloAnswerResponse; nextAt: number; run: SoloRun }
+  | { kind: "reveal"; result: SoloAnswerResponse; nextAt: number; run: SoloRun; timedOut: boolean }
   | { kind: "ended"; run: SoloRun; summary: SoloRunSummary }
   | { kind: "error"; message: string };
 
@@ -165,7 +165,18 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
         anime_id: animeId,
         client_response_ms: Date.now() - inMatchStart.current,
       });
-      setPhase({ kind: "reveal", result: response, nextAt: Date.now() + REVEAL_HOLD_MS, run: response.run });
+      // `animeId === null` only happens via the clip-timer's `submitTimeout`
+      // path — the user never had a chance to guess. Tracking it client-side
+      // lets the reveal screen distinguish a wrong submission ("Wrong · 4.2s")
+      // from an unanswered round ("Time's up · 20.0s"). Backend response
+      // doesn't carry a status flag yet.
+      setPhase({
+        kind: "reveal",
+        result: response,
+        nextAt: Date.now() + REVEAL_HOLD_MS,
+        run: response.run,
+        timedOut: animeId === null,
+      });
     } catch (err: any) {
       setPhase({ kind: "error", message: err?.message ?? "Failed to submit answer" });
     } finally {
@@ -198,7 +209,7 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
           />
         )}
         {phase.kind === "reveal" && (
-          <RevealScreen result={phase.result} run={phase.result.run} />
+          <RevealScreen result={phase.result} run={phase.result.run} timedOut={phase.timedOut} />
         )}
         {phase.kind === "ended" && (
           <RunEndScreen
@@ -473,18 +484,28 @@ function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; r
   );
 }
 
-function RevealScreen({ result, run }: { result: SoloAnswerResponse; run: SoloRun }) {
+function RevealScreen({ result, run, timedOut }: { result: SoloAnswerResponse; run: SoloRun; timedOut: boolean }) {
   const correct = result.round_result.correct;
   const op = result.round_result.correct_opening;
+  // Distinguish the three round outcomes in the eyebrow: a hit, an
+  // unanswered round (clip timer expired), or a submitted-but-wrong guess.
+  const eyebrowText = correct
+    ? `Correct · ${formatResponseMs(result.round_result.your_response_ms)}`
+    : timedOut
+      ? "Time's up · 20.0s"
+      : `Wrong · ${formatResponseMs(result.round_result.your_response_ms)}`;
   return (
     <>
-      <div style={{ position: "absolute", top: 60, left: 0, right: 0, bottom: 0, background: correct ? `${SOLO.ok}10` : `${SOLO.danger}0d`, pointerEvents: "none" }} />
+      {/* Page-wide tint covering the whole stage (including the topbar
+          and HUD) so the success/fail flash isn't visually clipped at
+          the top — previously `top: 60` left a purple strip up top. */}
+      <div style={{ position: "fixed", inset: 0, background: correct ? `${SOLO.ok}26` : `${SOLO.danger}26`, pointerEvents: "none", zIndex: 50 }} />
       <TimerBar pct={0.4} danger={!correct} />
       <Hud run={run} label={correct && result.round_result.life_regen ? "streak +1 · ♥+1" : correct ? "streak +1" : "streak reset"} />
       <div className="reveal-page" style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", padding: 40, position: "relative" }}>
         <div className="reveal-eyebrow" style={{ position: "absolute", top: 30, left: 40 }}>
           <Eyebrow color={correct ? SOLO.ok : SOLO.danger} dotColor={correct ? SOLO.ok : SOLO.danger}>
-            {correct ? `Correct · ${formatResponseMs(result.round_result.your_response_ms)}` : "Time's up · 20.0s"}
+            {eyebrowText}
           </Eyebrow>
         </div>
         <div className="reveal-card" style={{


### PR DESCRIPTION
## Summary
Two complaints on the endless reveal screen, both fixed here:

- **Wrong-answer eyebrow said "Time's up · 20.0s".** The reveal screen hardcoded the non-correct status as a timeout, so submitting a *wrong* anime still showed the unanswered-round label. Thread a `timedOut: boolean` through the reveal phase (set to `animeId === null`, which is the only path that fires the clip-timer's `submitTimeout`) and choose the eyebrow accordingly:
    - correct → `Correct · 4.2s`
    - timed out → `Time's up · 20.0s`
    - wrong submission → `Wrong · 4.2s`

- **Fail/success tint didn't cover the page.** The flash overlay was `position: absolute; top: 60; bottom: 0` with a ~6% alpha — that left the topbar strip un-tinted and was barely visible at the bottom of the viewport on mobile (the user described it as "the bottom keeps the purple color"). Switched both the Solo run and PvP round-end overlays to `position: fixed; inset: 0; z-index: 50` at ~15% alpha so the wash covers the entire viewport (topbar + HUD + reveal stage + mobile tab bar) and reads as a real flash.

## Test plan
- [ ] Submit a *wrong* anime in Endless → reveal shows "Wrong · X.Xs" (not "Time's up").
- [ ] Let the clip timer run out → reveal shows "Time's up · 20.0s".
- [ ] Submit a *correct* anime → reveal shows "Correct · X.Xs".
- [ ] On both Solo run and PvP round-end, the green/red flash covers the whole viewport — top to bottom — including the topbar/HUD and (on mobile) the bottom tab bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)