### PR TITLE
fix(mobile, battle): hide bottom tab bar in PvP match flow

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3184,6 +3184,16 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
      entry with the unread-count badge. */
   .rolebar { display: none; }
 
+  /* PvP battle mode uses Layout, so MobileNav renders its bottom tab bar
+     (z:40, 78px tall) right over the fixed-position in-match search bar.
+     Hide the tab bar throughout the match flow (lobby + playing + end)
+     — each phase has its own back/leave controls, the user doesn't need
+     the global nav while in a game. Endless `run.tsx` already opts out
+     of Layout so it isn't affected, but the `:has()` selector matches
+     either case uniformly. */
+  body:has([data-mobile-game]) .mtabbar { display: none !important; }
+  body:has([data-mobile-game]) .page-body { padding-bottom: 0 !important; }
+
   /* A loose grid cell or a long nowrap string can push the page wider than
      the viewport on phones, especially on the openings tab where some
      anime/singer names are long enough to overflow `.op-meta`. Clamp the


### PR DESCRIPTION
## Summary
Regression from #54: PvP match page (`/play/b/[code]`) goes through Layout, so `MobileNav`'s bottom tab bar (z-index: 40, ~78px tall) covers the fixed-position in-match search input. Endless run isn't affected because `run.tsx` opts out of Layout.

Hide `.mtabbar` whenever the document contains a `[data-mobile-game]` wrapper (the Solo run + PvP match outer divs). Each game phase has its own back / leave controls — the global nav isn't needed while you're in a match. Also zero out `.page-body`'s tab-bar gutter padding in the same scope so the match content can fill the viewport cleanly.

## Test plan
- [ ] PvP match — both during lobby and during the playing phase, no bottom tab bar over the search input.
- [ ] Endless run — unchanged (already no tab bar there).
- [ ] Home / Play hub / other non-game pages — tab bar still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)