### PR TITLE
fix(pvp): lobby flash on refresh, guest ready button doesn't move

### DIFF
--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -11,6 +11,7 @@ import {
   pvpClient,
   PvPSocket,
   type Frame,
+  type MatchStatus,
   type PvPMatchView,
   type RoundStartData,
   type RoundEndData,
@@ -64,6 +65,11 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 
 type Phase =
   | { kind: "lobby" }
+  // Page just loaded into a match that's already past the lobby
+  // (status === "countdown" | "playing"). The WS hasn't connected yet
+  // so we don't have a `round` to render; show a brief reconnect
+  // message instead of the wrong lobby UI.
+  | { kind: "rejoining" }
   | { kind: "countdown"; startsAtMs: number }
   | { kind: "reveal"; round: RoundStartData; countdownMs: number }
   | { kind: "playing"; round: RoundStartData; playedMs: number }
@@ -75,12 +81,29 @@ type Phase =
 const MODE_REVEAL_MS = 2000;
 const ROUND_END_HOLD_MS = 3500;
 
+// Pick the initial phase from the SSR `match.status` so a page refresh
+// mid-match doesn't flash the lobby for the time it takes the WS to
+// connect and replay current state.
+function initialPhaseFromStatus(status: MatchStatus | undefined): Phase {
+  switch (status) {
+    case "ended":
+      return { kind: "error", message: "This match has already ended." };
+    case "cancelled":
+    case "abandoned":
+      return { kind: "error", message: "This match is no longer active." };
+    case "countdown":
+    case "playing":
+      return { kind: "rejoining" };
+    case "lobby":
+    default:
+      return { kind: "lobby" };
+  }
+}
+
 export default function MatchPage({ user, modQueueCount, code, initial }: Props) {
   const router = useRouter();
   const [view, setView] = useState<PvPMatchView | null>(initial);
-  const [phase, setPhase] = useState<Phase>(initial?.match?.status === "ended"
-    ? { kind: "error", message: "This match has already ended." }
-    : { kind: "lobby" });
+  const [phase, setPhase] = useState<Phase>(initialPhaseFromStatus(initial?.match?.status));
   const [socketStatus, setSocketStatus] = useState<"connecting" | "open" | "closed">("connecting");
   // Running score across the whole match, keyed by user_id. Updated
   // on every round.end and the match.end frame so the in-match HUD
@@ -170,6 +193,12 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
           ready: p.ready,
           joined_at: prev.players.find((q) => q.user_id === p.user_id)?.joined_at ?? new Date().toISOString(),
         })) } : prev);
+        // If we landed on the page mid-match (status was "playing"/etc.
+        // on SSR) we're sitting in `rejoining`. Once the server confirms
+        // we're back in the lobby (e.g. the round ended while we were
+        // disconnected) we should fall through to the lobby UI rather
+        // than stay stuck on "Reconnecting…".
+        setPhase((p) => p.kind === "rejoining" ? initialPhaseFromStatus(d.status) : p);
         break;
       }
       case "match.countdown": {
@@ -322,6 +351,9 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
       <Head><meta name="description" content="PvP battle." /></Head>
       <audio ref={audioRef} preload="auto" />
       <div data-mobile-pvp-lobby data-mobile-game style={{ background: SOLO.bg, color: SOLO.fg, minHeight: "calc(100vh - 60px)", fontFamily: SOLO.sans }}>
+        {phase.kind === "rejoining" && (
+          <CenterMessage text="Reconnecting to the match…" />
+        )}
         {phase.kind === "lobby" && (
           <LobbyView
             view={view}
@@ -333,6 +365,7 @@ export default function MatchPage({ user, modQueueCount, code, initial }: Props)
             onCancel={handleCancel}
             isHost={view.you_are === "host"}
             inviteUrl={`${typeof window !== "undefined" ? window.location.origin : ""}/play/b/${view.match.room_code}`}
+            meUserId={user.id}
           />
         )}
         {phase.kind === "countdown" && (
@@ -388,13 +421,20 @@ function CenterMessage({ text, extra }: { text: string; extra?: React.ReactNode 
 }
 
 function LobbyView({
-  view, meReady, opponent, socketStatus, onReady, onLeave, onCancel, isHost, inviteUrl,
+  view, meReady, opponent, socketStatus, onReady, onLeave, onCancel, isHost, inviteUrl, meUserId,
 }: {
   view: PvPMatchView; meReady: boolean; opponent: any; socketStatus: string;
   onReady: () => void; onLeave: () => void; onCancel: () => void;
-  isHost: boolean; inviteUrl: string;
+  isHost: boolean; inviteUrl: string; meUserId: string;
 }) {
-  const me = view.players.find((p) => p.user_id === view.players.find((q) => q.seat === 1)?.user_id);
+  // Cards are seat-positioned (host left, guest right) and the "You"
+  // affordance follows the *viewer*, not the seat. The previous
+  // implementation picked the left card by "the player who isn't the
+  // opponent", which for the guest resolved to themselves but with the
+  // host's ready state — pressing ready as the guest never updated
+  // the visible card.
+  const hostPlayer = view.players.find((p) => p.seat === 1) ?? null;
+  const guestPlayer = view.players.find((p) => p.seat === 2) ?? null;
   const filled = view.players.length === 2 && opponent;
   const allReady = filled && view.players.every((p) => p.ready);
   const copyInvite = async () => {
@@ -429,25 +469,27 @@ function LobbyView({
         </div>
       </div>
 
-      {/* VS panel */}
+      {/* VS panel — left card is always the host (seat 1), right card is
+          always the guest (seat 2). The "You" / "Opponent" affordance
+          tracks the viewer via meUserId. */}
       <div className="vs-panel" style={{ marginTop: 32, display: "grid", gridTemplateColumns: "1fr 80px 1fr", gap: 0, alignItems: "stretch" }}>
         <PlayerCard
-          player={view.players.find((p) => p.user_id !== opponent?.user_id) ?? view.players[0]}
-          variant={isHost ? "you" : "opponent"}
-          label={isHost ? "You · host" : "Host"}
-          ready={view.players.find((p) => p.seat === 1)?.ready ?? false}
+          player={hostPlayer}
+          variant={hostPlayer?.user_id === meUserId ? "you" : "opponent"}
+          label={hostPlayer?.user_id === meUserId ? "You · host" : "Host"}
+          ready={hostPlayer?.ready ?? false}
         />
         <div className="vs-divider" style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", fontFamily: SOLO.mono, fontWeight: 600, fontSize: 20, color: SOLO.fg3, letterSpacing: "0.14em", gap: 14 }}>
           <div className="vs-line" style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
           <div style={{ padding: "8px 0" }}>VS</div>
           <div className="vs-line" style={{ flex: 1, width: 1, background: `linear-gradient(180deg, transparent 0%, ${SOLO.line2} 50%, transparent 100%)` }} />
         </div>
-        {opponent ? (
+        {guestPlayer ? (
           <PlayerCard
-            player={opponent}
-            variant={isHost ? "opponent" : "you"}
-            label={isHost ? "Opponent" : "You"}
-            ready={opponent.ready}
+            player={guestPlayer}
+            variant={guestPlayer.user_id === meUserId ? "you" : "opponent"}
+            label={guestPlayer.user_id === meUserId ? "You" : "Opponent"}
+            ready={guestPlayer.ready}
           />
         ) : (
           <EmptySlot />

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -637,15 +637,15 @@ function RevealView({ mode, countdownMs, view, score }: { mode: string; countdow
   return (
     <div style={{ minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column" }}>
       <MatchHud view={view} scoreOverride={score} />
-      <div style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", textAlign: "center", padding: "80px 40px" }}>
+      <div className="pvp-reveal-stage" style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", textAlign: "center", padding: "80px 40px" }}>
         <Eyebrow>Next round · listen carefully</Eyebrow>
-        <h1 style={{ margin: "20px 0 0", fontWeight: 900, fontSize: 160, letterSpacing: "-0.06em", lineHeight: 0.9, color: SOLO.accent, textShadow: `0 0 60px ${SOLO.accent}55` }}>
+        <h1 className="game-mode-big" style={{ margin: "20px 0 0", fontWeight: 900, fontSize: 160, letterSpacing: "-0.06em", lineHeight: 0.9, color: SOLO.accent, textShadow: `0 0 60px ${SOLO.accent}55` }}>
           {mode.toUpperCase()}
         </h1>
-        <p style={{ marginTop: 24, color: SOLO.fg2, fontSize: 18, maxWidth: 520, lineHeight: 1.45 }}>
+        <p className="pvp-reveal-desc" style={{ marginTop: 24, color: SOLO.fg2, fontSize: 18, maxWidth: 520, lineHeight: 1.45 }}>
           No video, no lyrics. Just the song. Guess the anime as fast as you can — first correct wins the round.
         </p>
-        <div style={{ marginTop: 60, fontFamily: SOLO.mono, fontWeight: 500, fontSize: 120, color: SOLO.fg, letterSpacing: "-0.04em" }}>
+        <div className="pvp-reveal-countdown" style={{ marginTop: 60, fontFamily: SOLO.mono, fontWeight: 500, fontSize: 120, color: SOLO.fg, letterSpacing: "-0.04em" }}>
           {Math.ceil(countdownMs / 1000)}
         </div>
         <div style={{ marginTop: 8, fontFamily: SOLO.mono, fontSize: 11, letterSpacing: "0.18em", textTransform: "uppercase", color: SOLO.fg4 }}>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3475,8 +3475,34 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   [data-mobile-game] .game-stage {
     padding: 20px 16px !important;
   }
+  /* Mode reveal title ("AUDIO", "VISUAL", "LYRICS"…). The desktop sizes
+     are 200px (Solo) / 160px (PvP); on a 360-414px phone either of
+     those overflows the side gutters. `clamp(48px, 16vw, 88px)` scales
+     to viewport width while staying readable — ~58px on a 360px phone
+     (which fits even longer mode names) climbing to 88px on tablets.
+     `overflow-wrap: anywhere` is a safety net for any future mode word
+     that would still overshoot. */
   [data-mobile-game] .game-mode-big {
-    font-size: 96px !important;
+    font-size: clamp(48px, 16vw, 88px) !important;
+    letter-spacing: -0.04em !important;
+    max-width: 100%;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  /* PvP reveal stage uses inline `padding: 80px 40px` — 80px of
+     horizontal gutter eats half the screen on narrow phones. Tighten
+     to match the rest of the mobile chrome. */
+  [data-mobile-game] .pvp-reveal-stage {
+    padding: 32px 16px !important;
+  }
+  [data-mobile-game] .pvp-reveal-desc {
+    font-size: 14px !important;
+    margin-top: 16px !important;
+  }
+  [data-mobile-game] .pvp-reveal-countdown {
+    font-size: 88px !important;
+    margin-top: 36px !important;
   }
   [data-mobile-game] .game-clip-time {
     font-size: 40px !important;


### PR DESCRIPTION
## Summary
Two bugs in `pages/play/b/[code].tsx`:

### 1. Lobby briefly flashes after a mid-match refresh
Initial phase was hardcoded:
```ts
const [phase, setPhase] = useState<Phase>(
  initial?.match?.status === "ended"
    ? { kind: "error", ... }
    : { kind: "lobby" }
);
```
Anything other than `"ended"` (including `"countdown"` and `"playing"`) fell through to the lobby, so refreshing during play painted the lobby UI for the seconds it took the WS to reconnect and replay state.

Added a `rejoining` phase that shows a centered "Reconnecting to the match…" message. The SSR-side `match.status` picks the initial phase via a new `initialPhaseFromStatus` helper. The `lobby.state` frame handler falls out of `rejoining` once the server confirms the actual status (so e.g. mid-round disconnects that end up back in the lobby still resolve cleanly).

### 2. Guest's ready button doesn't visibly move
`LobbyView` picked the left card as "the player whose user_id isn't the opponent's" and the right card as `opponent`. For the host that resolves to (self, opponent) and works fine. For the guest it resolves to (self, host) — but with the labels/variants/ready flags wired backwards:

- Left card: shows the *guest's* display name, with variant `"opponent"`, label `"Host"`, and the *host's* ready state.
- Right card: shows the *host's* data, with variant `"you"`, label `"You"`, and the *host's* ready state.

So pressing "Ready" as the guest toggled their server-side flag (host sees the correct change), but the guest's visible "You" card showed the *host's* unchanged ready state.

Both cards are now seat-positioned (host left, seat 1; guest right, seat 2) and the "You" label tracks the viewer via a new `meUserId` prop.

## Test plan
- [ ] Host opens a match, starts the round, guest joins from another browser, both ready up — match starts. Refresh either player's tab mid-round: the page shows "Reconnecting to the match…" briefly, then settles into the current round (or back to the lobby if the round ended in between). No lobby flash.
- [ ] Guest presses Ready in the lobby — their own "You" card flips to "Ready" immediately, and the host's view shows "Opponent · Ready" as before.
- [ ] Host presses Ready — host's own card flips to "Ready", guest sees "Host · Ready".
- [ ] Both ready → match starts after the 3s countdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)