### PR TITLE
fix(play): rate popup escapes reveal-card clipping via portal + clear

### DIFF
--- a/components/MatchRatePopup.tsx
+++ b/components/MatchRatePopup.tsx
@@ -1,0 +1,248 @@
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { pushToast } from "@/lib/toast";
+import type { RateResponse } from "@/lib/types";
+
+interface Props {
+  // Opening to rate. Changing this clears the locally-tracked score so
+  // the next reveal card opens with a clean trigger.
+  openingId: string;
+  // null when the viewer is anonymous — we render a "Log in to rate"
+  // link instead of opening a popover. signedIn is preferred over a
+  // generic disabled state so the link gives the user a path forward.
+  signedIn: boolean;
+}
+
+// MatchRatePopup — rate-this-opening control surfaced on every reveal
+// card in the match flow (Solo Endless `RevealScreen` and PvP
+// `RoundEndView`). Mirrors the behavior of `components/RatingPopup`
+// from /openings/[id]: 1–10 picker, clear, outside-click + Escape
+// close, toasts on save/fail. Differences from the catalog popup:
+//
+//   1. The popover renders through a React portal, anchored to the
+//      trigger by `getBoundingClientRect()` + position:fixed. The
+//      reveal card is a flex layout with `overflow: hidden` (for the
+//      glow-ring inset), which used to clip a position:absolute
+//      child popover off the bottom — that was the bug we were asked
+//      to fix here. A portal sidesteps any ancestor clipping.
+//
+//   2. The trigger compresses to a square icon button on mobile so
+//      it fits next to the existing action row without wrapping.
+//
+//   3. We don't show avg/count next to the trigger — the reveal card
+//      already prints "community ★ X.X" in its stats row, so a second
+//      number would be visual noise.
+//
+//   4. Rating state is local: we don't preload the viewer's prior
+//      score from the round payload (it isn't there). The button
+//      shows "Rate" until the user picks a number, then "Rated N".
+//      Clearing reverts to "Rate".
+export default function MatchRatePopup({ openingId, signedIn }: Props) {
+  const [open, setOpen] = useState(false);
+  const [score, setScore] = useState<number | null>(null);
+  const [hover, setHover] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [anchor, setAnchor] = useState<{ left: number; top: number; right: number; bottom: number } | null>(null);
+  const [openUp, setOpenUp] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const popRef = useRef<HTMLDivElement>(null);
+  const previewScore = hover ?? score ?? 0;
+
+  // Reset local state when the opening changes — reveal advances
+  // every few seconds, so the popover for round N shouldn't carry
+  // state into round N+1.
+  useEffect(() => {
+    setOpen(false);
+    setScore(null);
+    setHover(null);
+    setAnchor(null);
+  }, [openingId]);
+
+  // Anchor calculation. Runs when we open the popup and on resize/
+  // scroll while open so the popover tracks the trigger. We measure
+  // the trigger's viewport rect and let the popover render with
+  // position:fixed at those coords. The popover decides up-vs-down
+  // based on whether there's at least ~240px below the trigger; if
+  // not, it flips above. (240 ≈ head + 1-10 row + foot + arrow
+  // padding.)
+  const recompute = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    const spaceBelow = window.innerHeight - r.bottom;
+    setOpenUp(spaceBelow < 240);
+    setAnchor({ left: r.left, top: r.top, right: r.right, bottom: r.bottom });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    recompute();
+    const onScroll = () => recompute();
+    const onResize = () => recompute();
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onResize);
+    };
+  }, [open, recompute]);
+
+  // Outside-click + Escape. The trigger and the portal'd popover are
+  // both checked; clicks on either keep the popup open. Using
+  // mousedown rather than click so the close fires before a re-open
+  // click would land on the trigger (which would otherwise toggle it
+  // back open).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent | TouchEvent) => {
+      const t = e.target as Node;
+      if (triggerRef.current?.contains(t)) return;
+      if (popRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("touchstart", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("touchstart", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const commit = useCallback(async (n: number) => {
+    if (!signedIn || saving) return;
+    setSaving(true);
+    try {
+      const res = await fetch("/api/rate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ opening_id: openingId, score: n }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Rating failed (${res.status})`);
+      }
+      const data: RateResponse = await res.json();
+      setScore(data.user_score ?? n);
+      pushToast({ kind: "success", message: `Rated ${data.user_score ?? n}/10` });
+      // Close shortly after — gives the chosen segment a moment to
+      // flash so the action feels confirmed.
+      setTimeout(() => setOpen(false), 200);
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Could not save rating" });
+    } finally {
+      setSaving(false);
+    }
+  }, [openingId, signedIn, saving]);
+
+  const clear = useCallback(async () => {
+    if (!signedIn || saving || score === null) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/rate?opening_id=${encodeURIComponent(openingId)}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `Clear failed (${res.status})`);
+      }
+      setScore(null);
+      setHover(null);
+      pushToast({ kind: "success", message: "Rating cleared" });
+      setTimeout(() => setOpen(false), 150);
+    } catch (err) {
+      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Could not clear rating" });
+    } finally {
+      setSaving(false);
+    }
+  }, [openingId, signedIn, saving, score]);
+
+  if (!signedIn) {
+    return (
+      <Link href="/login" className="match-rate-trigger" aria-label="Log in to rate">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+          <path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" />
+        </svg>
+        <span>Log in to rate</span>
+      </Link>
+    );
+  }
+
+  // Popover is rendered through a portal so an ancestor's
+  // `overflow: hidden` (the reveal card has it on Solo's screen) can't
+  // clip it. createPortal only runs once mounted — typeof document
+  // gates SSR.
+  const portalTarget = typeof document !== "undefined" ? document.body : null;
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`match-rate-trigger${open ? " open" : ""}${score !== null ? " rated" : ""}`}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <svg className="star" width="13" height="13" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
+          <path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" />
+        </svg>
+        <span className="label">Rate</span>
+        {score !== null && <span className="score-chip">{score}</span>}
+        <svg className="chev" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M6 9l6 6 6-6" />
+        </svg>
+      </button>
+      {open && portalTarget && anchor && createPortal(
+        <div
+          ref={popRef}
+          className={`match-rate-pop${openUp ? " open-up" : ""}`}
+          role="dialog"
+          aria-label="Rate this opening"
+          style={openUp
+            ? { left: Math.max(8, anchor.right - 300), top: Math.max(8, anchor.top - 8) }
+            : { left: Math.max(8, anchor.right - 300), top: anchor.bottom + 8 }
+          }
+          onMouseLeave={() => setHover(null)}
+        >
+          <div className="head">
+            <span className="h-title">Rate this opening</span>
+            <span className="h-current">
+              {previewScore > 0 ? <>{previewScore}<em> / 10</em></> : <em>— / 10</em>}
+            </span>
+          </div>
+          <div className="rate10" role="group" aria-label="Rating from 1 to 10">
+            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
+              <button
+                key={n}
+                type="button"
+                className={n <= previewScore ? "on" : ""}
+                disabled={saving}
+                onMouseEnter={() => setHover(n)}
+                onFocus={() => setHover(n)}
+                onClick={() => commit(n)}
+                aria-label={`Rate ${n} out of 10`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <div className="foot">
+            <span className="foot-hint">Saves automatically · 1 = weakest</span>
+            {score !== null && (
+              <button type="button" className="clr" onClick={clear} disabled={saving}>
+                {saving ? "Clearing…" : "Clear"}
+              </button>
+            )}
+          </div>
+        </div>,
+        portalTarget,
+      )}
+    </>
+  );
+}

--- a/pages/play/b/[code].tsx
+++ b/pages/play/b/[code].tsx
@@ -20,7 +20,7 @@ import {
 } from "@/lib/pvp";
 import type { User } from "@/lib/types";
 import { useKeyboardInset } from "@/lib/useKeyboardInset";
-import { pushToast } from "@/lib/toast";
+import MatchRatePopup from "@/components/MatchRatePopup";
 
 // Mirrors the constant in /play/run.tsx. Tab-hidden for this long → we
 // POST leave() and surface the "session ended" modal so the player
@@ -1189,10 +1189,13 @@ function RoundEndView({ result, view, meID, signedIn, onExit }: { result: RoundE
         <div className="reveal-eyebrow" style={{ position: "absolute", top: 30, left: 40 }}>
           <Eyebrow color={accent} dotColor={accent}>{eyebrow}</Eyebrow>
         </div>
+        {/* overflow visible — the rate popover (portaled) doesn't need
+            it, but flipping from "hidden" matches the design source
+            and lets the inset glow ring bleed naturally. */}
         <div className="reveal-card" style={{
           display: "grid", gridTemplateColumns: "auto 1fr", gap: 40, maxWidth: 880,
           background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 14,
-          padding: 36, position: "relative", overflow: "hidden",
+          padding: 36, position: "relative",
         }}>
           <div style={{
             position: "absolute", inset: -1, borderRadius: 14, pointerEvents: "none",
@@ -1237,123 +1240,17 @@ function RoundEndView({ result, view, meID, signedIn, onExit }: { result: RoundE
                 </div>
               ) : null}
             </div>
-            {/* Inline rater — same shape as the Endless reveal card so
-                players can score the opening they just heard without
-                bouncing to the catalog page. */}
+            {/* Same widget on the Solo reveal — see components/
+                MatchRatePopup. Portaled so the dropdown isn't clipped
+                by the reveal-card's overflow rules. */}
             {op.id && (
               <div className="reveal-actions" style={{ marginTop: 18 }}>
-                <PvpRateButton openingId={op.id} signedIn={signedIn} />
+                <MatchRatePopup openingId={op.id} signedIn={signedIn} />
               </div>
             )}
           </div>
         </div>
       </div>
-    </div>
-  );
-}
-
-// Twin of run.tsx's RateOpeningButton, inlined here so the PvP page
-// doesn't pull the run-flow file into its bundle. POSTs /api/rate and
-// pushes a toast on success/failure; no clear button (the reveal card
-// auto-advances).
-function PvpRateButton({ openingId, signedIn }: { openingId: string; signedIn: boolean }) {
-  const [open, setOpen] = useState(false);
-  const [score, setScore] = useState<number | null>(null);
-  const [hover, setHover] = useState<number | null>(null);
-  const [saving, setSaving] = useState(false);
-  const previewScore = hover ?? score ?? 0;
-
-  const commit = useCallback(async (n: number) => {
-    if (!signedIn || saving) return;
-    setSaving(true);
-    try {
-      const res = await fetch("/api/rate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ opening_id: openingId, score: n }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error ?? `Rating failed (${res.status})`);
-      }
-      setScore(n);
-      pushToast({ kind: "success", message: `Rated ${n}/10` });
-    } catch (err) {
-      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Could not save rating" });
-    } finally {
-      setSaving(false);
-    }
-  }, [openingId, signedIn, saving]);
-
-  if (!signedIn) {
-    return (
-      <Link href="/login" className="reveal-rate-btn" style={{
-        display: "inline-flex", alignItems: "center", gap: 6,
-        background: "transparent", border: `1px solid ${SOLO.line2}`, color: SOLO.fg2,
-        padding: "8px 14px", borderRadius: 6, fontFamily: SOLO.sans, fontSize: 12,
-        textDecoration: "none",
-      }}>
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" /></svg>
-        Log in to rate
-      </Link>
-    );
-  }
-
-  return (
-    <div style={{ position: "relative" }}>
-      <button
-        type="button"
-        className="reveal-rate-btn"
-        onClick={() => setOpen((v) => !v)}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        style={{
-          display: "inline-flex", alignItems: "center", gap: 6,
-          background: score !== null ? "rgba(167,139,250,0.12)" : "transparent",
-          border: `1px solid ${score !== null ? SOLO.accent : SOLO.line2}`,
-          color: score !== null ? SOLO.accent : SOLO.fg2,
-          padding: "8px 14px", borderRadius: 6, fontFamily: SOLO.sans, fontSize: 12,
-          cursor: "pointer",
-        }}
-      >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" /></svg>
-        {score !== null ? <>Rated <strong style={{ marginLeft: 2 }}>{score}</strong>/10</> : "Rate"}
-      </button>
-      {open && (
-        <div style={{
-          position: "absolute", left: 0, top: "calc(100% + 6px)",
-          background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 8,
-          padding: 8, display: "flex", flexDirection: "column", gap: 6,
-          boxShadow: "0 14px 40px rgba(0,0,0,0.4)", zIndex: 10, minWidth: 260,
-        }} onMouseLeave={() => setHover(null)}>
-          <div style={{ display: "flex", gap: 3 }}>
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
-              <button
-                key={n}
-                type="button"
-                disabled={saving}
-                onMouseEnter={() => setHover(n)}
-                onFocus={() => setHover(n)}
-                onClick={() => commit(n)}
-                aria-label={`Rate ${n} out of 10`}
-                style={{
-                  flex: 1, minWidth: 0, padding: "8px 0",
-                  background: n <= previewScore ? SOLO.accent : SOLO.bg3,
-                  color: n <= previewScore ? SOLO.bg : SOLO.fg3,
-                  border: 0, borderRadius: 4,
-                  fontFamily: SOLO.mono, fontWeight: 600, fontSize: 12,
-                  cursor: saving ? "wait" : "pointer",
-                }}
-              >
-                {n}
-              </button>
-            ))}
-          </div>
-          <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.08em", textTransform: "uppercase" }}>
-            {previewScore > 0 ? `${previewScore} / 10` : "Pick a score"}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -12,7 +12,7 @@ import type {
 } from "@/lib/play";
 import type { User } from "@/lib/types";
 import { useKeyboardInset } from "@/lib/useKeyboardInset";
-import { pushToast } from "@/lib/toast";
+import MatchRatePopup from "@/components/MatchRatePopup";
 
 // How long the player can have the run page backgrounded (tab hidden,
 // app switched away) before the run is auto-abandoned on return. Mirrors
@@ -763,120 +763,6 @@ function InMatchScreen({ round, run, playedMs, onSubmit, onExit }: { round: Solo
   );
 }
 
-// RateOpeningButton — inline 1–10 rater shown on each reveal card.
-// Compact form of /components/RatingPopup (no SSR-supplied count, no
-// avg). On submit it POSTs /api/rate and pushes a toast; on success it
-// stays visible as "rated N/10" so the player can re-pick. The reveal
-// card auto-advances after REVEAL_HOLD_MS so there's no Clear/Cancel —
-// keep it small and one-shot. Disabled when the user isn't signed in.
-function RateOpeningButton({
-  openingId,
-  signedIn,
-}: {
-  openingId: string;
-  signedIn: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [score, setScore] = useState<number | null>(null);
-  const [hover, setHover] = useState<number | null>(null);
-  const [saving, setSaving] = useState(false);
-  const previewScore = hover ?? score ?? 0;
-
-  const commit = useCallback(async (n: number) => {
-    if (!signedIn || saving) return;
-    setSaving(true);
-    try {
-      const res = await fetch("/api/rate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ opening_id: openingId, score: n }),
-      });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body?.error ?? `Rating failed (${res.status})`);
-      }
-      setScore(n);
-      pushToast({ kind: "success", message: `Rated ${n}/10` });
-    } catch (err) {
-      pushToast({ kind: "error", message: err instanceof Error ? err.message : "Could not save rating" });
-    } finally {
-      setSaving(false);
-    }
-  }, [openingId, signedIn, saving]);
-
-  if (!signedIn) {
-    return (
-      <Link href="/login" className="reveal-rate-btn" style={{
-        display: "inline-flex", alignItems: "center", gap: 6,
-        background: "transparent", border: `1px solid ${SOLO.line2}`, color: SOLO.fg2,
-        padding: "8px 14px", borderRadius: 6, fontFamily: SOLO.sans, fontSize: 12,
-        textDecoration: "none",
-      }}>
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" /></svg>
-        Log in to rate
-      </Link>
-    );
-  }
-
-  return (
-    <div style={{ position: "relative" }}>
-      <button
-        type="button"
-        className="reveal-rate-btn"
-        onClick={() => setOpen((v) => !v)}
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        style={{
-          display: "inline-flex", alignItems: "center", gap: 6,
-          background: score !== null ? "rgba(167,139,250,0.12)" : "transparent",
-          border: `1px solid ${score !== null ? SOLO.accent : SOLO.line2}`,
-          color: score !== null ? SOLO.accent : SOLO.fg2,
-          padding: "8px 14px", borderRadius: 6, fontFamily: SOLO.sans, fontSize: 12,
-          cursor: "pointer",
-        }}
-      >
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden><path d="M12 3l2.6 5.9 6.4.6-4.9 4.3 1.5 6.3L12 17l-5.6 3.1 1.5-6.3L3 9.5l6.4-.6L12 3z" /></svg>
-        {score !== null ? <>Rated <strong style={{ marginLeft: 2 }}>{score}</strong>/10</> : "Rate"}
-      </button>
-      {open && (
-        <div style={{
-          position: "absolute", left: 0, top: "calc(100% + 6px)",
-          background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 8,
-          padding: 8, display: "flex", flexDirection: "column", gap: 6,
-          boxShadow: "0 14px 40px rgba(0,0,0,0.4)", zIndex: 10, minWidth: 260,
-        }} onMouseLeave={() => setHover(null)}>
-          <div style={{ display: "flex", gap: 3 }}>
-            {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((n) => (
-              <button
-                key={n}
-                type="button"
-                disabled={saving}
-                onMouseEnter={() => setHover(n)}
-                onFocus={() => setHover(n)}
-                onClick={() => commit(n)}
-                aria-label={`Rate ${n} out of 10`}
-                style={{
-                  flex: 1, minWidth: 0, padding: "8px 0",
-                  background: n <= previewScore ? SOLO.accent : SOLO.bg3,
-                  color: n <= previewScore ? SOLO.bg : SOLO.fg3,
-                  border: 0, borderRadius: 4,
-                  fontFamily: SOLO.mono, fontWeight: 600, fontSize: 12,
-                  cursor: saving ? "wait" : "pointer",
-                }}
-              >
-                {n}
-              </button>
-            ))}
-          </div>
-          <div style={{ fontFamily: SOLO.mono, fontSize: 10, color: SOLO.fg4, letterSpacing: "0.08em", textTransform: "uppercase" }}>
-            {previewScore > 0 ? `${previewScore} / 10` : "Pick a score"}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
 function RevealScreen({ result, run, timedOut, signedIn }: { result: SoloAnswerResponse; run: SoloRun; timedOut: boolean; signedIn: boolean }) {
   const correct = result.round_result.correct;
   const op = result.round_result.correct_opening;
@@ -901,10 +787,16 @@ function RevealScreen({ result, run, timedOut, signedIn }: { result: SoloAnswerR
             {eyebrowText}
           </Eyebrow>
         </div>
+        {/* overflow: visible (default) — was previously "hidden" to
+            contain the inset glow ring, but that clipped the rate
+            popover off the bottom edge. The portaled popover no longer
+            needs this card's overflow to be open, but flipping it
+            keeps any future absolute-positioned descendants visible
+            and matches the design source. */}
         <div className="reveal-card" style={{
           display: "grid", gridTemplateColumns: "auto 1fr", gap: 40, maxWidth: 880,
           background: SOLO.bg2, border: `1px solid ${SOLO.line2}`, borderRadius: 14,
-          padding: 36, position: "relative", overflow: "hidden",
+          padding: 36, position: "relative",
         }}>
           <div style={{
             position: "absolute", inset: -1, borderRadius: 14, pointerEvents: "none",
@@ -943,13 +835,13 @@ function RevealScreen({ result, run, timedOut, signedIn }: { result: SoloAnswerR
                 <StatCell value={op.avg_rating ? op.avg_rating.toFixed(1) : "—"} label="community" color={SOLO.accent} />
               )}
             </div>
-            {/* Rate-this-opening — Endless players asked for an inline
-                rater so they can score what they just heard without
-                leaving the run. Reveal card auto-advances, so the popup
-                is one-shot (no clear button). */}
+            {/* Rate-this-opening — same widget on every reveal card in
+                Endless / 1v1. See components/MatchRatePopup for the
+                portal-based positioning that keeps the dropdown out of
+                the reveal card's clip rect. */}
             {op && (
               <div className="reveal-actions" style={{ marginTop: 18 }}>
-                <RateOpeningButton openingId={op.id} signedIn={signedIn} />
+                <MatchRatePopup openingId={op.id} signedIn={signedIn} />
               </div>
             )}
           </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3509,6 +3509,167 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
   }
 }
 
+/* ── MATCH RATE POPUP — inline 1-10 rater on reveal cards (Solo + PvP). ──
+   Visual matches the design in /Downloads/PvP Match-2.html: small Rate
+   pill with optional score chip, dropdown panel with 10 number buttons,
+   "Clear" + auto-save hint in the foot. Logic mirrors the catalog's
+   RatingPopup (Outside-click / Escape close, toast on save).
+
+   The popup is portaled to <body> with position:fixed so it can't be
+   clipped by an ancestor's overflow:hidden — the reveal card uses
+   overflow:hidden for its inset glow ring, which used to chop the
+   bottom off the dropdown. */
+.match-rate-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  background: var(--bg-3);
+  color: var(--fg-2);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  line-height: 1;
+  white-space: nowrap;
+  text-decoration: none;
+  cursor: pointer;
+  transition: border-color .15s, color .15s, background .15s, box-shadow .15s;
+}
+.match-rate-trigger:hover { color: var(--fg); border-color: var(--accent); }
+.match-rate-trigger .star { color: var(--accent); flex-shrink: 0; }
+.match-rate-trigger .chev { color: var(--fg-3); transition: transform .15s; flex-shrink: 0; }
+.match-rate-trigger.open {
+  color: var(--fg);
+  background: var(--bg-2);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(167,139,250,.15);
+}
+.match-rate-trigger.open .chev { transform: rotate(180deg); color: var(--accent); }
+.match-rate-trigger.rated { color: var(--fg); border-color: var(--accent); }
+.match-rate-trigger .score-chip {
+  margin-left: 2px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: rgba(167,139,250,.16);
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  font-weight: 600;
+}
+
+.match-rate-pop {
+  position: fixed;
+  width: 300px;
+  background: var(--bg-2);
+  border: 1px solid var(--accent);
+  border-radius: 10px;
+  padding: 14px;
+  z-index: 1000;
+  box-shadow: 0 18px 50px -8px rgba(0,0,0,.65), 0 0 0 4px rgba(167,139,250,.12);
+  /* Below-trigger by default. open-up flips the transform so the
+     popover's bottom edge aligns to the trigger's top, used when
+     there's not enough room below (e.g. reveal card near viewport
+     bottom on a short laptop). */
+}
+.match-rate-pop.open-up {
+  transform: translateY(-100%);
+}
+.match-rate-pop .head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 12px;
+  gap: 10px;
+}
+.match-rate-pop .h-title {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+.match-rate-pop .h-current {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--accent);
+  font-weight: 500;
+}
+.match-rate-pop .h-current em { font-style: normal; color: var(--fg-4); }
+.match-rate-pop .rate10 { display: flex; gap: 3px; }
+.match-rate-pop .rate10 button {
+  flex: 1;
+  height: 30px;
+  border-radius: 4px;
+  background: var(--bg-3);
+  border: 1px solid var(--line-2);
+  display: inline-grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-3);
+  cursor: pointer;
+  transition: all .12s;
+  padding: 0;
+}
+.match-rate-pop .rate10 button:hover:not(:disabled) { color: var(--fg); border-color: var(--accent); }
+.match-rate-pop .rate10 button.on {
+  background: var(--accent);
+  color: var(--accent-ink, #0c0a14);
+  border-color: var(--accent);
+  font-weight: 600;
+  box-shadow: 0 0 12px rgba(167,139,250,.4);
+}
+.match-rate-pop .rate10 button:disabled { cursor: wait; opacity: .8; }
+.match-rate-pop .foot {
+  margin-top: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+.match-rate-pop .foot-hint {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--fg-4);
+  letter-spacing: 0.04em;
+}
+.match-rate-pop .foot .clr {
+  color: var(--fg-3);
+  background: transparent;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid transparent;
+  cursor: pointer;
+}
+.match-rate-pop .foot .clr:hover:not(:disabled) {
+  color: var(--danger);
+  border-color: var(--line-2);
+}
+
+/* Mobile: narrow viewports can't fit the 300px popover anchored to
+   the trigger. We stretch it to full-width with a small gutter so
+   the user always sees the whole 1-10 row. The portal layer is on
+   document.body so we can use viewport units freely. */
+@media (max-width: 720px) {
+  .match-rate-pop {
+    left: 12px !important;
+    right: 12px !important;
+    width: auto !important;
+  }
+  .match-rate-pop .rate10 button {
+    height: 40px;
+    font-size: 13px;
+  }
+}
+
 /* ── GAME PAGES (Solo run, PvP match) — mobile ─────────────────────────── */
 @media (max-width: 720px) {
   /* On the run pages the global Topbar/MobileNav are hidden — they have
@@ -3536,10 +3697,11 @@ footer a:hover { color: var(--fg-2); background: var(--bg-2); }
     padding: 14px 16px !important;
     min-height: 48px !important;
   }
-  /* Rate-this-opening pill on reveal cards. Full-width on mobile so it
-     sits naturally below the stats row instead of fighting for the
-     line. */
-  [data-mobile-game] .reveal-rate-btn {
+  /* Rate trigger on reveal cards — full-width on mobile so it sits
+     naturally below the stats row instead of fighting for the line.
+     The popover handles its own mobile sizing via the .match-rate-pop
+     mobile rules further down. */
+  [data-mobile-game] .match-rate-trigger {
     width: 100%;
     justify-content: center !important;
     padding: 10px 14px !important;


### PR DESCRIPTION
## Summary

The inline rate dropdown shipped in [#65](https://github.com/openingwiki/frontend/pull/65) was getting cut off at the bottom of the reveal card on desktop, and slid right off the viewport on mobile.

**Root cause:** `.reveal-card` has `overflow: hidden` for its inset glow-ring effect, so any `position: absolute` descendant gets chopped at the card edges.

**Fix:** Replaces both `RateOpeningButton` (Solo) and `PvpRateButton` (PvP) with a single shared `components/MatchRatePopup` that renders the dropdown through `createPortal(document.body)` with `position: fixed`, anchored to the trigger via `getBoundingClientRect()`. Ancestor overflow can no longer clip it.

## Behavior

Matches the catalog's `RatingPopup` (the "design like in opening page with rating" the user asked we mirror):
- Outside-click + Escape close
- Clear button when a score is already set
- POST `/api/rate` (commit) and DELETE `/api/rate` (clear); toast on success/failure
- Trigger button shows the user's score in a chip once rated

## Visual

Follows the new design in `/Downloads/PvP Match-2.html`:
- Trigger pill with star icon, "Rate" label, optional score chip, chevron
- Dropdown head: "Rate this opening" + current preview score
- 10 number buttons with `.on` accent fill on hover/select
- Foot: "Saves automatically · 1 = weakest" + Clear button

## Edge cases handled

- **Short viewports:** if there's <240px below the trigger, the popup flips upward (handles short laptops + mobile keyboard up).
- **Mobile:** CSS media query stretches the popup to viewport width with 12px gutters and bumps the number buttons to 40px tall for proper touch targets.
- **Re-open on next round:** local score state resets when `openingId` changes, so round N+1's reveal opens with a clean trigger.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean (production build)
- [ ] Solo reveal: open Rate dropdown — visible in full on a 1366×768 laptop.
- [ ] PvP reveal: same on a 360×640 phone — dropdown stretches edge-to-edge, doesn't clip.
- [ ] Click anywhere outside the popup → closes. Esc → closes.
- [ ] Pick 8 → toast "Rated 8/10", trigger shows score chip; reopen → "8" is highlighted.
- [ ] Click Clear → toast "Rating cleared", trigger reverts to "Rate" with no chip.
- [ ] Scroll the reveal card while popup is open → popup tracks the trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)