### PR TITLE
feat(edit+my-submissions): sequence_number editor + OP/ED prefix on every opening surface

### DIFF
--- a/pages/my-submissions.tsx
+++ b/pages/my-submissions.tsx
@@ -194,8 +194,14 @@ function SubmissionRow({ item }: { item: MySubmissionItem }) {
 function renderTypeTag(item: MySubmissionItem) {
   if (item.type === "opening") {
     const k = (item.kind ?? "opening").toString();
-    const label = k === "opening" ? "OP" : k === "ending" ? "ED" : "OST";
     const klass = k === "opening" ? "op" : k === "ending" ? "ed" : "ost";
+    // OP/ED tags include the sequence number when present (OP1, ED2);
+    // OST stays bare. Mirrors the rest of the site's badge format
+    // for inter-page consistency.
+    let label: string;
+    if (k === "opening") label = item.sequence_number != null ? `OP${item.sequence_number}` : "OP";
+    else if (k === "ending") label = item.sequence_number != null ? `ED${item.sequence_number}` : "ED";
+    else label = "OST";
     return <span className={`ms-tag ${klass}`}>{label}</span>;
   }
   if (item.type === "anime") return <span className="ms-tag anime">Anime</span>;

--- a/pages/openings/[id]/edit.tsx
+++ b/pages/openings/[id]/edit.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/router";
 import { useState, useCallback, useRef, useEffect } from "react";
 import Layout from "@/components/Layout";
 import { getAnime, getOpening, getSinger } from "@/lib/api";
+import { formatSequenceLabel } from "@/lib/openings";
 import { loadSession } from "@/lib/session";
 import { pushToast } from "@/lib/toast";
 import { youtubeEmbedURL } from "@/lib/youtube";
@@ -182,17 +183,36 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
   const [title, setTitle] = useState(opening.title);
   const [youtubeUrl, setYoutubeUrl] = useState(opening.youtube_url);
   const [kind, setKind] = useState<TrackKind>(opening.kind);
+  // Edit-form state is a string so the input can be blank between
+  // edits without coercing 0 into the payload. Cleared automatically
+  // when the user flips to "ost" since OSTs may not carry a number.
+  const [sequenceNumber, setSequenceNumber] = useState<string>(
+    opening.sequence_number != null ? String(opening.sequence_number) : ""
+  );
   const [anime, setAnime] = useState<EntityItem>({ id: opening.anime.id, name: opening.anime.name, coverUrl: animeCoverUrl });
   const [singer, setSinger] = useState<EntityItem>({ id: opening.singer.id, name: opening.singer.name, coverUrl: singerCoverUrl });
 
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
+  // setKindClamped mirrors the submit form: clearing the sequence
+  // input on a switch-to-ost keeps the wire body invariant
+  // (sequence_number: null for ost) without forcing the user to
+  // delete the digits manually.
+  const setKindClamped = (next: TrackKind) => {
+    setKind(next);
+    if (next === "ost") setSequenceNumber("");
+  };
+
+  const parsedSeq = parseInt(sequenceNumber.trim(), 10);
+  const currentSeqStr = opening.sequence_number != null ? String(opening.sequence_number) : "";
   const isDirty =
     title !== opening.title ||
     youtubeUrl !== opening.youtube_url ||
     kind !== opening.kind ||
+    sequenceNumber !== currentSeqStr ||
     anime.id !== opening.anime.id ||
     singer.id !== opening.singer.id;
 
@@ -206,6 +226,20 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
 
   const save = async () => {
     if (saving) return;
+    // Client-side guard before the network round-trip; the backend
+    // re-validates the same rule and surfaces fields.sequence_number
+    // for slower feedback.
+    const localErrs: Record<string, string> = {};
+    let sequencePayload: number | null = null;
+    if (kind !== "ost") {
+      if (!sequenceNumber.trim() || Number.isNaN(parsedSeq) || parsedSeq < 1) {
+        localErrs.sequence_number = "Sequence number is required (e.g. 1 for OP1)";
+      } else {
+        sequencePayload = parsedSeq;
+      }
+    }
+    if (Object.keys(localErrs).length > 0) { setFieldErrors(localErrs); return; }
+    setFieldErrors({});
     setSaving(true);
     try {
       const res = await fetch("/api/admin/opening-update", {
@@ -216,13 +250,17 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
           title: title.trim(),
           youtube_url: youtubeUrl.trim(),
           kind,
+          // null for ost — the backend rejects non-null on OST, by
+          // design. The wire shape is the same as POST /openings.
+          sequence_number: sequencePayload,
           anime_id: anime.id,
           singer_id: singer.id,
         }),
       });
       if (!res.ok && res.status !== 204) {
         const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error ?? `Save failed (${res.status})`);
+        if (body?.error?.fields) setFieldErrors(body.error.fields);
+        throw new Error(body?.error?.message ?? body?.error ?? `Save failed (${res.status})`);
       }
       pushToast({ kind: "success", message: "Opening updated" });
       router.push(`/openings/${opening.id}`);
@@ -258,7 +296,12 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
     }
   };
 
-  const displayName = opening.title;
+  // "OP1 · Rocks" if the opening has a sequence number, just the
+  // title otherwise. Used for the page title, breadcrumb, heading,
+  // and delete-confirm copy so the moderator always sees the same
+  // canonical name.
+  const seqLabel = formatSequenceLabel(opening.kind, opening.sequence_number);
+  const displayName = seqLabel ? `${seqLabel} · ${opening.title}` : opening.title;
 
   return (
     <Layout
@@ -272,7 +315,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
         <div className="edit-crumb">
           <Link href="/">Home</Link>
           <span className="edit-crumb-sep">/</span>
-          <Link href={`/openings/${opening.id}`}>{opening.title}</Link>
+          <Link href={`/openings/${opening.id}`}>{displayName}</Link>
           <span className="edit-crumb-sep">/</span>
           <span className="edit-crumb-here">Edit</span>
         </div>
@@ -329,7 +372,19 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
                     <div className="edit-pi-row">
                       <div className="edit-pi-cell">
                         <span className="edit-pi-lbl">Title</span>
-                        <span className="edit-pi-val">{title || opening.title}</span>
+                        <span className="edit-pi-val">
+                          {/* Live "OP1 · Rocks" preview — falls back
+                              to bare title when kind=ost or the input
+                              is empty mid-edit. */}
+                          {(() => {
+                            const seqLive = kind === "ost"
+                              ? null
+                              : (Number.isNaN(parsedSeq) ? null : parsedSeq);
+                            const seqLabel = formatSequenceLabel(kind, seqLive);
+                            const titleText = title || opening.title;
+                            return seqLabel ? `${seqLabel} · ${titleText}` : titleText;
+                          })()}
+                        </span>
                       </div>
                       <div className="edit-pi-cell">
                         <span className="edit-pi-lbl">Type</span>
@@ -373,7 +428,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
                       key={opt.value}
                       type="button"
                       className={`edit-type-pick${kind === opt.value ? " on" : ""}`}
-                      onClick={() => setKind(opt.value)}
+                      onClick={() => setKindClamped(opt.value)}
                     >
                       <span className="edit-type-tag">{opt.tag}</span>
                       <span className="edit-type-nm">{opt.label}</span>
@@ -413,6 +468,28 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
                     onChange={(e) => setTitle(e.target.value)}
                   />
                 </div>
+                {kind !== "ost" && (
+                  <div className={`edit-row${sequenceNumber !== currentSeqStr ? " dirty" : ""}`}>
+                    <label className="edit-label">
+                      Sequence number <span className="edit-req">*</span>
+                      <span className="edit-hint" style={{ marginLeft: 8 }}>
+                        ({kind === "ending" ? "ED1, ED2…" : "OP1, OP2…"})
+                      </span>
+                      {sequenceNumber !== currentSeqStr && <span className="edit-changed">unsaved</span>}
+                    </label>
+                    <input
+                      type="number"
+                      min={1}
+                      step={1}
+                      inputMode="numeric"
+                      className="edit-input"
+                      value={sequenceNumber}
+                      onChange={(e) => setSequenceNumber(e.target.value)}
+                      placeholder="1"
+                    />
+                    {fieldErrors.sequence_number && <span className="edit-hint" style={{ color: "var(--danger)" }}>{fieldErrors.sequence_number}</span>}
+                  </div>
+                )}
               </div>
             </div>
 
@@ -527,7 +604,7 @@ export default function OpeningEditPage({ user, modQueueCount, opening, embedUrl
           <div className="admin-modal" onClick={(e) => e.stopPropagation()}>
             <h2 className="admin-modal-title">Delete this opening?</h2>
             <p className="admin-modal-body">
-              You&apos;re about to permanently remove <strong>{opening.title}</strong>.
+              You&apos;re about to permanently remove <strong>{displayName}</strong>.
               All ratings and comments tied to it will remain in the database, but the
               opening disappears from the catalogue and all groups.
             </p>


### PR DESCRIPTION
## Summary

Two gaps from #61 (now merged):

1. **\`/openings/<id>/edit\` had no field for the OP/ED number.** A moderator could never correct the placeholder values that migration 000014's backfill assigned. Adds a kind-gated input below Title (required for opening/ending, hidden + cleared on switch-to-OST). The live preview row now reads \`OP1 · Rocks\` so the moderator can confirm the rendered name before saving. Heading, breadcrumb, and delete-confirm copy all use the prefixed name as well.

   Save sends \`sequence_number: null\` for OST so the wire shape matches \`POST /openings\`. Server-side \`fields.sequence_number\` errors surface inline.

2. **\`/my-submissions\` used bare \`OP\` / \`ED\` / \`OST\` badges.** Now renders \`OP1\` / \`ED2\` when \`sequence_number\` is present, matching the badge format on the home cards and opening detail. OST stays bare.

Pairs with [openingwiki/backend#53](https://github.com/openingwiki/backend/pull/53) which actually accepts \`sequence_number\` on the admin update endpoint. **Merge that first** — without it the form will surface a 400 from the backend when the field is sent.

## Test plan

- [ ] Open an existing opening as admin → \`/edit\`. The sequence number is pre-filled. Change it, save, confirm the new value reflects on the public detail page.
- [ ] Switch a row's kind from "opening" to "ost" — the sequence input disappears and the value is sent as null.
- [ ] Open \`/my-submissions\` with at least one OP-kind row — the badge reads \`OP1\` (or whichever number the row carries) instead of bare \`OP\`.