### PR TITLE
feat(mobile, play): smooth keyboard for in-match search

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -27,7 +27,12 @@ export default function Layout({
       <Head>
         <title>{title}</title>
         <meta name="description" content={description} />
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        {/* `interactive-widget=resizes-content` lets newer Chromium /
+            WebKit shrink the layout viewport when the on-screen keyboard
+            appears, so fixed-bottom inputs (the in-match search bar) ride
+            above the keyboard natively. Older browsers fall back to the
+            useKeyboardInset hook. */}
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
       </Head>
       <Topbar user={user} />

--- a/lib/useKeyboardInset.ts
+++ b/lib/useKeyboardInset.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+
+// Tracks how much of the bottom of the layout viewport the on-screen
+// keyboard is covering, and writes it to a `--kbd-inset` CSS variable on
+// the document root so layout-fixed elements (the in-match search bar +
+// its suggestions) can ride above the keyboard instead of being hidden
+// behind it.
+//
+// Newer Chromium/WebKit honor `env(keyboard-inset-height)` and
+// `<meta name="viewport" content="…, interactive-widget=resizes-content">`
+// natively — on those browsers this hook is a redundant safety net, but
+// it's cheap (one event listener, no re-renders) and degrades gracefully:
+// when `visualViewport` is unavailable the var simply stays unset and the
+// CSS falls back to the `env()` chain.
+export function useKeyboardInset() {
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.visualViewport) return;
+    const vp = window.visualViewport;
+    const root = document.documentElement;
+    const update = () => {
+      const inset = Math.max(0, window.innerHeight - (vp.height + vp.offsetTop));
+      root.style.setProperty("--kbd-inset", `${inset}px`);
+    };
+    update();
+    vp.addEventListener("resize", update);
+    vp.addEventListener("scroll", update);
+    return () => {
+      vp.removeEventListener("resize", update);
+      vp.removeEventListener("scroll", update);
+      root.style.removeProperty("--kbd-inset");
+    };
+  }, []);
+}

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -18,6 +18,7 @@ import {
   type PlayerDisconnectData,
 } from "@/lib/pvp";
 import type { User } from "@/lib/types";
+import { useKeyboardInset } from "@/lib/useKeyboardInset";
 
 interface Props {
   user: User;
@@ -650,6 +651,9 @@ function PlayingView({ view, round, playedMs, meID, score, onSubmit, onTyping }:
   score: Record<string, number>;
   onSubmit: (anime_id: string) => void; onTyping: () => void;
 }) {
+  // See run.tsx — keeps the fixed-bottom search bar above the on-screen
+  // keyboard on mobile.
+  useKeyboardInset();
   const [query, setQuery] = useState("");
   // Anime autocomplete — scoring is anime-based now, so the user
   // picks an anime and any of its openings counts as correct.

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -10,6 +10,7 @@ import type {
   SoloAnswerResponse, SoloOpening, SoloRound, SoloRun, SoloRunSummary,
 } from "@/lib/play";
 import type { User } from "@/lib/types";
+import { useKeyboardInset } from "@/lib/useKeyboardInset";
 
 interface Props {
   user: User | null;
@@ -186,7 +187,13 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
 
   return (
     <>
-      <Head><title>Solo run · Opening Wiki</title></Head>
+      <Head>
+        <title>Solo run · Opening Wiki</title>
+        {/* run.tsx doesn't go through Layout, so it needs its own viewport
+            meta with `interactive-widget=resizes-content` for the smooth
+            on-screen-keyboard handling on supported browsers. */}
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
+      </Head>
       <audio ref={audioRef} preload="auto" />
       <div data-mobile-game style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "100vh", fontFamily: SOLO.sans, display: "flex", flexDirection: "column" }}>
         <TopbarSolo />
@@ -334,6 +341,10 @@ function ModeRevealScreen({ mode, countdownMs, run, round }: { mode: string; cou
 }
 
 function InMatchScreen({ round, run, playedMs, onSubmit }: { round: SoloRound; run: SoloRun; playedMs: number; onSubmit: (animeId: string | null) => void }) {
+  // Keeps `--kbd-inset` on <html> in sync with the on-screen keyboard
+  // height so the fixed-bottom search bar (and its suggestions) ride
+  // above the keyboard instead of being covered.
+  useKeyboardInset();
   const [query, setQuery] = useState("");
   const [suggestions, setSuggestions] = useState<Array<{ id: string; title: string; year: number | null; cover: string | null }>>([]);
   const [activeIdx, setActiveIdx] = useState(0);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3477,8 +3477,30 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
     top: 14px !important; left: 16px !important;
     font-size: 10px !important;
   }
+  /* In-match search bar pins to the bottom of the layout viewport so
+     when the on-screen keyboard appears the bar rides up with it
+     (via `--kbd-inset` from useKeyboardInset on browsers without
+     `interactive-widget=resizes-content` support, or via the layout
+     viewport itself on browsers that do). The waveform/HUD behind it
+     stay put — no page-shake. The fixed bar also creates the
+     containing block for `.game-suggs` so they stack right above it. */
   [data-mobile-game] .game-input {
-    margin: 0 16px 22px !important;
+    position: fixed !important;
+    left: 16px !important;
+    right: 16px !important;
+    /* Stack: keyboard inset (JS) + iOS home-indicator safe area + 16px
+       breathing room. When the keyboard is open iOS reports
+       `safe-area-inset-bottom: 0` because the keyboard occupies that
+       region, so the safe-area term only adds height when the keyboard
+       is *closed* — exactly what we want. */
+    bottom: calc(
+      var(--kbd-inset, env(keyboard-inset-height, 0px))
+      + env(safe-area-inset-bottom, 0px)
+      + 16px
+    ) !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    z-index: 30;
   }
   [data-mobile-game] .game-input input {
     font-size: 16px !important;
@@ -3488,15 +3510,24 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
      blocking the actual text). Hide it on mobile. */
   [data-mobile-game] .game-submit-hint { display: none !important; }
 
-  /* The autocomplete is `position: absolute; bottom: 100%` so its top edge
-     moves up/down as the result count changes — on mobile this reads as
-     the page shaking. Cap the height with a max and let the rows scroll
-     inside, so the visible top edge stays near-stable across queries. */
+  /* The autocomplete is `position: absolute; bottom: 100%` of the now-fixed
+     search bar — so it sits just above the bar regardless of keyboard
+     state. Span the bar's full width (left/right 0 inside the bar's
+     containing block). Cap the height + scroll inside so the top edge
+     stays near-stable across keystrokes. */
   [data-mobile-game] .game-suggs {
-    left: 16px !important; right: 16px !important;
+    left: 0 !important; right: 0 !important;
     max-height: 50vh !important;
     overflow-y: auto !important;
     overscroll-behavior: contain;
+  }
+
+  /* The waveform stage sits in flex flow — give it room at the bottom so
+     the fixed search bar (~64px tall + safe-area + 16px gutter) doesn't
+     cover the "Name the anime. ↵ to submit." hint when the keyboard is
+     closed. */
+  [data-mobile-game] .game-stage {
+    padding-bottom: 110px !important;
   }
   /* Reveal page outer container — desktop has inline `padding: 40` and
      vertical centering, which on a 390px viewport eats 80px of horizontal


### PR DESCRIPTION
## Summary
Stops the in-match search bar from shaking the game UI when the on-screen keyboard opens. The waveform / HUD / timer now stay anchored — only the input bar (and its autocomplete) rides up above the keyboard.

Two-pronged approach so it works across browser versions:

- **CSS, modern browsers (Chromium ≥ 108, WebKit ≥ 17.4)**: viewport meta in `Layout.tsx` (and `run.tsx`, which renders its own `<Head>`) gains `interactive-widget=resizes-content`. The layout viewport shrinks when the keyboard appears, the fixed input rides up natively, and the JS hook becomes a no-op.
- **JS fallback (older browsers)**: new `useKeyboardInset` hook ([lib/useKeyboardInset.ts](lib/useKeyboardInset.ts)) listens on `window.visualViewport` and writes the keyboard height into a `--kbd-inset` CSS variable on `<html>`. Called from `InMatchScreen` (run.tsx) and `PlayingView` (b/[code].tsx) so the variable only exists while the user is actually typing in the game.

CSS hooks up both via:

```css
[data-mobile-game] .game-input {
  position: fixed;
  left: 16px; right: 16px;
  bottom: calc(
    var(--kbd-inset, env(keyboard-inset-height, 0px))
    + env(safe-area-inset-bottom, 0px)
    + 16px
  );
}
```

The suggestions list (the input's absolute child) rides above it at full bar width. `.game-stage` gets `padding-bottom: 110px` so the "Name the anime." hint doesn't slide under the now-fixed bar when the keyboard is closed.

## Test plan
- [ ] Endless run on iOS Safari: tap the input → keyboard slides up, search bar moves with it, the waveform and HUD stay where they were. Close the keyboard → bar settles back to the bottom + safe-area gutter.
- [ ] Same on Chrome Android — the layout viewport shrinks natively, the input pins to the new bottom, no JS-driven jump.
- [ ] PvP match `playing` phase shows the same behavior.
- [ ] Suggestions float just above the input regardless of keyboard state.
- [ ] On older Chromium / Safari (no `interactive-widget` support), the JS hook still keeps the bar above the keyboard.
- [ ] Desktop unchanged — the input still has its original inline `padding: 0 40px 32px` and stays in normal flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)