### PR TITLE
feat(play): rate popup shows the viewer's existing score

### DIFF
--- a/components/MatchRatePopup.tsx
+++ b/components/MatchRatePopup.tsx
@@ -34,10 +34,13 @@ interface Props {
 //      already prints "community ★ X.X" in its stats row, so a second
 //      number would be visual noise.
 //
-//   4. Rating state is local: we don't preload the viewer's prior
-//      score from the round payload (it isn't there). The button
-//      shows "Rate" until the user picks a number, then "Rated N".
-//      Clearing reverts to "Rate".
+//   4. Rating state is seeded from the opening's `viewer_rating` field:
+//      on mount (and on every openingId change), we fetch
+//      /api/v1/openings/{id} and use the returned viewer_rating as the
+//      starting score, so a player who already rated an opening sees
+//      "Rated N" on the trigger and the chip pre-filled — they don't
+//      have to remember what they gave it last time. Anonymous viewers
+//      skip the fetch (the trigger is a Log-in link anyway).
 export default function MatchRatePopup({ openingId, signedIn }: Props) {
   const [open, setOpen] = useState(false);
   const [score, setScore] = useState<number | null>(null);
@@ -58,6 +61,36 @@ export default function MatchRatePopup({ openingId, signedIn }: Props) {
     setHover(null);
     setAnchor(null);
   }, [openingId]);
+
+  // Prefetch the viewer's existing rating for this opening, if any.
+  // The opening-detail endpoint already includes `viewer_rating` for
+  // signed-in callers — same field /openings/[id] reads — so we don't
+  // need a dedicated route. AbortController guards against the reveal
+  // advancing to the next opening while this request is in flight (we
+  // don't want round N+1 displaying N's score).
+  useEffect(() => {
+    if (!signedIn) return;
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const res = await fetch(`/api/v1/openings/${encodeURIComponent(openingId)}`, {
+          credentials: "include",
+          signal: controller.signal,
+        });
+        if (!res.ok) return;
+        const body = await res.json();
+        const vr = body?.data?.viewer_rating;
+        if (typeof vr === "number" && vr >= 1 && vr <= 10) {
+          setScore(vr);
+        }
+      } catch {
+        // Network/abort — leave score null, trigger stays "Rate". A
+        // failed prefetch is harmless: if the user picks a new score
+        // the POST still goes through.
+      }
+    })();
+    return () => controller.abort();
+  }, [openingId, signedIn]);
 
   // Anchor calculation. Runs when we open the popup and on resize/
   // scroll while open so the popover tracks the trigger. We measure


### PR DESCRIPTION
## Summary

If the player already rated the opening from the catalog (`/openings/[id]`) or an earlier run, the in-match rate popup now opens with that score **pre-filled**:

- Trigger reads "Rated N" with the score chip instead of plain "Rate"
- The 1–10 row has the matching button highlighted
- The popup head shows `N / 10` instead of `— / 10`

Matches the catalog's `RatingPopup` behavior — same UX, just sourced at runtime instead of via SSR.

## How

Adds an effect that fetches `GET /api/v1/openings/{id}` on mount (and on every `openingId` change) and seeds `score` from `data.viewer_rating`. The opening-detail endpoint already carries `viewer_rating` for signed-in callers, so no new backend route is needed.

```tsx
useEffect(() => {
  if (!signedIn) return;
  const controller = new AbortController();
  (async () => {
    const res = await fetch(`/api/v1/openings/${encodeURIComponent(openingId)}`, {
      credentials: "include",
      signal: controller.signal,
    });
    const body = await res.json();
    const vr = body?.data?.viewer_rating;
    if (typeof vr === "number" && vr >= 1 && vr <= 10) setScore(vr);
  })();
  return () => controller.abort();
}, [openingId, signedIn]);
```

## Edge cases

- **Round advance race**: `AbortController` cancels the in-flight fetch when `openingId` changes, so round N's response can't overwrite round N+1's score.
- **Anonymous viewer**: prefetch is gated on `signedIn`; the trigger renders a Log-in link and never hits the endpoint.
- **Network/4xx failure**: silent. The trigger falls back to "Rate" and the POST path still works if the user picks a number.
- **Just-cleared rating**: the existing local `clear()` already sets `score = null`, so the trigger correctly reverts.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx next build` compiles successfully
- [ ] Rate an opening from `/openings/[id]` with score 7 → return to a run → answer that opening → reveal card shows "Rated 7" pre-filled.
- [ ] Open the popup → "7" button is highlighted, head shows "7 / 10".
- [ ] Click "Clear" → trigger goes back to "Rate", chip disappears.
- [ ] Rate an opening from the run popup → next round (different opening) → trigger shows plain "Rate" (no carry-over).
- [ ] Anonymous user → trigger shows "Log in to rate", no GET fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)