### PR TITLE
feat(submit+catalog): require sequence_number + romaji, surface OP/ED prefix, search English

### DIFF
--- a/components/OpeningCard.tsx
+++ b/components/OpeningCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Opening } from "@/lib/types";
+import { formatSequenceLabel } from "@/lib/openings";
 import { youtubeThumbnail } from "@/lib/youtube";
 
 interface Props {
@@ -51,6 +52,12 @@ export default function OpeningCard({ op, newLabel }: Props) {
           </h3>
           <div className="op-meta">
             <span>{op.anime.name}</span>
+            {formatSequenceLabel(op.kind, op.sequence_number) && (
+              <>
+                <span className="sep"> · </span>
+                <span className="op-seq">{formatSequenceLabel(op.kind, op.sequence_number)}</span>
+              </>
+            )}
             <span className="sep"> · </span>
             <span>{op.singer.name}</span>
           </div>

--- a/lib/mock.ts
+++ b/lib/mock.ts
@@ -83,6 +83,7 @@ function buildOpening(i: number): Opening {
     title: TITLES[i],
     youtube_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
     kind: "opening",
+    sequence_number: 1,
     anime: { id: `a_${i + 1}`, name: ANIME_NAMES[i] },
     singer: { id: `s_${i + 1}`, name: SINGER_NAMES[i] },
     status: "approved",

--- a/lib/openings.ts
+++ b/lib/openings.ts
@@ -1,0 +1,21 @@
+// Helpers for rendering opening metadata consistently across surfaces.
+
+import type { TrackKind } from "./types";
+
+// Formats an opening's "OP1" / "ED2" prefix from kind + sequence_number.
+//
+//   formatSequenceLabel("opening", 1) === "OP1"
+//   formatSequenceLabel("ending",  2) === "ED2"
+//   formatSequenceLabel("ost",     null) === ""
+//
+// OSTs deliberately have no sequence number (and the API enforces NULL),
+// so the prefix is suppressed. Same for the defensive null-on-non-OST
+// case: if the row predates the migration backfill the UI just shows
+// the title with no prefix rather than rendering "OP" / "ED" with a
+// missing number.
+export function formatSequenceLabel(kind: TrackKind, sequenceNumber: number | null): string {
+  if (sequenceNumber == null) return "";
+  if (kind === "opening") return `OP${sequenceNumber}`;
+  if (kind === "ending") return `ED${sequenceNumber}`;
+  return "";
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -45,6 +45,10 @@ export interface AnimeAutocompleteItem {
   id: string;
   name: string;
   title_romaji: string;
+  // Empty string when the row has no English title. The picker UI
+  // renders this as the dropdown sublabel so a user typing in English
+  // can confirm they picked the right anime.
+  title_english: string;
   format: AnimeFormat;
   year: number;
 }
@@ -60,6 +64,10 @@ export interface Opening {
   title: string;
   youtube_url: string;
   kind: TrackKind;
+  // OP/ED number (1, 2, …). Always non-null for kind "opening" /
+  // "ending" (enforced by openings_sequence_required_for_op_ed in
+  // migration 000014); always null for kind "ost".
+  sequence_number: number | null;
   anime: Pick<Anime, "id" | "name">;
   singer: Pick<Singer, "id" | "name">;
   legacy_anime_name?: string | null;
@@ -240,6 +248,8 @@ export interface GroupOpening {
   id: string;
   title: string;
   youtube_url: string;
+  kind: TrackKind;
+  sequence_number: number | null;
   avg_rating: number;
   rating_count: number;
   anime: { id: string; name: string; cover_image_url: string | null };

--- a/pages/anime/[id].tsx
+++ b/pages/anime/[id].tsx
@@ -83,9 +83,15 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
     return (a.sequence_number ?? 99) - (b.sequence_number ?? 99);
   });
 
-  const displayName = anime.title_english ?? anime.title_romaji ?? anime.name;
+  // Romaji is the canonical title (always present, NOT NULL since
+  // 000009). English is the secondary line beneath it; if there's no
+  // English title, fall back to the catalog `name` so the heading
+  // doesn't lose its English-readable form entirely.
+  const displayName = anime.title_romaji || anime.name;
+  const englishTitle = anime.title_english && anime.title_english !== displayName
+    ? anime.title_english
+    : (anime.name && anime.name !== displayName ? anime.name : null);
   const nativeTitle = anime.title_native;
-  const romajiTitle = anime.title_romaji !== displayName ? anime.title_romaji : null;
 
   const leadParts: string[] = [];
   if (anime.year) leadParts.push(String(anime.year));
@@ -144,8 +150,13 @@ export default function AnimePage({ user, modQueueCount, anime }: Props) {
           <div className="anime-hero-meta">
             <div className="anime-eyebrow">Anime</div>
             <h1 className="anime-title">{displayName}</h1>
+            {/* Reuse the existing .anime-romaji class for the
+                secondary line — the visual treatment ("mono, dim,
+                margin-bottom 18px") is the same whether we're
+                showing romaji-beneath-english or, now,
+                english-beneath-romaji. */}
+            {englishTitle && <div className="anime-romaji">{englishTitle}</div>}
             {nativeTitle && <div className="anime-native">{nativeTitle}</div>}
-            {romajiTitle && <div className="anime-romaji">{romajiTitle}</div>}
             {leadParts.length > 0 && (
               <div className="anime-lead">
                 {leadParts.map((p, i) => (

--- a/pages/g/[slug].tsx
+++ b/pages/g/[slug].tsx
@@ -37,7 +37,6 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 function asOpening(item: GroupOpening): Opening {
   return {
     ...item,
-    kind: "opening",
     status: "approved",
     submitted_by_user_id: "",
     submitted_at: "",

--- a/pages/groups/[id].tsx
+++ b/pages/groups/[id].tsx
@@ -52,11 +52,10 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
 
 // OpeningCard expects the full Opening shape. Group payloads only carry the
 // card-level fields, so fill the rest with neutral defaults — the card never
-// reads them.
+// reads them. (kind + sequence_number now come from the API.)
 function asOpening(item: GroupOpening): Opening {
   return {
     ...item,
-    kind: "opening",
     status: "approved",
     submitted_by_user_id: "",
     submitted_at: "",

--- a/pages/openings/[id].tsx
+++ b/pages/openings/[id].tsx
@@ -1,6 +1,7 @@
 import type { GetServerSideProps } from "next";
 import Link from "next/link";
 import Layout from "@/components/Layout";
+import { formatSequenceLabel } from "@/lib/openings";
 import { youtubeEmbedURL, youtubeThumbnail } from "@/lib/youtube";
 import RatingPopup from "@/components/RatingPopup";
 import CommentsSection from "@/components/CommentsSection";
@@ -413,6 +414,15 @@ export default function OpeningDetail({
                 <h1 className="detail-title">{op.title}</h1>
                 <div className="detail-sub">
                   <Link href={`/anime/${op.anime.id}`} className="detail-link">{op.anime.name}</Link>
+                  {/* "Naruto · OP1 · Asian Kung-Fu Generation" — OST rows
+                      have no sequence_number, so the prefix is skipped
+                      and the row collapses to "Naruto · Yasha". */}
+                  {formatSequenceLabel(op.kind, op.sequence_number) && (
+                    <>
+                      <span className="detail-sep"> · </span>
+                      <span className="detail-seq">{formatSequenceLabel(op.kind, op.sequence_number)}</span>
+                    </>
+                  )}
                   <span className="detail-sep"> · </span>
                   <Link href={`/singers/${op.singer.id}`} className="detail-link">{op.singer.name}</Link>
                 </div>

--- a/pages/singers/[id].tsx
+++ b/pages/singers/[id].tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Layout from "@/components/Layout";
 import LocalSortDropdown from "@/components/LocalSortDropdown";
 import { getSinger } from "@/lib/api";
+import { formatSequenceLabel } from "@/lib/openings";
 import { loadSession } from "@/lib/session";
 import { youtubeThumbnail } from "@/lib/youtube";
 import type { SingerDetail, SingerOpening, TrackKind, User } from "@/lib/types";
@@ -36,8 +37,11 @@ function kindTag(kind: TrackKind): "OP" | "ED" | "OST" {
 }
 
 function kindLabel(op: SingerOpening): string {
-  const tag = kindTag(op.kind);
-  return op.sequence_number != null ? `${tag} ${op.sequence_number}` : tag;
+  // Use the shared formatter so the "OP1" / "ED2" format matches what
+  // OpeningCard and the opening detail page render. OST rows have no
+  // sequence number → return just the kind tag.
+  const seq = formatSequenceLabel(op.kind, op.sequence_number);
+  return seq || kindTag(op.kind);
 }
 
 function kindClass(kind: TrackKind): "op" | "ed" | "ost" {

--- a/pages/submit.tsx
+++ b/pages/submit.tsx
@@ -32,13 +32,24 @@ async function fetchAnimeItems(q: string): Promise<AutocompleteItem[]> {
   if (!res.ok) return [];
   const payload = await res.json();
   const items = Array.isArray(payload.data) ? payload.data : [];
-  return items.map((a: any) => ({
-    id: a.id,
-    label: a.name,
-    coverUrl: a.cover_image_url ?? null,
-    iconShape: "square" as const,
-    sublabel: a.year ? `${a.year} · ${(a.format ?? "").toUpperCase().replace("_", " ")}` : undefined,
-  }));
+  return items.map((a: any) => {
+    // sublabel: English title (when present) followed by year / format.
+    // The English line lets a user confirm they picked the right anime
+    // even when they're searching in English while the row is keyed
+    // on romaji.
+    const tail = a.year ? `${a.year} · ${(a.format ?? "").toUpperCase().replace("_", " ")}` : "";
+    const english = (a.title_english ?? "").trim();
+    const sublabel = english
+      ? (tail ? `${english} · ${tail}` : english)
+      : (tail || undefined);
+    return {
+      id: a.id,
+      label: a.name,
+      coverUrl: a.cover_image_url ?? null,
+      iconShape: "square" as const,
+      sublabel,
+    };
+  });
 }
 
 async function fetchSingerItems(q: string): Promise<AutocompleteItem[]> {
@@ -63,12 +74,12 @@ function Sidebar({ tab }: { tab: Tab }) {
   const tips: Record<Tab, React.ReactNode[]> = {
     opening: [
       <><strong>Official upload preferred</strong> — Crunchyroll, the studio, or the artist&apos;s channel.</>,
-      <>Title in romaji or English — no season abbreviations (OP1, OP2 etc.).</>,
+      <>Title is the song name only (romaji or English) — the OP/ED number goes in the separate sequence-number field.</>,
       <>If the anime or singer isn&apos;t in the database yet, submit it first from the other tabs.</>,
     ],
     anime: [
       <>Use the <strong>AniList link</strong> as the reference — it&apos;s the easiest for mods to verify.</>,
-      <>Romaji title is the canonical key — spell it consistently with AniList.</>,
+      <>Romaji title is required — it&apos;s the canonical key, spell it consistently with AniList.</>,
       <>Sequels and side stories should be separate entries if they have their own OPs.</>,
     ],
     singer: [
@@ -130,11 +141,26 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
   const [kind, setKind] = useState<TrackKind>("opening");
   const [title, setTitle] = useState("");
   const [youtubeUrl, setYoutubeUrl] = useState("");
+  // sequenceNumber is the OP/ED number. Required when kind is
+  // "opening" or "ending" (CHECK constraint added in migration
+  // 000014 forbids NULLs for non-OST). Hidden when kind is "ost" —
+  // OSTs deliberately don't carry a sequence number. Kept as a
+  // string in the input state so the field can be cleared, parsed to
+  // a number on submit.
+  const [sequenceNumber, setSequenceNumber] = useState<string>("");
   const [selectedAnime, setSelectedAnime] = useState<AutocompleteItem | null>(null);
   const [selectedSinger, setSelectedSinger] = useState<AutocompleteItem | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+
+  // Clear the sequence field when switching to OST so a leftover value
+  // doesn't get sent to the API (the backend rejects sequence_number
+  // on OST submissions).
+  const setKindClamped = (next: TrackKind) => {
+    setKind(next);
+    if (next === "ost") setSequenceNumber("");
+  };
 
   const fetchAnime = useCallback(fetchAnimeItems, []);
   const fetchSinger = useCallback(fetchSingerItems, []);
@@ -146,6 +172,19 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
     if (!youtubeUrl.trim()) errs.youtube_url = "YouTube URL is required";
     if (!selectedAnime) errs.anime_id = "Select an anime";
     if (!selectedSinger) errs.singer_id = "Select a singer";
+    // Sequence-number client-side guard. The backend re-validates the
+    // same rule, so this is just for snappier feedback — server-side
+    // errors still flow through `setFieldErrors(err.fields)` below.
+    let parsedSeq: number | null = null;
+    if (kind !== "ost") {
+      const trimmed = sequenceNumber.trim();
+      const n = parseInt(trimmed, 10);
+      if (!trimmed || Number.isNaN(n) || n < 1) {
+        errs.sequence_number = "Sequence number is required (e.g. 1 for OP1)";
+      } else {
+        parsedSeq = n;
+      }
+    }
     if (Object.keys(errs).length > 0) { setFieldErrors(errs); return; }
 
     setSubmitting(true);
@@ -159,6 +198,9 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
         title: title.trim(),
         youtube_url: youtubeUrl.trim(),
         kind,
+        // null for OST — the backend rejects a non-null sequence
+        // number when kind is ost, by design.
+        sequence_number: parsedSeq,
         anime_id: selectedAnime!.id,
         singer_id: selectedSinger!.id,
       }),
@@ -203,7 +245,7 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
                 key={opt.value}
                 type="button"
                 className={`sub-type-pick ${opt.cls}${kind === opt.value ? " on" : ""}`}
-                onClick={() => setKind(opt.value)}
+                onClick={() => setKindClamped(opt.value)}
               >
                 <div className="tp-row">
                   <span className="tp-tag">{opt.tag}</span>
@@ -225,6 +267,24 @@ function OpeningPane({ onSwitchTab }: { onSwitchTab: (t: Tab) => void }) {
             <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Song name (romaji or english) — e.g. Mukanjyo" />
             {fieldErrors.title && <span className="ferr">{fieldErrors.title}</span>}
           </div>
+          {kind !== "ost" && (
+            <div className="sub-row">
+              <label>
+                Sequence number <span className="req">*</span>
+                <span className="sub-hint"> ({kind === "ending" ? "ED1, ED2…" : "OP1, OP2…"})</span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                value={sequenceNumber}
+                onChange={(e) => setSequenceNumber(e.target.value)}
+                placeholder="1"
+              />
+              {fieldErrors.sequence_number && <span className="ferr">{fieldErrors.sequence_number}</span>}
+            </div>
+          )}
 
           <div className="sub-section"><span className="sub-step">03</span> Anime &amp; singer</div>
           <div className="sub-grid-2">
@@ -311,6 +371,7 @@ function AnimePane() {
   };
 
   const [f, setF] = useState({
+    title_romaji: "",
     title_english: "",
     year: "", format: "tv" as AnimeFormat,
     reference_url: "",
@@ -357,7 +418,8 @@ function AnimePane() {
     setImportQuery("");
     setImportResults([]);
     setF({
-      title_english: item.title_english || item.title_romaji,
+      title_romaji: item.title_romaji,
+      title_english: item.title_english,
       year: item.year ? String(item.year) : "",
       format: item.format,
       reference_url: item.reference_url,
@@ -397,6 +459,7 @@ function AnimePane() {
     e.preventDefault();
     const errs: Record<string, string> = {};
     if (!coverKey) errs.cover_image_key = "Cover image is required";
+    if (!f.title_romaji.trim()) errs.title_romaji = "Romaji title is required";
     if (!f.title_english.trim()) errs.title_english = "English title is required";
     if (!f.year.trim()) errs.year = "Year is required";
     if (!f.reference_url.trim()) errs.reference_url = "Reference link is required";
@@ -428,7 +491,7 @@ function AnimePane() {
         <div className="sub-form-body" style={{ textAlign: "center", padding: "48px 26px" }}>
           <p style={{ fontSize: 16, marginBottom: 20 }}>Anime submitted for review ✓</p>
           <p className="hint" style={{ marginBottom: 24 }}>Once a mod approves it, it will appear in the anime picker on the Opening tab.</p>
-          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ title_english: "", year: "", format: "tv", reference_url: "" }); setCoverKey(""); setCoverPreviewUrl(null); }}>
+          <button type="button" className="btn" onClick={() => { setSuccess(false); setF({ title_romaji: "", title_english: "", year: "", format: "tv", reference_url: "" }); setCoverKey(""); setCoverPreviewUrl(null); }}>
             Submit another
           </button>
         </div>
@@ -502,6 +565,12 @@ function AnimePane() {
           {fieldErrors.cover_image_key && <span className="ferr">{fieldErrors.cover_image_key}</span>}
 
           <div className="sub-section"><span className="sub-step">02</span> Title</div>
+          <div className="sub-row">
+            <label>Romaji title <span className="req">*</span></label>
+            <input type="text" value={f.title_romaji} onChange={set("title_romaji")} placeholder="Shingeki no Kyojin" />
+            <span className="hint">Canonical key — required. Picker matches both romaji and English.</span>
+            {fieldErrors.title_romaji && <span className="ferr">{fieldErrors.title_romaji}</span>}
+          </div>
           <div className="sub-row">
             <label>English title <span className="req">*</span></label>
             <input type="text" value={f.title_english} onChange={set("title_english")} placeholder="Attack on Titan" />


### PR DESCRIPTION
## Summary

Frontend half of the required-`sequence_number` / required-`title_romaji` / romaji+English-search tightening. Backend ships in [openingwiki/backend#52](https://github.com/openingwiki/backend/pull/52) — **merge backend first**; without the new `title_english` field on `/anime/search` the picker sublabel falls back to blank (hidden) but doesn't break.

1. **Opening submit form** — required \`sequence_number\` input gated on the selected kind. Shown for opening/ending; hidden for ost. Submitted as \`null\` when kind is ost so the backend's "OST ⇒ NULL" invariant flows through. Inline validation + server-side \`fields.sequence_number\` mirroring.

2. **Anime submit form** — required \`title_romaji\` input added above \`title_english\`, with copy that says romaji is the canonical key (and the picker now matches both). The sidebar Tips list flips from "canonical" wording to "required" wording.

3. **Types** — \`Opening.sequence_number\` and \`GroupOpening.kind\` + \`.sequence_number\` added; \`AnimeAutocompleteItem\` gains \`title_english\` so the picker sublabel is typed.

4. **Picker sublabel** — \`fetchAnimeItems\` now renders "english · year · format" so a user typing in English can confirm the right anime even if the row is keyed on romaji.

5. **Display surfaces** — new \`lib/openings.ts::formatSequenceLabel(kind, sequence_number)\` returns \`OP1\` / \`ED2\` for the right kinds and \`""\` for ost. Used on \`OpeningCard\`, the opening detail page, and the singer detail listings. Moderation queue already exposed \`sequence_number\` on opening rows.

6. **Anime detail header** — romaji is the canonical H1 (matches the submit-form ordering and the "title_romaji is the canonical key" rule). English title sits beneath as a secondary line; falls back to \`.name\` if \`title_english\` is null.

## Test plan

- [ ] Visit \`/submit\`, opening tab: switching between OP / ED / OST shows the right helper text on the sequence-number input; switching to OST hides the input and clears any leftover value.
- [ ] Visit \`/submit\`, anime tab: a submission with empty Romaji is blocked inline; with a romaji value the post succeeds.
- [ ] Type a known English-only string in the anime picker: result row shows up with the English title in the sublabel.
- [ ] Visit \`/openings/<id>\` for an opening/ending: meta line shows \`<anime> · OP1 · <singer>\`. For an OST: \`<anime> · <singer>\` (no prefix).
- [ ] Visit \`/anime/<id>\`: heading is romaji, English appears as a secondary line below.
- [ ] Visit \`/mod/queue\`: pending opening rows surface \`Sequence #\` (already wired, sanity check).