### PR TITLE
fix(play): Exit-run always starts a fresh session on re-entry

### DIFF
--- a/pages/play/run.tsx
+++ b/pages/play/run.tsx
@@ -20,6 +20,33 @@ import { pushToast } from "@/lib/toast";
 // and was still in the same match" complaint that motivated this.
 const IDLE_ABANDON_MS = 15_000;
 
+// sessionStorage flag that forces the next /play/run mount to start a
+// fresh run instead of resuming whatever /me/current points at. Set
+// from the Exit button and the "Back to hub" path on the idle modal.
+// Why this exists: the abandon POST is best-effort — if it 4xx's
+// (e.g. transient CSRF or network), the player still expects to be
+// out of the run. Without this flag, the next /me/current would
+// re-hydrate the still-active run on the server and we'd land back
+// in the same session that the user just clicked Exit on, which is
+// the exact bug the user reported.
+const FRESH_RUN_FLAG = "ow:force-fresh-run";
+
+function markForceFreshRun() {
+  if (typeof window === "undefined") return;
+  try { window.sessionStorage.setItem(FRESH_RUN_FLAG, "1"); } catch { /* */ }
+}
+
+function consumeForceFreshRun(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const v = window.sessionStorage.getItem(FRESH_RUN_FLAG);
+    if (v) window.sessionStorage.removeItem(FRESH_RUN_FLAG);
+    return v === "1";
+  } catch {
+    return false;
+  }
+}
+
 interface Props {
   user: User | null;
   modQueueCount: number;
@@ -125,11 +152,16 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
   // resume and goes straight to start.
   useEffect(() => {
     let abandoned = false;
+    // Consume the force-fresh flag once per mount. A previous Exit
+    // (or idle-modal "Back to hub") sets it; we skip the resume
+    // probe and go straight to startRun(), which on the backend
+    // closes any lingering active run before issuing a new one.
+    const forceFresh = consumeForceFreshRun();
     setPhase({ kind: "starting" });
     submittingRef.current = false;
     const start = async () => {
       try {
-        if (runGen === 0) {
+        if (runGen === 0 && !forceFresh) {
           const current = await playClient.currentRun();
           if (current?.current_round) {
             if (abandoned) return;
@@ -352,7 +384,14 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
             countdownMs={Math.max(0, phase.round.play_at_ms - serverNow(phase.clockOffsetMs))}
             run={phase.run}
             round={phase.round}
-            onExit={async () => { await abandonRun(phase.run.id); router.push("/play/endless"); }}
+            onExit={async () => {
+              // Flag-before-await: if the abandon POST 4xx's, we still
+              // want the next /play/run mount to start fresh instead of
+              // resuming the run the player just exited.
+              markForceFreshRun();
+              await abandonRun(phase.run.id);
+              router.push("/play/endless");
+            }}
           />
         )}
         {phase.kind === "in-match" && (
@@ -361,7 +400,14 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
             run={phase.run}
             playedMs={Math.max(0, serverNow(phase.clockOffsetMs) - phase.round.play_at_ms)}
             onSubmit={(animeId) => submitAnswer(phase, animeId)}
-            onExit={async () => { await abandonRun(phase.run.id); router.push("/play/endless"); }}
+            onExit={async () => {
+              // Flag-before-await: if the abandon POST 4xx's, we still
+              // want the next /play/run mount to start fresh instead of
+              // resuming the run the player just exited.
+              markForceFreshRun();
+              await abandonRun(phase.run.id);
+              router.push("/play/endless");
+            }}
           />
         )}
         {phase.kind === "reveal" && (
@@ -384,7 +430,14 @@ export default function SoloRunPage({ user, modQueueCount }: Props) {
         )}
         {staleAbandoned && (
           <IdleSessionModal
-            onAck={() => { setStaleAbandoned(false); router.push("/play/endless"); }}
+            onAck={() => {
+              // Idle-abandon may have raced the backend write the same
+              // way the manual Exit can — mark the flag so the next
+              // visit to /play/run doesn't dredge the stale run back up.
+              markForceFreshRun();
+              setStaleAbandoned(false);
+              router.push("/play/endless");
+            }}
             onRestart={() => { setStaleAbandoned(false); setRunGen((g) => g + 1); }}
           />
         )}


### PR DESCRIPTION
## Problem

After clicking the Exit-run button (or "Back to hub" on the 15s idle modal), re-entering `/play/run` was dropping the player straight back into the run they just left, instead of starting a new session.

## Root cause

The abandon POST in `onExit` is wrapped in `try/catch` and silently swallows errors. If the abandon call hits a transient issue (CSRF token blip, offline, backend 5xx), the navigation still happens but the run stays `status='active'` server-side. The next visit to `/play/run` calls `playClient.currentRun()`, the backend's `GET /me/current` returns the still-active run, and the resume path runs.

```js
// before — best-effort with no fallback
const abandonRun = async (runID) => {
  try { await playClient.abandonRun(runID); } catch { /* */ }
};
onExit={async () => { await abandonRun(phase.run.id); router.push("/play/endless"); }}
```

## Fix

Adds a `ow:force-fresh-run` sessionStorage flag that the Exit and idle-acknowledge handlers set **before** awaiting the abandon. The `/play/run` mount effect consumes the flag once and skips the `currentRun()` resume probe, going straight to `playClient.startRun()` — which on the backend closes any lingering active run before issuing a new one. So even if the original abandon never landed, the next visit gets a clean session.

```js
// after — flag set before the await so transient abandon failures
// don't leave the player stuck in the stale session
onExit={async () => {
  markForceFreshRun();           // ow:force-fresh-run = "1"
  await abandonRun(phase.run.id);
  router.push("/play/endless");
}}
```

## Preserved behavior

- **Reload-resume** (the anti-skip-countdown property): a normal F5 or nav back to `/play/run` *without* having clicked Exit still hits `currentRun()` and re-derives the in-flight round off the server clock. The flag is only set when the user explicitly exits.
- **"Run again" / "New run" buttons**: unchanged. They use `setRunGen((g) => g + 1)`, which already bypasses the resume probe via the `runGen === 0` guard.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [ ] Click Exit-run mid-round → land on /play/endless → click Start run → see fresh "Round 01" mode-reveal (was previously dropping back into mid-round of the abandoned run).
- [ ] On a flaky network: click Exit-run while the backend is unreachable → still get a fresh run on next start (this was the broken case).
- [ ] Tab-hide for 20s → return → click "Back to hub" on the idle modal → click Start run → fresh run.
- [ ] F5 during in-match → still resumes the in-flight round (no regression on the anti-skip-countdown property).

🤖 Generated with [Claude Code](https://claude.com/claude-code)